### PR TITLE
Update the package name everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,7 +165,7 @@ cython_debug/
 .asv
 
 # memray stuff
-pensieve-*
+memray-*
 
 # VSCode
 .devcontainer

--- a/setup.py
+++ b/setup.py
@@ -166,16 +166,16 @@ DEFINE_MACROS = []
 # 1152 bytes for oportunustic usage for shared libraries with initial-exec, so
 # this model will not present problems as long as the application uses glibc. In
 # case these assumptions are wrong, memray can revert to use the most
-# conservative model by setting the NO_PENSIEVE_FAST_TLS environment variable.
+# conservative model by setting the NO_MEMRAY_FAST_TLS environment variable.
 
-PENSIEVE_FAST_TLS = True
-if os.getenv("NO_PENSIEVE_FAST_TLS", None) is not None:
-    PENSIEVE_FAST_TLS = False
+MEMRAY_FAST_TLS = True
+if os.getenv("NO_MEMRAY_FAST_TLS", None) is not None:
+    MEMRAY_FAST_TLS = False
 
-if PENSIEVE_FAST_TLS:
-    DEFINE_MACROS.append(("PENSIEVE_TLS_MODEL", '"initial-exec"'))
+if MEMRAY_FAST_TLS:
+    DEFINE_MACROS.append(("MEMRAY_TLS_MODEL", '"initial-exec"'))
 
-PENSIEVE_EXTENSION = Extension(
+MEMRAY_EXTENSION = Extension(
     name="memray._memray",
     sources=[
         "src/memray/_memray.pyx",
@@ -204,7 +204,7 @@ PENSIEVE_EXTENSION = Extension(
     undef_macros=UNDEF_MACROS,
 )
 
-PENSIEVE_EXTENSION.libraries.append("dl")
+MEMRAY_EXTENSION.libraries.append("dl")
 
 if "linux" not in platform:
     raise RuntimeError("memray only supports Linux platforms")
@@ -240,7 +240,7 @@ setup(
     package_dir={"": "src"},
     packages=find_namespace_packages(where="src"),
     ext_modules=cythonize(
-        [PENSIEVE_EXTENSION],
+        [MEMRAY_EXTENSION],
         include_path=["src/memray"],
         compiler_directives=COMPILER_DIRECTIVES,
     ),

--- a/src/memray/_memray/elf_shenanigans.cpp
+++ b/src/memray/_memray/elf_shenanigans.cpp
@@ -87,7 +87,7 @@ overwrite_elf_table(
         patch_symbol(hooks::hookname, &intercept::hookname, symname, symbol_addr, restore_original);    \
         continue;                                                                                       \
     }
-        PENSIEVE_HOOKED_FUNCTIONS
+        MEMRAY_HOOKED_FUNCTIONS
     }
 #undef FOR_EACH_HOOKED_FUNCTION
 }

--- a/src/memray/_memray/hooks.cpp
+++ b/src/memray/_memray/hooks.cpp
@@ -68,14 +68,14 @@ allocatorKind(const Allocator& allocator)
 }
 
 #define FOR_EACH_HOOKED_FUNCTION(f) SymbolHook<decltype(&::f)> f(#f, &::f);
-PENSIEVE_HOOKED_FUNCTIONS
+MEMRAY_HOOKED_FUNCTIONS
 #undef FOR_EACH_HOOKED_FUNCTION
 
 void
 ensureAllHooksAreValid()
 {
 #define FOR_EACH_HOOKED_FUNCTION(f) f.ensureValidOriginalSymbol();
-    PENSIEVE_HOOKED_FUNCTIONS
+    MEMRAY_HOOKED_FUNCTIONS
 #undef FOR_EACH_HOOKED_FUNCTION
 }
 

--- a/src/memray/_memray/hooks.h
+++ b/src/memray/_memray/hooks.h
@@ -1,5 +1,5 @@
-#ifndef _PENSIEVE_HOOKS_H
-#define _PENSIEVE_HOOKS_H
+#ifndef _MEMRAY_HOOKS_H
+#define _MEMRAY_HOOKS_H
 
 #include <sys/types.h>
 
@@ -16,7 +16,7 @@
 
 #include "logging.h"
 
-#define PENSIEVE_HOOKED_FUNCTIONS                                                                       \
+#define MEMRAY_HOOKED_FUNCTIONS                                                                         \
     FOR_EACH_HOOKED_FUNCTION(malloc)                                                                    \
     FOR_EACH_HOOKED_FUNCTION(free)                                                                      \
     FOR_EACH_HOOKED_FUNCTION(calloc)                                                                    \
@@ -112,7 +112,7 @@ AllocatorKind
 allocatorKind(const Allocator& allocator);
 
 #define FOR_EACH_HOOKED_FUNCTION(f) extern SymbolHook<decltype(&::f)> f;
-PENSIEVE_HOOKED_FUNCTIONS
+MEMRAY_HOOKED_FUNCTIONS
 #undef FOR_EACH_HOOKED_FUNCTION
 
 }  // namespace memray::hooks
@@ -165,4 +165,4 @@ PyGILState_Ensure() noexcept;
 
 }  // namespace memray::intercept
 
-#endif  //_PENSIEVE_HOOKS_H
+#endif  //_MEMRAY_HOOKS_H

--- a/src/memray/_memray/logging.h
+++ b/src/memray/_memray/logging.h
@@ -1,5 +1,5 @@
-#ifndef _PENSIEVE_LOGGING_H
-#define _PENSIEVE_LOGGING_H
+#ifndef _MEMRAY_LOGGING_H
+#define _MEMRAY_LOGGING_H
 
 #include <sstream>
 #include <string>
@@ -55,4 +55,4 @@ class LOG
 
 }  // namespace memray
 
-#endif  //_PENSIEVE_LOGGING_H
+#endif  //_MEMRAY_LOGGING_H

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -33,10 +33,10 @@ struct RecursionGuard
     }
 
     const bool wasLocked;
-    PENSIEVE_FAST_TLS static thread_local bool isActive;
+    MEMRAY_FAST_TLS static thread_local bool isActive;
 };
 
-PENSIEVE_FAST_TLS thread_local bool RecursionGuard::isActive = false;
+MEMRAY_FAST_TLS thread_local bool RecursionGuard::isActive = false;
 
 std::string
 get_executable()
@@ -126,7 +126,7 @@ class PythonStackTracker
 
 // See giant comment above.
 static_assert(std::is_trivially_destructible<PythonStackTracker>::value);
-PENSIEVE_FAST_TLS thread_local PythonStackTracker t_python_stack_tracker;
+MEMRAY_FAST_TLS thread_local PythonStackTracker t_python_stack_tracker;
 
 void
 PythonStackTracker::reset(PyFrameObject* current_frame)
@@ -237,7 +237,7 @@ PythonStackTracker::pushPythonFrame(PyFrameObject* frame)
     };
 
     setMostRecentFrameLineNumber(parent_lineno);
-    PENSIEVE_FAST_TLS static thread_local StackCreator t_stack_creator;
+    MEMRAY_FAST_TLS static thread_local StackCreator t_stack_creator;
     t_stack_creator.stack.push_back({frame, {function, filename, 0}, false});
     assert(d_stack);  // The above call sets d_stack if it wasn't already set.
     return 0;
@@ -264,7 +264,7 @@ PythonStackTracker::popPythonFrame()
 std::atomic<bool> Tracker::d_active = false;
 std::unique_ptr<Tracker> Tracker::d_instance_owner;
 std::atomic<Tracker*> Tracker::d_instance = nullptr;
-PENSIEVE_FAST_TLS thread_local size_t NativeTrace::MAX_SIZE{64};
+MEMRAY_FAST_TLS thread_local size_t NativeTrace::MAX_SIZE{64};
 
 Tracker::Tracker(
         std::unique_ptr<RecordWriter> record_writer,

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -23,10 +23,10 @@
 #include "record_writer.h"
 #include "records.h"
 
-#ifdef PENSIEVE_TLS_MODEL
-#    define PENSIEVE_FAST_TLS __attribute__((tls_model(PENSIEVE_TLS_MODEL)))
+#ifdef MEMRAY_TLS_MODEL
+#    define MEMRAY_FAST_TLS __attribute__((tls_model(MEMRAY_TLS_MODEL)))
 #else
-#    define PENSIEVE_FAST_TLS
+#    define MEMRAY_FAST_TLS
 #endif
 
 namespace memray::tracking_api {
@@ -116,7 +116,7 @@ class NativeTrace
     }
 
   private:
-    PENSIEVE_FAST_TLS static thread_local size_t MAX_SIZE;
+    MEMRAY_FAST_TLS static thread_local size_t MAX_SIZE;
     __attribute__((always_inline)) static inline int unwind(frame_id_t* data)
     {
         return unw_backtrace((void**)data, MAX_SIZE);


### PR DESCRIPTION
We missed a few places where the old name was used as part of a longer
string.