### PR TITLE
Avoid inlining `exact_unwind`

### DIFF
--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -110,6 +110,7 @@ class NativeTrace
         if (size == MAX_SIZE) {
             d_data.resize(0);
             size = exact_unwind();
+            skip += 1;  // skip the non-inlined exact_unwind frame
             MAX_SIZE = MAX_SIZE * 2 > size ? MAX_SIZE * 2 : size;
             d_data.resize(MAX_SIZE);
         }
@@ -143,7 +144,9 @@ class NativeTrace
         return unw_backtrace((void**)data, MAX_SIZE);
     }
 
-    __attribute__((always_inline)) size_t inline exact_unwind()
+    // This can not be inlined as some architectures (e.g. ppc64le) don't
+    // support inlining functions that call setjmp()
+    __attribute__((noinline)) size_t inline exact_unwind()
     {
         unw_context_t context;
         if (unw_getcontext(&context) < 0) {


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #51*

**Describe your changes**
Remove inline attribute from exact_unwind()

**Testing performed**
Compiled and ran a simple test on a ppc64le machine.

