### PR TITLE
Update `sys.path` when running `memray run`

### DIFF
--- a/src/memray/commands/run.py
+++ b/src/memray/commands/run.py
@@ -34,9 +34,6 @@ def _run_tracker(
     post_run_message: Optional[str] = None,
     follow_fork: bool = False,
 ) -> None:
-    sys.argv = [args.script, *args.script_args]
-    if args.run_as_module:
-        sys.argv.insert(0, "-m")
     try:
         kwargs = {}
         if follow_fork:
@@ -46,14 +43,20 @@ def _run_tracker(
         raise MemrayCommandError(str(error), exit_code=1)
 
     with tracker:
-        sys.argv[1:] = args.script_args
         pid = os.getpid()
         try:
             if args.run_as_module:
+                sys.path[0] = os.getcwd()
+                # run_module will replace argv[0] with the script's path
+                sys.argv = ["", *args.script_args]
                 runpy.run_module(args.script, run_name="__main__", alter_sys=True)
             elif args.run_as_cmd:
+                sys.path[0] = ""
+                sys.argv = ["-c", *args.script_args]
                 exec(args.script, {"__name__": "__main__"})
             else:
+                sys.path[0] = str(pathlib.Path(args.script).resolve().parent.absolute())
+                sys.argv = [args.script, *args.script_args]
                 runpy.run_path(args.script, run_name="__main__")
         finally:
             if not args.quiet and post_run_message is not None and pid == os.getpid():


### PR DESCRIPTION
Hi, this closes #76.
 
- refactor suggestion to `test_cli.py::TestRunSubCommand` (class level mocks limited testing possibilities)
- added test that fails when not editing sys.path
- added method `edit_sys` that edits sys.path (also moved existing sys edits to it). 
sys.path[0] will be the directory containing args.script, or `'.'` when `run -c` (like python does)