### PR TITLE
Add `--wheel` to the `make dist` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build-js: $(generated_js_files)  ## Build package assets in-place
 
 .PHONY: dist
 dist:  ## Generate Python distribution files
-	$(PYTHON) -m build .
+	$(PYTHON) -m build --wheel .
 
 .PHONY: install-sdist
 install-sdist: dist  ## Install from source distribution


### PR DESCRIPTION
Closes: #30

When we build the distribution without "--wheel", `build_ext` gets
called during "python -m build" from the temporary build directory,
while with "--wheel" the files built during "make build" are copied into
the created wheel. This allows the build to be more reproducible as in
this way the DWARF included in the extension to not change due to the
temporary directory path being part of it.
