### PR TITLE
Find leaks and high water mark in one pass

### DIFF
--- a/src/memray/_memray/snapshot.cpp
+++ b/src/memray/_memray/snapshot.cpp
@@ -4,6 +4,53 @@
 
 namespace memray::api {
 
+namespace {  // unnamed
+
+reduced_snapshot_map_t
+reduceSnapshotAllocations(
+        bool merge_threads,
+        const IntervalTree<Allocation>& ranges,
+        const std::unordered_map<uintptr_t, Allocation>& allocations_by_ptr)
+{
+    reduced_snapshot_map_t stack_to_allocation{};
+
+    for (const auto& it : allocations_by_ptr) {
+        const Allocation& record = it.second;
+        const thread_id_t thread_id = merge_threads ? NO_THREAD_INFO : record.tid;
+        auto alloc_it = stack_to_allocation.find(std::pair(record.frame_index, thread_id));
+        if (alloc_it == stack_to_allocation.end()) {
+            stack_to_allocation.insert(
+                    alloc_it,
+                    std::pair(std::pair(record.frame_index, thread_id), record));
+        } else {
+            alloc_it->second.size += record.size;
+            alloc_it->second.n_allocations += 1;
+        }
+    }
+
+    // Process ranged allocations. As there can be partial deallocations in mmap'd regions,
+    // we update the allocation to reflect the actual size at the peak, based on the lengths
+    // of the ranges in the interval tree.
+    for (const auto& [range, allocation] : ranges) {
+        const thread_id_t thread_id = merge_threads ? NO_THREAD_INFO : allocation.tid;
+        auto alloc_it = stack_to_allocation.find(std::pair(allocation.frame_index, thread_id));
+        if (alloc_it == stack_to_allocation.end()) {
+            Allocation new_alloc = allocation;
+            new_alloc.size = range.size();
+            stack_to_allocation.insert(
+                    alloc_it,
+                    std::pair(std::pair(allocation.frame_index, thread_id), new_alloc));
+        } else {
+            alloc_it->second.size += range.size();
+            alloc_it->second.n_allocations += 1;
+        }
+    }
+
+    return stack_to_allocation;
+}
+
+}  // unnamed namespace
+
 Interval::Interval(uintptr_t begin, uintptr_t end)
 : begin(begin)
 , end(end){};
@@ -74,47 +121,219 @@ SnapshotAllocationAggregator::addAllocation(const Allocation& allocation)
             break;
         }
     }
-    d_index++;
 }
 
 reduced_snapshot_map_t
 SnapshotAllocationAggregator::getSnapshotAllocations(bool merge_threads)
 {
-    reduced_snapshot_map_t stack_to_allocation{};
+    return reduceSnapshotAllocations(merge_threads, d_interval_tree, d_ptr_to_allocation);
+}
 
-    for (const auto& it : d_ptr_to_allocation) {
-        const Allocation& record = it.second;
-        const thread_id_t thread_id = merge_threads ? NO_THREAD_INFO : record.tid;
-        auto alloc_it = stack_to_allocation.find(std::pair(record.frame_index, thread_id));
-        if (alloc_it == stack_to_allocation.end()) {
-            stack_to_allocation.insert(
-                    alloc_it,
-                    std::pair(std::pair(record.frame_index, thread_id), record));
-        } else {
-            alloc_it->second.size += record.size;
-            alloc_it->second.n_allocations += 1;
-        }
+bool
+StreamingAllocationAggregator::atHighWaterMark() const
+{
+    if (d_delta_freed_size == 0 && d_delta_allocated_size == 0) {
+        assert(0 == d_delta_freed_ranges.size());
+        assert(0 == d_delta_allocated_ranges.size());
+        assert(0 == d_delta_freed_ptrs.size());
+        assert(0 == d_delta_allocated_ptrs.size());
+        return true;
+    }
+    return false;
+}
+
+void
+StreamingAllocationAggregator::applyDeltaToSnapshot(
+        IntervalTree<Allocation>* allocated_ranges,
+        std::unordered_map<uintptr_t, Allocation>* allocated_ptrs)
+{
+    for (auto& address : d_delta_freed_ptrs) {
+        allocated_ptrs->erase(address);
+    }
+    for (auto& [interval, _] : d_delta_freed_ranges) {
+        allocated_ranges->removeInterval(interval.begin, interval.size());
+    }
+    for (auto& [_, allocation] : d_delta_allocated_ptrs) {
+        allocated_ptrs->insert_or_assign(allocation.address, allocation);
+    }
+    for (auto& [_, allocation] : d_delta_allocated_ranges) {
+        allocated_ranges->addInterval(allocation.address, allocation.size, allocation);
+    }
+}
+
+void
+StreamingAllocationAggregator::resetDelta()
+{
+    d_delta_allocated_size = 0;
+    d_delta_freed_size = 0;
+    d_delta_freed_ranges.clear();
+    d_delta_freed_ptrs.clear();
+    d_delta_allocated_ranges.clear();
+    d_delta_allocated_ptrs.clear();
+}
+
+void
+StreamingAllocationAggregator::addAllocationWhileAtHighWaterMark(const Allocation& allocation)
+{
+    assert(atHighWaterMark());
+    size_t index = d_allocations_seen++;
+    switch (hooks::allocatorKind(allocation.allocator)) {
+        case hooks::AllocatorKind::SIMPLE_ALLOCATOR: {
+            d_high_water_mark_ptrs[allocation.address] = allocation;
+            d_high_water_mark_index = index;
+            d_high_water_mark_memory += allocation.size;
+        } break;
+        case hooks::AllocatorKind::RANGED_ALLOCATOR: {
+            d_high_water_mark_ranges.addInterval(allocation.address, allocation.size, allocation);
+            d_high_water_mark_index = index;
+            d_high_water_mark_memory += allocation.size;
+        } break;
+        case hooks::AllocatorKind::SIMPLE_DEALLOCATOR: {
+            // If the ptr was in the high water mark, start a delta.
+            auto it = d_high_water_mark_ptrs.find(allocation.address);
+            if (it != d_high_water_mark_ptrs.end()) {
+                if (it->second.size) {
+                    d_delta_freed_ptrs.insert(allocation.address);
+                    d_delta_freed_size += it->second.size;
+                    assert(!atHighWaterMark());
+                } else {
+                    // Special case: if the freed pointer was for a 0 byte
+                    // allocation, we're still at the high water mark.
+                    d_high_water_mark_ptrs.erase(it);
+                    d_high_water_mark_index = index;
+                }
+            }
+        } break;
+        case hooks::AllocatorKind::RANGED_DEALLOCATOR: {
+            // If the range being freed overlaps with any ranges included in
+            // the high water mark, start a delta.
+            auto overlap =
+                    d_high_water_mark_ranges.findIntersection(allocation.address, allocation.size);
+            for (auto& interval : overlap) {
+                d_delta_freed_ranges.addInterval(interval.begin, interval.size(), 0);
+                d_delta_freed_size += interval.size();
+            }
+        } break;
+    }
+}
+
+void
+StreamingAllocationAggregator::addAllocationWhileNotAtHighWaterMark(const Allocation& allocation)
+{
+    assert(!atHighWaterMark());
+    size_t index = d_allocations_seen++;
+    switch (hooks::allocatorKind(allocation.allocator)) {
+        case hooks::AllocatorKind::SIMPLE_ALLOCATOR: {
+            d_delta_allocated_ptrs[allocation.address] = allocation;
+            d_delta_allocated_size += allocation.size;
+        } break;
+        case hooks::AllocatorKind::RANGED_ALLOCATOR: {
+            d_delta_allocated_ranges.addInterval(allocation.address, allocation.size, allocation);
+            d_delta_allocated_size += allocation.size;
+        } break;
+        case hooks::AllocatorKind::SIMPLE_DEALLOCATOR: {
+            auto it = d_delta_allocated_ptrs.find(allocation.address);
+            if (it != d_delta_allocated_ptrs.end()) {
+                // This ptr was allocated after forking the delta.
+                assert(d_delta_allocated_size >= it->second.size);
+                d_delta_allocated_size -= it->second.size;
+                d_delta_allocated_ptrs.erase(it);
+            } else if (d_delta_freed_ptrs.count(allocation.address)) {
+                // Our delta already holds a free for this address. This can
+                // happen if, after being freed, it was reallocated by a call
+                // that we didn't track, then freed by a call that we did. In
+                // particular, this can happen if it's allocated with the
+                // recursion guard enabled and freed with it disabled. For
+                // instance, the allocation for our TLS vector happens while
+                // the recursion guard is set, but the deallocation happens as
+                // our thread is dying, after the recursion guard is unset.
+            } else {
+                // This ptr was allocated before forking the delta.
+                // Check if it was part of the high water mark.
+                auto it = d_high_water_mark_ptrs.find(allocation.address);
+                if (it != d_high_water_mark_ptrs.end()) {
+                    // It was part of the high water mark.
+                    d_delta_freed_ptrs.insert(allocation.address);
+                    d_delta_freed_size += it->second.size;
+                } else {
+                    // Ignore it. This must be a free of something allocated
+                    // before tracking started.
+                }
+            }
+        } break;
+        case hooks::AllocatorKind::RANGED_DEALLOCATOR: {
+            // Handle portions of the range allocated since forking the delta.
+            auto allocated_since_delta_began =
+                    d_delta_allocated_ranges.findIntersection(allocation.address, allocation.size);
+
+            for (auto& interval : allocated_since_delta_began) {
+                d_delta_allocated_ranges.removeInterval(interval.begin, interval.size());
+                assert(d_delta_allocated_size >= interval.size());
+                d_delta_allocated_size -= interval.size();
+            }
+
+            // Handle portions of the range included in the high water mark.
+            IntervalTree<int> allocated_before_delta_began;
+            allocated_before_delta_began.addInterval(allocation.address, allocation.size, 0);
+            for (auto& interval : allocated_since_delta_began) {
+                allocated_before_delta_began.removeInterval(interval.begin, interval.size());
+            }
+
+            size_t deltaFreedIntervalsSizeBefore = d_delta_freed_ranges.size();
+            for (auto& [old_interval, _] : allocated_before_delta_began) {
+                auto included_in_high_water_mark = d_high_water_mark_ranges.findIntersection(
+                        old_interval.begin,
+                        old_interval.size());
+
+                for (auto& interval : included_in_high_water_mark) {
+                    d_delta_freed_ranges.removeInterval(interval.begin, interval.size());
+                    d_delta_freed_ranges.addInterval(interval.begin, interval.size(), 0);
+                }
+            }
+            size_t deltaFreedIntervalsSizeAfter = d_delta_freed_ranges.size();
+            d_delta_freed_size += (deltaFreedIntervalsSizeAfter - deltaFreedIntervalsSizeBefore);
+        } break;
     }
 
-    // Process ranged allocations. As there can be partial deallocations in mmap'd regions,
-    // we update the allocation to reflect the actual size at the peak, based on the lengths
-    // of the ranges in the interval tree.
-    for (const auto& [range, allocation] : d_interval_tree) {
-        const thread_id_t thread_id = merge_threads ? NO_THREAD_INFO : allocation.tid;
-        auto alloc_it = stack_to_allocation.find(std::pair(allocation.frame_index, thread_id));
-        if (alloc_it == stack_to_allocation.end()) {
-            Allocation new_alloc = allocation;
-            new_alloc.size = range.size();
-            stack_to_allocation.insert(
-                    alloc_it,
-                    std::pair(std::pair(allocation.frame_index, thread_id), new_alloc));
-        } else {
-            alloc_it->second.size += range.size();
-            alloc_it->second.n_allocations += 1;
-        }
+    if (d_delta_allocated_size >= d_delta_freed_size) {
+        // New high water mark!
+        d_high_water_mark_index = index;
+        d_high_water_mark_memory += (d_delta_allocated_size - d_delta_freed_size);
+        applyDeltaToSnapshot(&d_high_water_mark_ranges, &d_high_water_mark_ptrs);
+        resetDelta();
+        assert(atHighWaterMark());
     }
+}
 
-    return stack_to_allocation;
+void
+StreamingAllocationAggregator::addAllocation(const Allocation& allocation)
+{
+    if (atHighWaterMark()) {
+        addAllocationWhileAtHighWaterMark(allocation);
+    } else {
+        addAllocationWhileNotAtHighWaterMark(allocation);
+    }
+}
+
+reduced_snapshot_map_t
+StreamingAllocationAggregator::getHighWaterMarkAllocations(bool merge_threads)
+{
+    return reduceSnapshotAllocations(merge_threads, d_high_water_mark_ranges, d_high_water_mark_ptrs);
+}
+
+reduced_snapshot_map_t
+StreamingAllocationAggregator::getLeakedAllocations(bool merge_threads)
+{
+    auto ranges = d_high_water_mark_ranges;
+    auto ptrs = d_high_water_mark_ptrs;
+    applyDeltaToSnapshot(&ranges, &ptrs);
+    return reduceSnapshotAllocations(merge_threads, ranges, ptrs);
+}
+
+HighWaterMark
+StreamingAllocationAggregator::getHighWaterMark() const noexcept
+{
+    return {d_high_water_mark_index, d_high_water_mark_memory};
 }
 
 /**
@@ -139,68 +358,6 @@ reduceSnapshotAllocations(const allocations_t& records, size_t snapshot_index, b
     });
 
     return aggregator.getSnapshotAllocations(merge_threads);
-}
-
-void
-HighWatermarkFinder::updatePeak(size_t index) noexcept
-{
-    if (d_current_memory >= d_last_high_water_mark.peak_memory) {
-        d_last_high_water_mark.index = index;
-        d_last_high_water_mark.peak_memory = d_current_memory;
-    }
-}
-
-void
-HighWatermarkFinder::processAllocation(const Allocation& allocation)
-{
-    size_t index = d_allocations_seen++;
-    switch (hooks::allocatorKind(allocation.allocator)) {
-        case hooks::AllocatorKind::SIMPLE_ALLOCATOR: {
-            d_current_memory += allocation.size;
-            updatePeak(index);
-            d_ptr_to_allocation_size[allocation.address] = allocation.size;
-            break;
-        }
-        case hooks::AllocatorKind::SIMPLE_DEALLOCATOR: {
-            auto it = d_ptr_to_allocation_size.find(allocation.address);
-            if (it != d_ptr_to_allocation_size.end()) {
-                d_current_memory -= it->second;
-                d_ptr_to_allocation_size.erase(it);
-            }
-            break;
-        }
-        case hooks::AllocatorKind::RANGED_ALLOCATOR: {
-            d_mmap_intervals.addInterval(allocation.address, allocation.size, allocation);
-            d_current_memory += allocation.size;
-            updatePeak(index);
-            break;
-        }
-        case hooks::AllocatorKind::RANGED_DEALLOCATOR: {
-            const auto address = allocation.address;
-            const auto size = allocation.size;
-            const auto removed = d_mmap_intervals.removeInterval(address, size);
-
-            if (!removed.has_value()) {
-                break;
-            }
-            size_t removed_size = std::accumulate(
-                    removed.value().begin(),
-                    removed.value().cend(),
-                    0,
-                    [](size_t sum, const std::pair<Interval, Allocation>& range) {
-                        return sum + range.first.size();
-                    });
-            d_current_memory -= removed_size;
-            updatePeak(index);
-            break;
-        }
-    }
-}
-
-HighWatermark
-HighWatermarkFinder::getHighWatermark() const noexcept
-{
-    return d_last_high_water_mark;
 }
 
 PyObject*

--- a/src/memray/_memray/snapshot.pxd
+++ b/src/memray/_memray/snapshot.pxd
@@ -4,13 +4,9 @@ from libcpp.vector cimport vector
 
 
 cdef extern from "snapshot.h" namespace "memray::api":
-    cdef struct HighWatermark:
+    cdef struct HighWaterMark:
         size_t index
         size_t peak_memory
-
-    cdef cppclass HighWatermarkFinder:
-        void processAllocation(const Allocation&) except+
-        HighWatermark getHighWatermark()
 
     cdef cppclass reduced_snapshot_map_t:
         pass
@@ -18,6 +14,12 @@ cdef extern from "snapshot.h" namespace "memray::api":
     cdef cppclass SnapshotAllocationAggregator:
         void addAllocation(const Allocation&) except+
         reduced_snapshot_map_t getSnapshotAllocations(bool merge_threads) except+
+
+    cdef cppclass StreamingAllocationAggregator:
+        void addAllocation(const Allocation&) except+
+        reduced_snapshot_map_t getHighWaterMarkAllocations(bool merge_threads) except+
+        reduced_snapshot_map_t getLeakedAllocations(bool merge_threads) except+
+        HighWaterMark getHighWaterMark() except+
 
     object Py_ListFromSnapshotAllocationRecords(const reduced_snapshot_map_t&) except+
     object Py_GetSnapshotAllocationRecords(const vector[Allocation]& all_records, size_t record_index, bool merge_threads) except+


### PR DESCRIPTION
Rather than making two passes over the file, make a single pass that
tracks both the high water mark and any allocations or deallocations
since the high water mark. From the allocations and deallocations since
the high water mark we can determine if a new high water mark has been
hit, and we can determine what was leaked at the end by aggregating
these extra allocations and deallocations on top of the high water mark
allocations.

I believe that with this scheme we need to process any given allocation
record at most twice.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>