### PR TITLE
Use LTO and hide our symbols

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,8 @@ jobs:
         python3 -m pip install --upgrade pip
         python3 -m pip install -r requirements-test.txt
         python3 -m pip install -e .
+      env:
+        MEMRAY_MINIMIZE_INLINING: 1
     - name: Run Valgrind
       run: make valgrind
     - name: Run Helgrind

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,8 @@ if "--test-build" in sys.argv:
 if os.getenv("CYTHON_TEST_MACROS", None) is not None:
     TEST_BUILD = True
 
+MINIMIZE_INLINING = os.getenv("MEMRAY_MINIMIZE_INLINING", "") != ""
+
 COMPILER_DIRECTIVES = {
     "language_level": 3,
     "embedsignature": True,
@@ -133,7 +135,14 @@ COMPILER_DIRECTIVES = {
     "c_string_encoding": "utf8",
 }
 EXTRA_COMPILE_ARGS = []
+EXTRA_LINK_ARGS = []
 UNDEF_MACROS = []
+
+if MINIMIZE_INLINING:
+    EXTRA_COMPILE_ARGS.append("-Og")
+else:
+    EXTRA_COMPILE_ARGS.append("-flto")
+    EXTRA_LINK_ARGS.append("-flto")
 
 # For Python 3.9+, hide all of our symbols except the module init function. For
 # Python 3.8 and earlier this isn't as easy, because PyMODINIT_FUNC doesn't
@@ -204,8 +213,8 @@ MEMRAY_EXTENSION = Extension(
     library_dirs=[str(LIBBACKTRACE_LIBDIR)],
     include_dirs=["src", str(LIBBACKTRACE_INCLUDEDIRS)],
     language="c++",
-    extra_compile_args=["-std=c++17", "-Wall", "-flto", *EXTRA_COMPILE_ARGS],
-    extra_link_args=["-std=c++17", "-flto", "-l:libbacktrace.a"],
+    extra_compile_args=["-std=c++17", "-Wall", *EXTRA_COMPILE_ARGS],
+    extra_link_args=["-std=c++17", "-l:libbacktrace.a", *EXTRA_LINK_ARGS],
     define_macros=DEFINE_MACROS,
     undef_macros=UNDEF_MACROS,
 )

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,13 @@ COMPILER_DIRECTIVES = {
 EXTRA_COMPILE_ARGS = []
 UNDEF_MACROS = []
 
+# For Python 3.9+, hide all of our symbols except the module init function. For
+# Python 3.8 and earlier this isn't as easy, because PyMODINIT_FUNC doesn't
+# include __attribute__((visibility ("default"))), and Cython doesn't give us
+# a way to add the attribute. So, skip this optimization on 3.8 and earlier.
+if sys.version_info[:2] >= (3, 9):
+    EXTRA_COMPILE_ARGS.append("-fvisibility=hidden")
+
 if TEST_BUILD:
     COMPILER_DIRECTIVES = {
         "language_level": 3,
@@ -197,8 +204,8 @@ MEMRAY_EXTENSION = Extension(
     library_dirs=[str(LIBBACKTRACE_LIBDIR)],
     include_dirs=["src", str(LIBBACKTRACE_INCLUDEDIRS)],
     language="c++",
-    extra_compile_args=["-std=c++17", "-Wall", *EXTRA_COMPILE_ARGS],
-    extra_link_args=["-std=c++17", "-l:libbacktrace.a"],
+    extra_compile_args=["-std=c++17", "-Wall", "-flto", *EXTRA_COMPILE_ARGS],
+    extra_link_args=["-std=c++17", "-flto", "-l:libbacktrace.a"],
     define_macros=DEFINE_MACROS,
     undef_macros=UNDEF_MACROS,
 )

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -81,7 +81,7 @@
    <cython_cached_constants>
    Memcheck:Leak
    ...
-   fun:__Pyx_InitCachedConstants
+   fun:*__Pyx_InitCachedConstants*
    ...
 }
 


### PR DESCRIPTION
This seems to achieve some minor tracking speedups on the order of 2%.