### PR TITLE
Add `-c` option: program passed as string

### DIFF
--- a/src/memray/commands/run.py
+++ b/src/memray/commands/run.py
@@ -134,7 +134,7 @@ def _run_with_file_output(args: argparse.Namespace) -> None:
     if args.output is None:
         script_name = args.script
         if args.run_as_cmd:
-            script_name = "cmd_script"
+            script_name = "string"
 
         output = f"memray-{os.path.basename(script_name)}.{os.getpid()}.bin"
         filename = os.path.join(os.path.dirname(script_name), output)
@@ -268,7 +268,7 @@ class RunCommand:
             parser.error("The --live-port argument requires --live-remote")
         if args.follow_fork is True and (args.live_mode or args.live_remote_mode):
             parser.error("--follow-fork cannot be used with the live TUI")
-        if args.run_as_cmd and args.script.endswith(".py"):
+        if args.run_as_cmd and pathlib.Path(args.script).exists():
             parser.error("remove the option -c to run a file")
 
         self.validate_target_file(args)

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -254,7 +254,10 @@ class TestRunSubcommand:
 
         # THEN
         captured = capsys.readouterr()
-        assert captured.err.strip() == "Only Python files can be executed under memray"
+        assert (
+            captured.err.strip()
+            == "Only valid Python files or commands can be executed under memray"
+        )
 
     @patch("memray.commands.run.os.getpid")
     def test_run_file_exists(self, getpid, tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
Hi, this closes #44.

can now run: 
- `memray run -c 'print("my python commands")'`  -> a py file will be created with this string as its content. then `arg.script` will be replaced with this file's name. after that, memray runs as before.
- `memray run -c <my_file>.py` -> parser.error with help message to remove `-c` option

(EDIT: no longer creating a file)