### PR TITLE
tests: Disable coverage on multiprocessing tests

### DIFF
--- a/tests/integration/test_processes.py
+++ b/tests/integration/test_processes.py
@@ -1,6 +1,8 @@
 from multiprocessing import Pool
 from pathlib import Path
 
+import pytest
+
 from memray import AllocatorType
 from memray import FileReader
 from memray import Tracker
@@ -15,6 +17,7 @@ def multiproc_func(repetitions):
         allocator.free()
 
 
+@pytest.mark.no_cover
 def test_allocations_with_multiprocessing(tmpdir):
     # GIVEN
     output = Path(tmpdir) / "test.bin"
@@ -52,6 +55,7 @@ def test_allocations_with_multiprocessing(tmpdir):
     assert list(child_files) == []
 
 
+@pytest.mark.no_cover
 def test_allocations_with_multiprocessing_following_fork(tmpdir):
     # GIVEN
     output = Path(tmpdir) / "test.bin"


### PR DESCRIPTION
The `pytest-cov` plugin doesn't support `multiprocessing.Pool.__exit__`.
They suggest using `Pool.close()` and `Pool.join()` instead, but that's
not an option here - what we're testing is our own behavior when the
pool is terminated, and so using `Pool.close()` and `Pool.join()` would
defeat at least one of the goals of these tests.

We may be able to solve this some other way, but for now, just disable
coverage analysis for these tests to fix our CI flakiness.
