### PR TITLE
Split test utilities into a separate .pyx file

### DIFF
--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -9,29 +9,10 @@ cimport cython
 import threading
 from datetime import datetime
 
-from posix.mman cimport MAP_ANONYMOUS
-from posix.mman cimport MAP_FAILED
-from posix.mman cimport MAP_SHARED
-from posix.mman cimport PROT_WRITE
-from posix.mman cimport mmap
-from posix.mman cimport munmap
-
-from _memray.alloc cimport calloc
-from _memray.alloc cimport free
-from _memray.alloc cimport malloc
-from _memray.alloc cimport memalign
-from _memray.alloc cimport posix_memalign
-from _memray.alloc cimport pvalloc
-from _memray.alloc cimport realloc
-from _memray.alloc cimport valloc
 from _memray.logging cimport setLogThreshold
-from _memray.pthread cimport pthread_create
-from _memray.pthread cimport pthread_join
-from _memray.pthread cimport pthread_t
 from _memray.record_reader cimport RecordReader
 from _memray.record_reader cimport RecordResult
 from _memray.record_writer cimport RecordWriter
-from _memray.records cimport Allocation as NativeAllocation
 from _memray.sink cimport FileSink
 from _memray.sink cimport NullSink
 from _memray.sink cimport Sink
@@ -44,9 +25,6 @@ from _memray.source cimport FileSource
 from _memray.source cimport SocketSource
 from _memray.tracking_api cimport Tracker as NativeTracker
 from _memray.tracking_api cimport install_trace_function
-from libc.errno cimport errno
-from libc.stdint cimport uint16_t
-from libc.stdint cimport uintptr_t
 from libcpp cimport bool
 from libcpp.memory cimport make_shared
 from libcpp.memory cimport make_unique
@@ -56,109 +34,11 @@ from libcpp.string cimport string as cppstring
 from libcpp.utility cimport move
 from libcpp.vector cimport vector
 
-import typing
-
-from ._destination import Destination
 from ._destination import FileDestination
 from ._destination import SocketDestination
 from ._metadata import Metadata
 
-# Testing utilities
-# This code is at the top so that tests which rely on line numbers don't have to
-# be updated every time a line change is introduced in the core memray code.
-
-cdef extern from "sys/prctl.h":
-    int prctl(int, char*, char*, char*, char*)
-
-
-def set_thread_name(new_name):
-    cdef int PR_SET_NAME = 15
-    return prctl(PR_SET_NAME, new_name, NULL, NULL, NULL)
-
-
-cdef class MemoryAllocator:
-    cdef void* ptr
-
-    def __cinit__(self):
-        self.ptr = NULL
-
-    @cython.profile(True)
-    def free(self):
-        if self.ptr == NULL:
-            raise RuntimeError("Pointer cannot be NULL")
-        free(self.ptr)
-        self.ptr = NULL
-
-    @cython.profile(True)
-    def malloc(self, size_t size):
-        self.ptr = malloc(size)
-
-    @cython.profile(True)
-    def calloc(self, size_t size):
-        self.ptr = calloc(1, size)
-
-    @cython.profile(True)
-    def realloc(self, size_t size):
-        self.ptr = malloc(1)
-        self.ptr = realloc(self.ptr, size)
-
-    @cython.profile(True)
-    def posix_memalign(self, size_t size):
-        posix_memalign(&self.ptr, sizeof(void*), size)
-
-    @cython.profile(True)
-    def memalign(self, size_t size):
-        self.ptr = memalign(sizeof(void*), size)
-
-    @cython.profile(True)
-    def valloc(self, size_t size):
-        self.ptr = valloc(size)
-
-    @cython.profile(True)
-    def pvalloc(self, size_t size):
-        self.ptr = pvalloc(size)
-
-    @cython.profile(True)
-    def run_in_pthread(self, callback):
-        cdef pthread_t thread
-        cdef int ret = pthread_create(&thread, NULL, &_pthread_worker, <void*>callback)
-        if ret != 0:
-            raise RuntimeError("Failed to create thread")
-        with nogil:
-            pthread_join(thread, NULL)
-
-
-@cython.profile(True)
-def _cython_nested_allocation(allocator_fn, size):
-    allocator_fn(size)
-    cdef void* p = valloc(size);
-    free(p)
-
-cdef class MmapAllocator:
-    cdef uintptr_t _address
-
-    @cython.profile(True)
-    def __cinit__(self, size, address=0):
-        cdef uintptr_t start_address = address
-
-        self._address = <uintptr_t>mmap(<void *>start_address, size, PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0)
-        if <void *>self._address == MAP_FAILED:
-            raise MemoryError
-
-    @property
-    def address(self):
-        return self._address
-
-    @cython.profile(True)
-    def munmap(self, length, offset=0):
-        cdef uintptr_t addr = self._address + <uintptr_t> offset
-        cdef int ret = munmap(<void *>addr, length)
-        if ret != 0:
-            raise MemoryError(f"munmap rcode: {ret} errno: {errno}")
-
-@cython.profile(True)
-cdef void* _pthread_worker(void* arg) with gil:
-    (<object> arg)()
+include "_memray_test_utils.pyx"
 
 
 def set_log_level(int level):

--- a/src/memray/_memray_test_utils.pyx
+++ b/src/memray/_memray_test_utils.pyx
@@ -1,0 +1,121 @@
+"""Utilities used only by memray's test suite.
+
+If you make changes to this file that move functions around, you will need to
+change line numbers in test files as well.
+"""
+from posix.mman cimport MAP_ANONYMOUS
+from posix.mman cimport MAP_FAILED
+from posix.mman cimport MAP_SHARED
+from posix.mman cimport PROT_WRITE
+from posix.mman cimport mmap
+from posix.mman cimport munmap
+
+from _memray.alloc cimport calloc
+from _memray.alloc cimport free
+from _memray.alloc cimport malloc
+from _memray.alloc cimport memalign
+from _memray.alloc cimport posix_memalign
+from _memray.alloc cimport pvalloc
+from _memray.alloc cimport realloc
+from _memray.alloc cimport valloc
+from _memray.pthread cimport pthread_create
+from _memray.pthread cimport pthread_join
+from _memray.pthread cimport pthread_t
+from libc.errno cimport errno
+from libc.stdint cimport uintptr_t
+
+from ._destination import Destination
+
+
+cdef extern from "sys/prctl.h":
+    int prctl(int, char*, char*, char*, char*)
+
+
+def set_thread_name(new_name):
+    cdef int PR_SET_NAME = 15
+    return prctl(PR_SET_NAME, new_name, NULL, NULL, NULL)
+
+
+cdef class MemoryAllocator:
+    cdef void* ptr
+
+    def __cinit__(self):
+        self.ptr = NULL
+
+    @cython.profile(True)
+    def free(self):
+        if self.ptr == NULL:
+            raise RuntimeError("Pointer cannot be NULL")
+        free(self.ptr)
+        self.ptr = NULL
+
+    @cython.profile(True)
+    def malloc(self, size_t size):
+        self.ptr = malloc(size)
+
+    @cython.profile(True)
+    def calloc(self, size_t size):
+        self.ptr = calloc(1, size)
+
+    @cython.profile(True)
+    def realloc(self, size_t size):
+        self.ptr = malloc(1)
+        self.ptr = realloc(self.ptr, size)
+
+    @cython.profile(True)
+    def posix_memalign(self, size_t size):
+        posix_memalign(&self.ptr, sizeof(void*), size)
+
+    @cython.profile(True)
+    def memalign(self, size_t size):
+        self.ptr = memalign(sizeof(void*), size)
+
+    @cython.profile(True)
+    def valloc(self, size_t size):
+        self.ptr = valloc(size)
+
+    @cython.profile(True)
+    def pvalloc(self, size_t size):
+        self.ptr = pvalloc(size)
+
+    @cython.profile(True)
+    def run_in_pthread(self, callback):
+        cdef pthread_t thread
+        cdef int ret = pthread_create(&thread, NULL, &_pthread_worker, <void*>callback)
+        if ret != 0:
+            raise RuntimeError("Failed to create thread")
+        with nogil:
+            pthread_join(thread, NULL)
+
+
+@cython.profile(True)
+def _cython_nested_allocation(allocator_fn, size):
+    allocator_fn(size)
+    cdef void* p = valloc(size);
+    free(p)
+
+cdef class MmapAllocator:
+    cdef uintptr_t _address
+
+    @cython.profile(True)
+    def __cinit__(self, size, address=0):
+        cdef uintptr_t start_address = address
+
+        self._address = <uintptr_t>mmap(<void *>start_address, size, PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0)
+        if <void *>self._address == MAP_FAILED:
+            raise MemoryError
+
+    @property
+    def address(self):
+        return self._address
+
+    @cython.profile(True)
+    def munmap(self, length, offset=0):
+        cdef uintptr_t addr = self._address + <uintptr_t> offset
+        cdef int ret = munmap(<void *>addr, length)
+        if ret != 0:
+            raise MemoryError(f"munmap rcode: {ret} errno: {errno}")
+
+@cython.profile(True)
+cdef void* _pthread_worker(void* arg) with gil:
+    (<object> arg)()

--- a/tests/integration/test_socket.py
+++ b/tests/integration/test_socket.py
@@ -274,7 +274,7 @@ class TestSocketReaderAccess:
 
         symbol, filename, lineno = allocation.stack_trace()[0]
         assert symbol == "valloc"
-        assert filename == "src/memray/_memray.pyx"
+        assert filename == "src/memray/_memray_test_utils.pyx"
         assert 0 < lineno < 200
 
     @pytest.mark.valgrind
@@ -302,7 +302,7 @@ class TestSocketReaderAccess:
 
         symbol, filename, lineno = allocation.stack_trace()[0]
         assert symbol == "valloc"
-        assert filename == "src/memray/_memray.pyx"
+        assert filename == "src/memray/_memray_test_utils.pyx"
         assert 0 < lineno < 200
 
     @pytest.mark.valgrind

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -146,14 +146,14 @@ def test_cython_traceback(tmpdir):
 
     traceback = list(alloc1.stack_trace())
     assert traceback[-3:] == [
-        ("valloc", ANY, 114),
-        ("_cython_nested_allocation", ANY, 132),
+        ("valloc", ANY, 74),
+        ("_cython_nested_allocation", ANY, 92),
         ("test_cython_traceback", ANY, 137),
     ]
 
     traceback = list(alloc2.stack_trace())
     assert traceback[-3:] == [
-        ("_cython_nested_allocation", ANY, 132),
+        ("_cython_nested_allocation", ANY, 92),
         ("test_cython_traceback", ANY, 137),
     ]
 
@@ -166,7 +166,7 @@ def test_cython_traceback(tmpdir):
     (free,) = frees
     traceback = list(free.stack_trace())
     assert traceback[-3:] == [
-        ("_cython_nested_allocation", ANY, 132),
+        ("_cython_nested_allocation", ANY, 92),
         ("test_cython_traceback", ANY, 137),
     ]
 


### PR DESCRIPTION
Cython correctly uses the name and line numbers from the included file
when profiling is enabled, so by moving these into a dedicated file that
won't need to change very often, we can avoid needing to change the line
numbers in `test_tracing.py` as often.