### PR TITLE
docs: Use the `memray` entry point in more places

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ Please submit feedback, ideas and bugs by filing a new issue at https://github.c
 To use Memray over a script or a single python file you can use
 
 ```shell
-python3.x -m memray run my_script.py
+python3 -m memray run my_script.py
 ```
 
-(where 3.x is the version of Python you installed Memray for). If you normally run your application with `python3 -m my_module`, you can use the `-m` flag with `memray run`:
+If you normally run your application with `python3 -m my_module`, you can use the `-m` flag with `memray run`:
 
 ```shell
-python3.x -m memray run -m my_module
+python3 -m memray run -m my_module
 ```
 
 You can also invoke Memray as a command line tool without having to use `-m` to invoke it as a module:

--- a/docs/examples/README.rst
+++ b/docs/examples/README.rst
@@ -15,7 +15,7 @@ To track memory allocations, invoke ``memray3.9 run``:
 
 .. code:: shell
 
-   python3.9 -m memray run numpy/example.py
+   memray3.9 run numpy/example.py
 
 Memray will print a message displaying the output file it creates.
 
@@ -28,7 +28,7 @@ graph, use the following command:
 
 .. code:: shell
 
-   python3.9 -m memray flamegraph numpy/memray-basexample.py.6570.bin
+   memray3.9 flamegraph numpy/memray-basexample.py.6570.bin
 
 The HTML file for the flame graph will be generated under
 ``memray-flamegraph-example.py.6570.html``. The flame graph displays the stack frames

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -26,12 +26,23 @@ You can invoke Memray the following way:
 
   python3.9 -m memray
 
-
 Or alternatively through the version-qualified ``memrayX.Y`` script:
 
 .. code:: shell
 
   memray3.9
+
+You can also invoke Memray without version-qualifying it:
+
+.. code:: shell
+
+  memray
+
+The downside to the unqualified ``memray`` script is that it's not immediately
+clear what Python interpreter will be used to execute Memray. If you're using
+a virtualenv that's not a problem because you know exactly what interpreter is
+in use, but otherwise you need to be careful to ensure that ``memray`` is
+running with the interpreter you meant to use.
 
 Profiling with Memray should be done in two steps:
 
@@ -45,7 +56,7 @@ To run memray on the ``example.py`` script, use :doc:`the run subcommand <run>`.
 
 .. code:: shell
 
-  python3.9 -m memray run example.py
+  memray3.9 run example.py
 
 This will execute the script and track its memory allocations, displaying the name of the file where results are being recorded with a message like:
 
@@ -61,8 +72,7 @@ the results file:
 
 .. code:: shell
 
-  $ python3.9 -m memray flamegraph memray-example.py.4131.bin
-
+  memray3.9 flamegraph memray-example.py.4131.bin
 
 This will generate the ``memray-flamegraph-example.py.4131.html`` file in the current directory. See the :doc:`flamegraph`
 documentation which explains how to interpret flame graphs.

--- a/docs/live.rst
+++ b/docs/live.rst
@@ -21,7 +21,7 @@ To use live mode, you can specify the program to be profiled in live mode using 
 
 .. code:: shell-session
 
-  $ memray3.9 run --live application.py
+  $ memray run --live application.py
 
 Immediately Memray will start your process in the background and will connect a TUI to it in the foreground. The TUI will
 display the current high watermark of the heap every time it takes a snapshot, in a tabular format.
@@ -69,8 +69,8 @@ specify the program to be profiled in live mode using ``run --live-remote``:
 
 .. code:: shell-session
 
-  $ memray3.9 run --live-remote application.py
-  Run 'memray3.9 live <port>' in another shell to see live results
+  $ memray run --live-remote application.py
+  Run 'memray live <port>' in another shell to see live results
 
 As you can see, Memray is now waiting on a connection to the live tracking server. You can now attach to
 the server using running the ``live`` command in a separate shell.  
@@ -78,7 +78,7 @@ the server using running the ``live`` command in a separate shell.
 .. code:: shell-session
 
   $ # Run this in a different shell:
-  $ memray3.9 live <port>
+  $ memray live <port>
 
 This command will connect to the server that was started in the previous command, when given the requested port number.
 Once the connection is established, the program will start executing. All memory allocations and deallocations
@@ -95,8 +95,8 @@ It is possible to make ``run --live-remote`` start the server on a user-specifie
 
 .. code:: shell-session
 
-  $ python3.9 -m memray run --live-remote --live-port 12345 application.py
-  Run 'memray3.9 live 12345' in another shell to see live results
+  $ memray run --live-remote --live-port 12345 application.py
+  Run 'memray live 12345' in another shell to see live results
 
 .. important::
 
@@ -104,12 +104,13 @@ It is possible to make ``run --live-remote`` start the server on a user-specifie
   ``run`` command *before* your script/module. Otherwise, they will be treated as arguments for the script and will not
   be used by Memray.
 
-  For example, the following invocation will try running ``python3.9 application.py --live-remote --live-port 12345``:
+  For example, the following invocation will pass ``--live-remote`` and ``--live-port 12345`` to ``application.py``,
+  instead of having them be used by ``memray run``:
 
   .. code:: shell-session
 
-    $ python3.9 -m memray run --live-remote application.py --live-port 12345
-    Run 'memray3.9 live 60125' in another shell to see live results
+    $ memray run --live-remote application.py --live-port 12345
+    Run 'memray live 60125' in another shell to see live results
 
 Using with native tracking
 --------------------------
@@ -119,5 +120,5 @@ to the ``run`` command.
 
 .. code:: shell-session
 
-  $ python3.9 -m memray run --live --native application.py
-  Run 'memray3.9 live 60125' in another shell to see live results
+  $ memray run --live --native application.py
+  Run 'memray live 60125' in another shell to see live results

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -68,7 +68,7 @@ To activate native tracking, you need to provide the ``--native`` argument when 
 
 .. code:: shell
 
-  python3.9 -m memray run --native example.py
+  memray run --native example.py
 
 This will add native stack information to the result file, which any reporter will automatically use.
 
@@ -134,7 +134,7 @@ To activate tracking through forks, you need to provide the ``--follow-fork`` ar
 
 .. code:: shell
 
-  python3.9 -m memray run --follow-fork example.py
+  memray run --follow-fork example.py
 
 In this mode, each time the process forks, a new output file will be created for the new child process, with the new
 child's process ID appended to the original capture file's name. The capture files for child processes are exactly like


### PR DESCRIPTION
Wherever we're not specifically trying to suggest using Memray for
a particular Python version, use the non-version-qualified `memray`
entry point.