### PR TITLE
Add a check for the DCO in the CI

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -1,0 +1,17 @@
+name: Sanity check
+on: [pull_request]
+
+jobs:
+  commits_check_job:
+    runs-on: ubuntu-latest
+    name: Commits Check
+    steps:
+    - name: Get PR Commits
+      id: 'get-pr-commits'
+      uses: tim-actions/get-pr-commits@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: DCO Check
+      uses: tim-actions/dco@master
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}


### PR DESCRIPTION
To avoud having to manually mention the DCO to contributors and to make
sure we don't forget to check that all contributors include the
sign-off, add a check to the CI that ensures that this is enforced.

Closes: #41