### PR TITLE
Fix allocation count in header record

### DIFF
--- a/src/memray/_memray/record_writer.h
+++ b/src/memray/_memray/record_writer.h
@@ -72,7 +72,7 @@ bool inline RecordWriter::writeRecordUnsafe(const RecordType& token, const T& it
             std::is_trivially_copyable<T>::value,
             "Called writeRecord on binary records which cannot be trivially copied");
 
-    if (token == RecordType::ALLOCATION) {
+    if (token == RecordType::ALLOCATION || token == RecordType::ALLOCATION_WITH_NATIVE) {
         d_stats.n_allocations += 1;
     }
     return d_sink->writeAll(reinterpret_cast<const char*>(&token), sizeof(RecordType))


### PR DESCRIPTION
When we split off `ALLOCATION_WITH_NATIVE` from `ALLOCATION`, we missed
a spot that needed to be updated to keep an accurate count of the total
number of allocation-ish records.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>
