### PR TITLE
DOC fix -o position

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ such as `memray flamegraph` or `memray table` to convert the results into HTML.
 
 Example:
 
-    $ python3 -m memray run my_script.py -o output.bin
+    $ python3 -m memray run -o output.bin my_script.py
     $ python3 -m memray flamegraph output.bin
 
 positional arguments:

--- a/src/memray/commands/__init__.py
+++ b/src/memray/commands/__init__.py
@@ -39,7 +39,7 @@ _DESCRIPTION = textwrap.dedent(
 
     Example:
 
-        $ python3 -m memray run my_script.py -o output.bin
+        $ python3 -m memray run -o output.bin my_script.py
         $ python3 -m memray flamegraph output.bin
     """
 )


### PR DESCRIPTION
As stated in https://github.com/bloomberg/memray/issues/46, `-o` should come after `run`, and not after the script. This PR fixes that in README and the `__init__` file.

cc @pablogsal 