### PR TITLE
Leverage lz4 to add file compression on the boundaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Set up dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -qy libunwind-dev pkg-config npm
+        sudo apt-get install -qy libunwind-dev liblz4-dev pkg-config npm
     - name: Install Python dependencies
       run: |
         python3 -m pip install --upgrade pip
@@ -68,7 +68,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set up dependencies
       run: |
-        apk add --update build-base libunwind-dev musl-dev python3-dev
+        apk add --update build-base libunwind-dev lz4-dev musl-dev python3-dev
     - name: Install Python dependencies
       run: |
         python3 -m pip install --upgrade pip
@@ -90,7 +90,7 @@ jobs:
     - name: Set up dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -qy clang-format npm libunwind-dev pkg-config
+        sudo apt-get install -qy clang-format npm libunwind-dev liblz4-dev pkg-config
         npm install -g prettier
     - name: Install Python dependencies
       run: |
@@ -117,7 +117,7 @@ jobs:
     - name: Set up dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -qy libunwind-dev pkg-config npm valgrind
+        sudo apt-get install -qy libunwind-dev liblz4-dev pkg-config npm valgrind
     - name: Install Python dependencies and package
       run: |
         python3 -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update \
     && apt-get install -y --force-yes --no-install-recommends \
     build-essential \
     libunwind-dev \
+    liblz4-dev \
     pkg-config \
     python3-dev \
     python3-dbg \

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ system where you are doing the installation.
 If you wish to build Memray from source you need the following binary dependencies in your system:
 
 - libunwind
+- liblz4
 
-Check your package manager on how to install these dependencies (for example `apt-get install libunwind-dev` in Debian-based systems).
+Check your package manager on how to install these dependencies (for example `apt-get install libunwind-dev liblz4-dev` in Debian-based systems).
 
 Once you have the binary dependencies installed, you can clone the repository and follow with the normal building process:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,4 +51,4 @@ build = ["cp37-*", "cp38-*", "cp39-*", "cp310-*"]
 skip = "*musllinux*"
 
 [tool.cibuildwheel.linux]
-before-all = "yum install -y libunwind-devel"
+before-all = "yum install -y libunwind-devel lz4-devel"

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ MEMRAY_EXTENSION = Extension(
         "src/memray/_memray/socket_reader_thread.cpp",
         "src/memray/_memray/native_resolver.cpp",
     ],
-    libraries=["unwind"],
+    libraries=["unwind", "lz4"],
     library_dirs=[str(LIBBACKTRACE_LIBDIR)],
     include_dirs=["src", str(LIBBACKTRACE_INCLUDEDIRS)],
     language="c++",

--- a/src/memray/_destination.py
+++ b/src/memray/_destination.py
@@ -21,6 +21,7 @@ class FileDestination(Destination):
 
     path: typing.Union[pathlib.Path, str]
     overwrite: bool = False
+    compress: bool = True
 
 
 @dataclass(frozen=True)

--- a/src/memray/_destination.py
+++ b/src/memray/_destination.py
@@ -21,7 +21,7 @@ class FileDestination(Destination):
 
     path: typing.Union[pathlib.Path, str]
     overwrite: bool = False
-    compress: bool = True
+    compress_on_exit: bool = True
 
 
 @dataclass(frozen=True)

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -261,7 +261,9 @@ cdef class Tracker:
 
             if is_dev_null:
                 return unique_ptr[Sink](new NullSink())
-            return unique_ptr[Sink](new FileSink(os.fsencode(destination.path), destination.overwrite))
+            return unique_ptr[Sink](new FileSink(os.fsencode(destination.path),
+                                                 destination.overwrite,
+                                                 destination.compress))
 
         elif isinstance(destination, SocketDestination):
             return unique_ptr[Sink](new SocketSink(destination.address, destination.server_port))

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -263,7 +263,7 @@ cdef class Tracker:
                 return unique_ptr[Sink](new NullSink())
             return unique_ptr[Sink](new FileSink(os.fsencode(destination.path),
                                                  destination.overwrite,
-                                                 destination.compress))
+                                                 destination.compress_on_exit))
 
         elif isinstance(destination, SocketDestination):
             return unique_ptr[Sink](new SocketSink(destination.address, destination.server_port))

--- a/src/memray/_memray/lz4_stream.h
+++ b/src/memray/_memray/lz4_stream.h
@@ -1,0 +1,311 @@
+// Copyright (c) 2015, Kasper Laudrup <laudrup@stacktrace.dk>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#ifndef LZ4_STREAM
+#define LZ4_STREAM
+
+// LZ4 Headers
+#include <lz4frame.h>
+
+// Standard headers
+#include <array>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <streambuf>
+#include <vector>
+
+namespace lz4_stream {
+/**
+ * @brief An output stream that will LZ4 compress the input data.
+ *
+ * An output stream that will wrap another output stream and LZ4
+ * compress its input data to that stream.
+ *
+ */
+template<size_t SrcBufSize = 256>
+class basic_ostream : public std::ostream
+{
+  public:
+    /**
+     * @brief Constructs an LZ4 compression output stream
+     *
+     * @param sink The stream to write compressed data to
+     */
+    basic_ostream(std::ostream& sink)
+    : std::ostream(new output_buffer(sink))
+    , buffer_(dynamic_cast<output_buffer*>(rdbuf()))
+    {
+        assert(buffer_);
+    }
+
+    /**
+     * @brief Destroys the LZ4 output stream. Calls close() if not already called.
+     */
+    ~basic_ostream()
+    {
+        close();
+        delete buffer_;
+    }
+
+    /**
+     * @brief Flushes and writes LZ4 footer data to the LZ4 output stream.
+     *
+     * After calling this function no more data should be written to the stream.
+     */
+    void close()
+    {
+        buffer_->close();
+    }
+
+  private:
+    class output_buffer : public std::streambuf
+    {
+      public:
+        output_buffer(const output_buffer&) = delete;
+        output_buffer& operator=(const output_buffer&) = delete;
+
+        output_buffer(std::ostream& sink)
+        : sink_(sink)
+        ,
+        // TODO: No need to recalculate the dest_buf_ size on each construction
+        dest_buf_(LZ4F_compressBound(src_buf_.size(), nullptr))
+        , ctx_(nullptr)
+        , closed_(false)
+        {
+            char* base = &src_buf_.front();
+            setp(base, base + src_buf_.size() - 1);
+
+            size_t ret = LZ4F_createCompressionContext(&ctx_, LZ4F_VERSION);
+            if (LZ4F_isError(ret) != 0) {
+                throw std::runtime_error(
+                        std::string("Failed to create LZ4 compression context: ")
+                        + LZ4F_getErrorName(ret));
+            }
+            write_header();
+        }
+
+        ~output_buffer()
+        {
+            close();
+        }
+
+        void close()
+        {
+            if (closed_) {
+                return;
+            }
+            sync();
+            write_footer();
+            LZ4F_freeCompressionContext(ctx_);
+            closed_ = true;
+        }
+
+      private:
+        int_type overflow(int_type ch) override
+        {
+            assert(std::less_equal<char*>()(pptr(), epptr()));
+
+            *pptr() = static_cast<basic_ostream::char_type>(ch);
+            pbump(1);
+            compress_and_write();
+
+            return ch;
+        }
+
+        int_type sync() override
+        {
+            compress_and_write();
+            return 0;
+        }
+
+        void compress_and_write()
+        {
+            // TODO: Throw exception instead or set badbit
+            assert(!closed_);
+            int orig_size = static_cast<int>(pptr() - pbase());
+            pbump(-orig_size);
+            size_t ret = LZ4F_compressUpdate(
+                    ctx_,
+                    &dest_buf_.front(),
+                    dest_buf_.capacity(),
+                    pbase(),
+                    orig_size,
+                    nullptr);
+            if (LZ4F_isError(ret) != 0) {
+                throw std::runtime_error(
+                        std::string("LZ4 compression failed: ") + LZ4F_getErrorName(ret));
+            }
+            sink_.write(&dest_buf_.front(), ret);
+        }
+
+        void write_header()
+        {
+            // TODO: Throw exception instead or set badbit
+            assert(!closed_);
+            size_t ret = LZ4F_compressBegin(ctx_, &dest_buf_.front(), dest_buf_.capacity(), nullptr);
+            if (LZ4F_isError(ret) != 0) {
+                throw std::runtime_error(
+                        std::string("Failed to start LZ4 compression: ") + LZ4F_getErrorName(ret));
+            }
+            sink_.write(&dest_buf_.front(), ret);
+        }
+
+        void write_footer()
+        {
+            assert(!closed_);
+            size_t ret = LZ4F_compressEnd(ctx_, &dest_buf_.front(), dest_buf_.capacity(), nullptr);
+            if (LZ4F_isError(ret) != 0) {
+                throw std::runtime_error(
+                        std::string("Failed to end LZ4 compression: ") + LZ4F_getErrorName(ret));
+            }
+            sink_.write(&dest_buf_.front(), ret);
+        }
+
+        std::ostream& sink_;
+        std::array<char, SrcBufSize> src_buf_;
+        std::vector<char> dest_buf_;
+        LZ4F_compressionContext_t ctx_;
+        bool closed_;
+    };
+
+    output_buffer* buffer_;
+};
+
+/**
+ * @brief An input stream that will LZ4 decompress output data.
+ *
+ * An input stream that will wrap another input stream and LZ4
+ * decompress its output data to that stream.
+ *
+ */
+template<size_t SrcBufSize = 256, size_t DestBufSize = 256>
+class basic_istream : public std::istream
+{
+  public:
+    /**
+     * @brief Constructs an LZ4 decompression input stream
+     *
+     * @param source The stream to read LZ4 compressed data from
+     */
+    basic_istream(std::istream& source)
+    : std::istream(new input_buffer(source))
+    , buffer_(dynamic_cast<input_buffer*>(rdbuf()))
+    {
+        assert(buffer_);
+    }
+
+    /**
+     * @brief Destroys the LZ4 output stream.
+     */
+    ~basic_istream()
+    {
+        delete buffer_;
+    }
+
+  private:
+    class input_buffer : public std::streambuf
+    {
+      public:
+        input_buffer(std::istream& source)
+        : source_(source)
+        , offset_(0)
+        , src_buf_size_(0)
+        , ctx_(nullptr)
+        {
+            size_t ret = LZ4F_createDecompressionContext(&ctx_, LZ4F_VERSION);
+            if (LZ4F_isError(ret) != 0) {
+                throw std::runtime_error(
+                        std::string("Failed to create LZ4 decompression context: ")
+                        + LZ4F_getErrorName(ret));
+            }
+            setg(&src_buf_.front(), &src_buf_.front(), &src_buf_.front());
+        }
+
+        ~input_buffer()
+        {
+            LZ4F_freeDecompressionContext(ctx_);
+        }
+
+        int_type underflow() override
+        {
+            size_t written_size = 0;
+            while (written_size == 0) {
+                if (offset_ == src_buf_size_) {
+                    source_.read(&src_buf_.front(), src_buf_.size());
+                    src_buf_size_ = static_cast<size_t>(source_.gcount());
+                    offset_ = 0;
+                }
+
+                if (src_buf_size_ == 0) {
+                    return traits_type::eof();
+                }
+
+                size_t src_size = src_buf_size_ - offset_;
+                size_t dest_size = dest_buf_.size();
+                size_t ret = LZ4F_decompress(
+                        ctx_,
+                        &dest_buf_.front(),
+                        &dest_size,
+                        &src_buf_.front() + offset_,
+                        &src_size,
+                        nullptr);
+                if (LZ4F_isError(ret) != 0) {
+                    throw std::runtime_error(
+                            std::string("LZ4 decompression failed: ") + LZ4F_getErrorName(ret));
+                }
+                written_size = dest_size;
+                offset_ += src_size;
+            }
+            setg(&dest_buf_.front(), &dest_buf_.front(), &dest_buf_.front() + written_size);
+            return traits_type::to_int_type(*gptr());
+        }
+
+        input_buffer(const input_buffer&) = delete;
+        input_buffer& operator=(const input_buffer&) = delete;
+
+      private:
+        std::istream& source_;
+        std::array<char, SrcBufSize> src_buf_;
+        std::array<char, DestBufSize> dest_buf_;
+        size_t offset_;
+        size_t src_buf_size_;
+        LZ4F_decompressionContext_t ctx_;
+    };
+
+    input_buffer* buffer_;
+};
+
+using ostream = basic_ostream<>;
+using istream = basic_istream<>;
+
+}  // namespace lz4_stream
+#endif  // LZ4_STREAM

--- a/src/memray/_memray/sink.h
+++ b/src/memray/_memray/sink.h
@@ -33,6 +33,7 @@ class FileSink : public memray::io::Sink
     std::unique_ptr<Sink> cloneInChildProcess() override;
 
   private:
+    void compress() noexcept;
     bool grow(size_t needed);
     bool slideWindow();
     size_t bytesBeyondBufferNeedle();

--- a/src/memray/_memray/sink.h
+++ b/src/memray/_memray/sink.h
@@ -21,7 +21,7 @@ class Sink
 class FileSink : public memray::io::Sink
 {
   public:
-    FileSink(const std::string& file_name, bool overwrite);
+    FileSink(const std::string& file_name, bool overwrite, bool compress);
     ~FileSink() override;
     FileSink(FileSink&) = delete;
     FileSink(FileSink&&) = delete;
@@ -37,7 +37,9 @@ class FileSink : public memray::io::Sink
     bool slideWindow();
     size_t bytesBeyondBufferNeedle();
 
+    std::string d_filename;
     std::string d_fileNameStem;
+    bool d_compress{1};
     int d_fd{-1};
     size_t d_fileSize{0};
     const size_t BUFFER_SIZE{16 * 1024 * 1024};  // 16 MiB

--- a/src/memray/_memray/sink.pxd
+++ b/src/memray/_memray/sink.pxd
@@ -8,7 +8,7 @@ cdef extern from "sink.h" namespace "memray::io":
         pass
 
     cdef cppclass FileSink(Sink):
-        FileSink(const string& file_name, bool overwrite) except +IOError
+        FileSink(const string& file_name, bool overwrite, bool compress) except +IOError
 
     cdef cppclass SocketSink(Sink):
         SocketSink(string host, unsigned int port) except +IOError

--- a/src/memray/_memray/source.h
+++ b/src/memray/_memray/source.h
@@ -3,7 +3,10 @@
 #include <atomic>
 #include <cstdint>
 #include <fstream>
+#include <memory>
 #include <string>
+
+#include "lz4_stream.h"
 
 namespace memray::io {
 
@@ -37,7 +40,8 @@ class FileSource : public Source
   private:
     void _close();
     const std::string& d_file_name;
-    std::ifstream d_stream;
+    std::shared_ptr<std::ifstream> d_raw_stream;
+    std::shared_ptr<std::istream> d_stream;
 };
 
 class SocketBuf : public std::streambuf

--- a/src/memray/commands/run.py
+++ b/src/memray/commands/run.py
@@ -155,7 +155,9 @@ def _run_with_file_output(args: argparse.Namespace) -> None:
         """
     ).strip()
 
-    destination = FileDestination(path=filename, overwrite=args.force)
+    destination = FileDestination(
+        path=filename, overwrite=args.force, compress_on_exit=args.compress_on_exit
+    )
     try:
         _run_tracker(
             destination=destination,
@@ -225,6 +227,19 @@ class RunCommand:
             help="If the output file already exists, overwrite it",
             action="store_true",
             default=False,
+        )
+        parser.add_argument(
+            "--compress-on-exit",
+            help="Compress the resulting file using lz4 after tracking completes",
+            dest="compress_on_exit",
+            default=True,
+            action="store_true",
+        )
+        parser.add_argument(
+            "--no-compress",
+            help="Do not compress the resulting file using lz4",
+            dest="compress_on_exit",
+            action="store_false",
         )
         parser.add_argument(
             "-c",

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from memray import FileDestination
 from memray import FileReader
 from memray import Tracker
 from memray._memray import MemoryAllocator
@@ -35,7 +36,8 @@ def test_rejects_different_header_version(tmp_path):
 
     # WHEN
     # Create a valid allocation record file
-    with Tracker(output):
+    destination = FileDestination(output, overwrite=False, compress=False)
+    with Tracker(destination=destination):
         allocator.valloc(1024)
 
     # Change the header version to zero

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -36,7 +36,7 @@ def test_rejects_different_header_version(tmp_path):
 
     # WHEN
     # Create a valid allocation record file
-    destination = FileDestination(output, overwrite=False, compress=False)
+    destination = FileDestination(output, overwrite=False, compress_on_exit=False)
     with Tracker(destination=destination):
         allocator.valloc(1024)
 


### PR DESCRIPTION
- Vendor a copy of lz4 stream
- Update the `FileSink` and `FileSource` to use `lz4`
- Update project files to account for the dependency on `lz4`

As a bonus, this seem to make the reader 5% faster:

```
Benchmark 1: memray parse /tmp/lel.bin  > /dev/null
  Time (mean ± σ):      1.051 s ±  0.018 s    [User: 1.023 s, System: 0.026 s]
  Range (min … max):    1.016 s …  1.081 s    10 runs

Benchmark 1: memray parse /tmp/lel2.bin  > /dev/null
  Time (mean ± σ):     990.6 ms ±   9.5 ms    [User: 968.2 ms, System: 21.5 ms]
  Range (min … max):   969.1 ms … 999.5 ms    10 runs
```
