### PR TITLE
Don't rely on architecture information to get the type of the PLT table

### DIFF
--- a/src/memray/_memray/elf_utils.h
+++ b/src/memray/_memray/elf_utils.h
@@ -16,7 +16,6 @@
 #        define ELF_ST_BIND ELF64_ST_BIND
 #    endif
 #    define ELFCLASS_BITS 64
-#    define Elf_Rela ElfW(Rela)
 typedef uint64_t bloom_el_t;
 #else
 #    define ELF_R_SYM ELF32_R_SYM
@@ -25,7 +24,6 @@ typedef uint64_t bloom_el_t;
 #    endif
 #    define ELFCLASS_BITS 32
 typedef uint32_t bloom_el_t;
-#    define Elf_Rela ElfW(Rel)
 #endif
 
 /* Utility classes and definitons */
@@ -70,8 +68,9 @@ struct DynamicInfoTable
 };
 
 using RelTable = DynamicInfoTable<Rel, DT_REL, DT_RELSZ>;
-using RelaTable = DynamicInfoTable<Elf_Rela, DT_RELA, DT_RELASZ>;
-using JmprelTable = DynamicInfoTable<Elf_Rela, DT_JMPREL, DT_PLTRELSZ>;
+using RelaTable = DynamicInfoTable<Rela, DT_RELA, DT_RELASZ>;
+using JmpRelTable = DynamicInfoTable<Rel, DT_JMPREL, DT_PLTRELSZ>;
+using JmpRelaTable = DynamicInfoTable<Rela, DT_JMPREL, DT_PLTRELSZ>;
 
 struct SymbolTable
 {


### PR DESCRIPTION
The PLT/Jump table can have different entry types depending on the phase
of the moon, the position of the planets, the current weather and other
unpredictable stuff. Normally x86_64 uses RELA entries, and x86 uses REL
entries. But sometimes it doesn't happen, so we need to check the
DT_PLTREL tag to see which one we should use at runtime.

This method is more reliable than assuming that 64 bits means RELA and
32 bits mean REL.
