### PR TITLE
Add a `memray` entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,14 @@ python3.x -m memray run -m my_module
 You can also invoke Memray as a command line tool without having to use `-m` to invoke it as a module:
 
 ```shell
-memray3.x run my_script.py
-memray3.x run -m my_module
+memray run my_script.py
+memray run -m my_module
 ```
 
 The output will be a binary file (like `memray-my_script.2369.bin`) that you can analyze in different ways. One way is to use the `memray flamegraph` command to generate a flame graph:
 
 ```shell
-memray3.x flamegraph my_script.2369.bin
+memray flamegraph my_script.2369.bin
 ```
 
 This will produce an HTML file with a flame graph of the memory usage that you can inspect with your favorite browser. There are multiple other reporters that you can use to generate other types of reports, some of them generating terminal-based output and some of them generating HTML files. Here is an example of a Memray flamegraph:
@@ -148,7 +148,7 @@ Memray supports tracking native C/C++ functions as well as Python functions. Thi
 To activate native tracking, you need to provide the `--native` argument when using the `run` subcommand:
 
 ```shell
-python3.x -m memray run --native my_script.py
+memray run --native my_script.py
 ```
 
 This will automatically add native information to the result file and it will be automatically used by any reporter (such the flamegraph or table reporters). This means that instead of seeing this in the flamegraphs:
@@ -166,13 +166,13 @@ Reporters display native frames in a different color than Python frames. They ca
 Memray's live mode runs a script or a module in a terminal-based interface that allows you to interactively inspect its memory usage while it runs. This is useful for debugging scripts or modules that take a long time to run or that exhibit multiple complex memory patterns. You can use the `--live` option to run the script or module in live mode:
 
 ```shell
-    python3.x -m memray run --live my_script.py
+    memray run --live my_script.py
 ```
 
 or if you want to execute a module:
 
 ```shell
-    python3.x -m memray run --live -m my_module
+    memray run --live -m my_module
 ```
 
 This will show the following TUI interface in your terminal:

--- a/docs/flamegraph.rst
+++ b/docs/flamegraph.rst
@@ -259,9 +259,7 @@ The general form of the ``flamegraph`` subcommand is:
 
 .. code:: shell
 
-    memray3.x flamegraph [options] <results>
-
-(where "x" is the Python minor version).
+    memray flamegraph [options] <results>
 
 The only argument the ``flamegraph`` subcommand requires is the capture file
 previously generated using :doc:`the run subcommand <run>`.

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -11,10 +11,8 @@ The general form of the ``run`` subcommand is one of:
 
 .. code:: shell
 
-    memray3.x run [options] file.py [args]
-    memray3.x run [options] -m module [args]
-
-(where "x" is the Python minor version).
+    memray run [options] file.py [args]
+    memray run [options] -m module [args]
 
 Like the Python interpreter itself, the ``run`` subcommand can take a path to a Python file to run,
 or the name of a Python module to run if you use the ``-m`` flag. While it runs, memory allocations

--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -36,9 +36,7 @@ The general form of the ``stats`` subcommand is:
 
 .. code:: shell
 
-    memray3.x stats [options] <results>
-
-(where "x" is the Python minor version).
+    memray stats [options] <results>
 
 The only argument the ``tree`` subcommand requires is the capture file
 previously generated using :doc:`the run subcommand <run>`.

--- a/docs/summary.rst
+++ b/docs/summary.rst
@@ -19,9 +19,7 @@ The general form of the ``summary`` subcommand is:
 
 .. code:: shell
 
-    memray3.x summary [options] <results>
-
-(where "x" is the Python minor version).
+    memray summary [options] <results>
 
 The only argument the ``summary`` subcommand requires is the capture file
 previously generated using :doc:`the run subcommand <run>`.

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -25,9 +25,7 @@ The general form of the ``table`` subcommand is:
 
 .. code:: shell
 
-    memray3.x table [options] <results>
-
-(where "x" is the Python minor version).
+    memray table [options] <results>
 
 The only argument the ``table`` subcommand requires is the capture file
 previously generated using :doc:`the run subcommand <run>`.

--- a/docs/tree.rst
+++ b/docs/tree.rst
@@ -36,9 +36,7 @@ The general form of the ``tree`` subcommand is:
 
 .. code:: shell
 
-    memray3.x tree [options] <results>
-
-(where "x" is the Python minor version).
+    memray tree [options] <results>
 
 The only argument the ``tree`` subcommand requires is the capture file
 previously generated using :doc:`the run subcommand <run>`.

--- a/setup.py
+++ b/setup.py
@@ -255,7 +255,8 @@ setup(
     },
     entry_points={
         "console_scripts": [
-            f"memray{version_info.major}.{version_info.minor}=" f"memray.__main__:main"
+            f"memray{version_info.major}.{version_info.minor}=memray.__main__:main",
+            "memray=memray.__main__:main",
         ],
     },
     cmdclass={


### PR DESCRIPTION
Closes: #12

Currently we only have `memray3.X` as an entry point but having also
`memray` as an entry point will make it easier for people with only one
Python version installed and it would make the usage examples from -h
line up with how we actually expect it to be used.

This commit also updates the docs and the README file to simplify the
examples with the new entry point.
