### PR TITLE
Reduce result file size by 20% in non-native mode

### DIFF
--- a/src/memray/_memray/hooks.h
+++ b/src/memray/_memray/hooks.h
@@ -88,7 +88,7 @@ struct SymbolHook
 void
 ensureAllHooksAreValid();
 
-enum class Allocator {
+enum class Allocator : unsigned char {
     MALLOC = 1,
     FREE = 2,
     CALLOC = 3,

--- a/src/memray/_memray/record_reader.h
+++ b/src/memray/_memray/record_reader.h
@@ -80,6 +80,7 @@ class RecordReader
     [[nodiscard]] bool parseFrameIndex();
     [[nodiscard]] bool parseNativeFrameIndex();
     [[nodiscard]] bool parseAllocationRecord();
+    [[nodiscard]] bool parseNativeAllocationRecord();
     [[nodiscard]] bool parseSegmentHeader();
     [[nodiscard]] bool parseSegment(Segment& segment);
     [[nodiscard]] bool parseThreadRecord();

--- a/src/memray/_memray/records.cpp
+++ b/src/memray/_memray/records.cpp
@@ -23,16 +23,16 @@ Allocation::toPythonObject() const
             return nullptr;                                                                             \
         }                                                                                               \
     } while (0)
-    PyObject* elem = PyLong_FromLong(record.tid);
+    PyObject* elem = PyLong_FromLong(tid);
     __CHECK_ERROR(elem);
     PyTuple_SET_ITEM(tuple, 0, elem);
-    elem = PyLong_FromUnsignedLong(record.address);
+    elem = PyLong_FromUnsignedLong(address);
     __CHECK_ERROR(elem);
     PyTuple_SET_ITEM(tuple, 1, elem);
-    elem = PyLong_FromSize_t(record.size);
+    elem = PyLong_FromSize_t(size);
     __CHECK_ERROR(elem);
     PyTuple_SET_ITEM(tuple, 2, elem);
-    elem = PyLong_FromLong(static_cast<int>(record.allocator));
+    elem = PyLong_FromLong(static_cast<int>(allocator));
     __CHECK_ERROR(elem);
     PyTuple_SET_ITEM(tuple, 3, elem);
     elem = PyLong_FromSize_t(frame_index);
@@ -41,7 +41,7 @@ Allocation::toPythonObject() const
     elem = PyLong_FromSize_t(n_allocations);
     __CHECK_ERROR(elem);
     PyTuple_SET_ITEM(tuple, 5, elem);
-    elem = PyLong_FromSize_t(record.native_frame_id);
+    elem = PyLong_FromSize_t(native_frame_id);
     __CHECK_ERROR(elem);
     PyTuple_SET_ITEM(tuple, 6, elem);
     elem = PyLong_FromSize_t(native_segment_generation);

--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -14,7 +14,7 @@
 namespace memray::tracking_api {
 
 const char MAGIC[] = "memray";
-const int CURRENT_HEADER_VERSION = 6;
+const int CURRENT_HEADER_VERSION = 7;
 
 using frame_id_t = size_t;
 using thread_id_t = unsigned long;
@@ -23,15 +23,16 @@ using millis_t = long long;
 enum class RecordType {
     UNINITIALIZED = 0,
     ALLOCATION = 1,
-    FRAME_INDEX = 2,
-    FRAME_PUSH = 3,
-    NATIVE_TRACE_INDEX = 4,
-    MEMORY_MAP_START = 5,
-    SEGMENT_HEADER = 6,
-    SEGMENT = 7,
-    FRAME_POP = 8,
-    THREAD_RECORD = 9,
-    MEMORY_RECORD = 10,
+    ALLOCATION_WITH_NATIVE = 2,
+    FRAME_INDEX = 3,
+    FRAME_PUSH = 4,
+    NATIVE_TRACE_INDEX = 5,
+    MEMORY_MAP_START = 6,
+    SEGMENT_HEADER = 7,
+    SEGMENT = 8,
+    FRAME_POP = 9,
+    THREAD_RECORD = 10,
+    MEMORY_RECORD = 11,
 };
 
 struct TrackerStats
@@ -72,12 +73,24 @@ struct AllocationRecord
     uintptr_t address;
     size_t size;
     hooks::Allocator allocator;
+};
+
+struct NativeAllocationRecord
+{
+    thread_id_t tid;
+    uintptr_t address;
+    size_t size;
+    hooks::Allocator allocator;
     frame_id_t native_frame_id{0};
 };
 
 struct Allocation
 {
-    tracking_api::AllocationRecord record;
+    thread_id_t tid;
+    uintptr_t address;
+    size_t size;
+    hooks::Allocator allocator;
+    frame_id_t native_frame_id{0};
     size_t frame_index{0};
     size_t native_segment_generation{0};
     size_t n_allocations{1};

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -342,6 +342,7 @@ class TestParseSubcommand:
         # GIVEN
         record_types = [
             "ALLOCATION",
+            "ALLOCATION_WITH_NATIVE",
             "FRAME_PUSH",
             "FRAME_POP",
             "FRAME_ID",


### PR DESCRIPTION
Here are a bunch of optimizations that reduce the result file size by 20%:

- Reduce file size in non-native mode by specializing native allocations
- Ensure our enumerations only use the size of a char
