### PR TITLE
Decode capture files in two passes

### DIFF
--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -337,7 +337,8 @@ cdef class FileReader:
 
         # Initial pass to populate _header, _high_watermark, and _memory_records.
         cdef shared_ptr[RecordReader] reader_sp = make_shared[RecordReader](
-            unique_ptr[FileSource](new FileSource(self._path))
+            unique_ptr[FileSource](new FileSource(self._path)),
+            False
         )
         cdef RecordReader* reader = reader_sp.get()
 

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -29,6 +29,7 @@ from _memray.source cimport FileSource
 from _memray.source cimport SocketSource
 from _memray.tracking_api cimport Tracker as NativeTracker
 from _memray.tracking_api cimport install_trace_function
+from cpython cimport PyErr_CheckSignals
 from libcpp cimport bool
 from libcpp.limits cimport numeric_limits
 from libcpp.memory cimport make_shared
@@ -350,6 +351,7 @@ cdef class FileReader:
 
         cdef HighWatermarkFinder finder
         while True:
+            PyErr_CheckSignals()
             ret = reader.nextRecord()
             if ret == RecordResult.RecordResultAllocationRecord:
                 finder.processAllocation(reader.getLatestAllocation())
@@ -390,6 +392,7 @@ cdef class FileReader:
         cdef RecordReader* reader = reader_sp.get()
 
         while records_to_process > 0:
+            PyErr_CheckSignals()
             ret = reader.nextRecord()
             if ret == RecordResult.RecordResultAllocationRecord:
                 aggregator.addAllocation(reader.getLatestAllocation())
@@ -427,6 +430,7 @@ cdef class FileReader:
         cdef RecordReader* reader = reader_sp.get()
 
         while True:
+            PyErr_CheckSignals()
             ret = reader.nextRecord()
             if ret == RecordResult.RecordResultAllocationRecord:
                 alloc = AllocationRecord(reader.getLatestAllocation().toPythonObject())

--- a/src/memray/_memray/record_reader.h
+++ b/src/memray/_memray/record_reader.h
@@ -34,7 +34,7 @@ class RecordReader
         ERROR,
         END_OF_FILE,
     };
-    explicit RecordReader(std::unique_ptr<memray::io::Source> source);
+    explicit RecordReader(std::unique_ptr<memray::io::Source> source, bool track_stacks = true);
     void close() noexcept;
     bool isOpen() const noexcept;
     PyObject*
@@ -62,6 +62,7 @@ class RecordReader
     // Data members
     mutable std::mutex d_mutex;
     std::unique_ptr<memray::io::Source> d_input;
+    const bool d_track_stacks;
     HeaderRecord d_header;
     pyframe_map_t d_frame_map{};
     FrameCollection<Frame> d_allocation_frames{1, 2};

--- a/src/memray/_memray/record_reader.pxd
+++ b/src/memray/_memray/record_reader.pxd
@@ -17,6 +17,7 @@ cdef extern from "record_reader.h" namespace "memray::api":
 
     cdef cppclass RecordReader:
         RecordReader(unique_ptr[Source]) except+
+        RecordReader(unique_ptr[Source], bool track_stacks) except+
         void close()
         bool isOpen() const
         RecordResult nextRecord() except+

--- a/src/memray/_memray/snapshot.pxd
+++ b/src/memray/_memray/snapshot.pxd
@@ -12,4 +12,12 @@ cdef extern from "snapshot.h" namespace "memray::api":
         void processAllocation(const Allocation&) except+
         HighWatermark getHighWatermark()
 
+    cdef cppclass reduced_snapshot_map_t:
+        pass
+
+    cdef cppclass SnapshotAllocationAggregator:
+        void addAllocation(const Allocation&) except+
+        reduced_snapshot_map_t getSnapshotAllocations(bool merge_threads) except+
+
+    object Py_ListFromSnapshotAllocationRecords(const reduced_snapshot_map_t&) except+
     object Py_GetSnapshotAllocationRecords(const vector[Allocation]& all_records, size_t record_index, bool merge_threads) except+

--- a/src/memray/_memray/source.cpp
+++ b/src/memray/_memray/source.cpp
@@ -57,12 +57,8 @@ void
 FileSource::_close()
 {
     d_stream.close();
-    if (d_stream.fail() && !d_stream.eof()) {
-        // d_file_name might have been already destroyed at this point, so don't
-        // try to print it
-        std::cerr << "Failed to close output file, results might be incomplete" << std::endl;
-    }
 }
+
 bool
 FileSource::is_open()
 {


### PR DESCRIPTION
Instead, read the file twice. The first time through, collect the memory
records and find the high water mark. After that, the user can choose to
do a pass that actually yields allocation records.

Note that with this design it no longer makes sense to warn if the input
file was closed before we reached EOF, since now that's a normal
consequence of retrieving the high water mark allocations: the second
pass over the file closes it once it has read up through the high water
mark index.

Closes: #43 