### PR TITLE
Adjusting docs flamegraph description to follow the depicted graph

### DIFF
--- a/docs/flamegraph.rst
+++ b/docs/flamegraph.rst
@@ -175,7 +175,7 @@ is deallocated as soon as the call ends.
 
 With this information we know that if you need to chose a place to start
 looking for optimizations, you should start looking at ``g()``, then
-``a()`` and then ``i()`` (in that order) as these are the places that
+``e()`` and then ``i()`` (in that order) as these are the places that
 allocated the most memory when the program reached its maximum. Of
 course, the actual optimization may be done in the callers of these
 functions, but you have a way to start understanding where to optimize.


### PR DESCRIPTION
I'm proposing a quickfix for the documentation.

As reading the documention to memray flamegraphs
https://bloomberg.github.io/memray/flamegraph.html
I consider the information that says that the graph shows the second biggest memory consumption going from function `a()` is not correct as the `a()`[1] does not allocates the memory. The second biggest memory allocator should be `e()`.

[1]
```
def a(n):
    return [b(n), h(n)]
```