### PR TITLE
Fix popping more than 16 frames with `popFrames`

### DIFF
--- a/src/memray/_memray/record_writer.h
+++ b/src/memray/_memray/record_writer.h
@@ -137,10 +137,10 @@ bool inline RecordWriter::writeRecordUnsafe(const FramePop& record)
 {
     size_t count = record.count;
     while (count) {
-        uint8_t to_pop = (count > 64 ? 64 : count);
+        uint8_t to_pop = (count > 16 ? 16 : count);
         count -= to_pop;
 
-        to_pop -= 1;  // i.e. 0 means pop 1 frame, 63 means pop 64 frames
+        to_pop -= 1;  // i.e. 0 means pop 1 frame, 15 means pop 16 frames
         RecordTypeAndFlags token{RecordType::FRAME_POP, to_pop};
         assert(token.flags == to_pop);
         if (!writeSimpleType(token)) {

--- a/src/memray/_memray/record_writer.h
+++ b/src/memray/_memray/record_writer.h
@@ -142,6 +142,7 @@ bool inline RecordWriter::writeRecordUnsafe(const FramePop& record)
 
         to_pop -= 1;  // i.e. 0 means pop 1 frame, 63 means pop 64 frames
         RecordTypeAndFlags token{RecordType::FRAME_POP, to_pop};
+        assert(token.flags == to_pop);
         if (!writeSimpleType(token)) {
             return false;
         }


### PR DESCRIPTION
Fix a bug introduced in:

    d168b0a Store count of frames to pop in FRAME_POP flags

which fortunately never made it into a released version. That commit
changed our tracker to pack the number of frames being popped into
a bit field, and handle the case where the number of frames to pop was
too large for the bit field by looping and emitting multiple records.

But, the check to see whether the number of frames to pop was too large
for the bit field was incorrect - the bit field is only 4 bits wide, and
so can only hold a maximum value of 15, not 63.