### PR TITLE
Allow tracing the Python allocators

### DIFF
--- a/docs/python_allocators.rst
+++ b/docs/python_allocators.rst
@@ -123,4 +123,8 @@ How can I deactivate ``pymalloc``
 ---------------------------------
 
 To deactivate ``pymalloc`` you can set the ``PYTHONMALLOC=malloc`` environment
-variable or execute Python with ``-Xdev``. 
+variable or execute Python with ``-Xdev``. Or, you can pass the
+``--track-python-allocators`` flag to ``memray run`` so that, even though
+``pymalloc`` is still used, Memray sees every call to the ``pymalloc``
+allocator instead of only the ones where it needs to make a request to the
+system allocator.

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -83,6 +83,40 @@ When reporters display native information they will normally use a different col
 frames. This can also be distinguished by looking at the file name in a frame, since Python frames will generally come
 from source files with a ``.py`` extension.
 
+Python allocator tracking
+-------------------------
+
+Memray normally tracks allocation and deallocation requests made to the system
+allocator, but by default it won't see individual Python objects being created.
+That's because the Python interpreter normally uses its own memory pools for
+creating most objects, only making calls to the system allocator as needed to
+grow or shrink its memory pools. Our documentation on :doc:`python allocators
+<python_allocators>` describes this memory pooling in greater detail. This
+behavior speeds the Python interpreter up, and by extension speeds up profiling
+with Memray, while still allowing Memray to show you each place where your
+program needs to acquire more memory.
+
+You can ask Memray to show you each individual object being created and
+destroyed, instead, by proving the ``--track-python-allocators`` argument to
+the ``run`` subcommand. This records a lot more data and makes profiling much
+slower. It will show you all allocations, even ones that don't result in your
+program requesting more memory from the system because the interpreter already
+had memory available for reuse. It can be useful in some cases, though,
+especially when tracking down memory leaks.
+
+.. note::
+  This acts also as an alternative way to run with `PYTHONMALLOC=malloc` but
+  in a way that allows distiguishing allocations made by using the system
+  allocator directly and ones made by using the Python allocator.
+
+.. code:: shell
+
+  memray run --track-python-allocators example.py
+
+.. caution:: 
+  Tracking the Python allocators will result in much larger report files and
+  slower profiling due to the larger amount of data that needs to be collected.
+
 .. _Live tracking:
 
 Live tracking

--- a/news/92.feature.rst
+++ b/news/92.feature.rst
@@ -1,0 +1,1 @@
+Add a new ``--track-python-allocators`` option to ``memray run`` that allows tracking all allocations made using the Python allocators. This will result in bigger output files and slower profiling but it allows getting insights about all of the interpreter's memory allocations.

--- a/src/memray/_memray.pyi
+++ b/src/memray/_memray.pyi
@@ -71,6 +71,10 @@ class AllocatorType(enum.IntEnum):
     PVALLOC: int
     MMAP: int
     MUNMAP: int
+    PYMALLOC_MALLOC: int
+    PYMALLOC_CALLOC: int
+    PYMALLOC_REALLOC: int
+    PYMALLOC_FREE: int
 
 def start_thread_trace(frame: FrameType, event: str, arg: Any) -> None: ...
 
@@ -130,6 +134,7 @@ class Tracker:
         file_name: Union[Path, str],
         *,
         native_traces: bool = False,
+        trace_python_allocators: bool = False,
     ) -> None: ...
     @overload
     def __init__(
@@ -157,6 +162,18 @@ class MemoryAllocator:
     def valloc(self, size: int) -> None: ...
     def pvalloc(self, size: int) -> None: ...
     def run_in_pthread(self, callback: Callable[[], None]) -> None: ...
+
+class PymallocDomain(enum.IntEnum):
+    PYMALLOC_RAW: int
+    PYMALLOC_MEM: int
+    PYMALLOC_OBJECT: int
+
+class PymallocMemoryAllocator:
+    def __init__(self, domain: PymallocDomain) -> None: ...
+    def free(self) -> None: ...
+    def malloc(self, size: int) -> None: ...
+    def calloc(self, size: int) -> None: ...
+    def realloc(self, size: int) -> None: ...
 
 class MmapAllocator:
     def __init__(self, size: int, address: int = 0) -> None: ...

--- a/src/memray/_memray.pyi
+++ b/src/memray/_memray.pyi
@@ -133,15 +133,20 @@ class Tracker:
         self,
         file_name: Union[Path, str],
         *,
-        native_traces: bool = False,
-        trace_python_allocators: bool = False,
+        native_traces: bool = ...,
+        memory_interval_ms: int = ...,
+        follow_fork: bool = ...,
+        trace_python_allocators: bool = ...,
     ) -> None: ...
     @overload
     def __init__(
         self,
         *,
         destination: Destination,
-        native_traces: bool = False,
+        native_traces: bool = ...,
+        memory_interval_ms: int = ...,
+        follow_fork: bool = ...,
+        trace_python_allocators: bool = ...,
     ) -> None: ...
     def __enter__(self) -> Any: ...
     def __exit__(

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -72,6 +72,10 @@ cpdef enum AllocatorType:
     PVALLOC = 9
     MMAP = 10
     MUNMAP = 11
+    PYMALLOC_MALLOC = 12
+    PYMALLOC_CALLOC = 13
+    PYMALLOC_REALLOC = 14
+    PYMALLOC_FREE = 15
 
 cpdef enum PythonAllocatorType:
     PYTHON_ALLOCATOR_PYMALLOC = 1
@@ -246,6 +250,7 @@ cdef class Tracker:
     cdef bool _native_traces
     cdef unsigned int _memory_interval_ms
     cdef bool _follow_fork
+    cdef bool _trace_python_allocators
     cdef object _previous_profile_func
     cdef object _previous_thread_profile_func
     cdef unique_ptr[RecordWriter] _writer
@@ -273,7 +278,7 @@ cdef class Tracker:
 
     def __cinit__(self, object file_name=None, *, object destination=None,
                   bool native_traces=False, unsigned int memory_interval_ms = 10,
-                  bool follow_fork=False):
+                  bool follow_fork=False, bool trace_python_allocators=False):
         if (file_name, destination).count(None) != 1:
             raise TypeError("Exactly one of 'file_name' or 'destination' argument must be specified")
 
@@ -281,6 +286,7 @@ cdef class Tracker:
         self._native_traces = native_traces
         self._memory_interval_ms = memory_interval_ms
         self._follow_fork = follow_fork
+        self._trace_python_allocators = trace_python_allocators
 
         if file_name is not None:
             destination = FileDestination(path=file_name)
@@ -312,6 +318,7 @@ cdef class Tracker:
             self._native_traces,
             self._memory_interval_ms,
             self._follow_fork,
+            self._trace_python_allocators,
         )
         return self
 

--- a/src/memray/_memray/alloc.pxd
+++ b/src/memray/_memray/alloc.pxd
@@ -8,3 +8,19 @@ cdef extern from "alloc.h" nogil:
     void* valloc(size_t size)
     void* memalign(size_t alignment, size_t size)
     void* pvalloc(size_t size)
+
+cdef extern from "Python.h":
+    void* PyMem_RawMalloc(size_t n) nogil
+    void* PyMem_RawCalloc(size_t nelem, size_t elsize) nogil
+    void* PyMem_RawRealloc(void *p, size_t n) nogil
+    void PyMem_RawFree(void *p) nogil
+
+    void* PyMem_Malloc(size_t n)
+    void* PyMem_Calloc(size_t nelem, size_t elsize)
+    void* PyMem_Realloc(void *p, size_t n)
+    void PyMem_Free(void *p)
+
+    void* PyObject_Malloc(size_t size)
+    void* PyObject_Calloc(size_t nelem, size_t elsize)
+    void* PyObject_Realloc(void *ptr, size_t new_size)
+    void PyObject_Free(void *ptr)

--- a/src/memray/_memray/hooks.h
+++ b/src/memray/_memray/hooks.h
@@ -109,6 +109,10 @@ enum class Allocator : unsigned char {
     PVALLOC = 9,
     MMAP = 10,
     MUNMAP = 11,
+    PYMALLOC_MALLOC = 12,
+    PYMALLOC_CALLOC = 13,
+    PYMALLOC_REALLOC = 14,
+    PYMALLOC_FREE = 15,
 };
 
 enum class AllocatorKind {
@@ -180,6 +184,15 @@ prctl(int option, ...) noexcept;
 
 PyGILState_STATE
 PyGILState_Ensure() noexcept;
+
+void*
+pymalloc_malloc(void* ctx, size_t size) noexcept;
+void*
+pymalloc_realloc(void* ctx, void* ptr, size_t new_size) noexcept;
+void*
+pymalloc_calloc(void* ctx, size_t nelem, size_t size) noexcept;
+void
+pymalloc_free(void* ctx, void* ptr) noexcept;
 
 }  // namespace memray::intercept
 

--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -48,6 +48,14 @@ allocatorName(hooks::Allocator allocator)
             return "mmap";
         case hooks::Allocator::MUNMAP:
             return "munmap";
+        case hooks::Allocator::PYMALLOC_MALLOC:
+            return "pymalloc_malloc";
+        case hooks::Allocator::PYMALLOC_CALLOC:
+            return "pymalloc_calloc";
+        case hooks::Allocator::PYMALLOC_REALLOC:
+            return "pymalloc_realloc";
+        case hooks::Allocator::PYMALLOC_FREE:
+            return "pymalloc_free";
     }
 
     return nullptr;

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -199,7 +199,8 @@ class Tracker
             std::unique_ptr<RecordWriter> record_writer,
             bool native_traces,
             unsigned int memory_interval,
-            bool follow_fork);
+            bool follow_fork,
+            bool trace_python_allocators);
     static PyObject* destroyTracker();
     static Tracker* getTracker();
 
@@ -292,6 +293,7 @@ class Tracker
     bool d_unwind_native_frames;
     unsigned int d_memory_interval;
     bool d_follow_fork;
+    bool d_trace_python_allocators;
     elf::SymbolPatcher d_patcher;
     std::unique_ptr<BackgroundThread> d_background_thread;
 
@@ -303,12 +305,15 @@ class Tracker
     void invalidate_module_cache_impl();
     void updateModuleCacheImpl();
     void registerThreadNameImpl(const char* name);
+    void registerPymallocHooks() const noexcept;
+    void unregisterPymallocHooks() const noexcept;
 
     explicit Tracker(
             std::unique_ptr<RecordWriter> record_writer,
             bool native_traces,
             unsigned int memory_interval,
-            bool follow_fork);
+            bool follow_fork,
+            bool trace_python_allocators);
 
     static void prepareFork();
     static void parentFork();

--- a/src/memray/_memray/tracking_api.pxd
+++ b/src/memray/_memray/tracking_api.pxd
@@ -14,6 +14,7 @@ cdef extern from "tracking_api.h" namespace "memray::tracking_api":
             bool native_traces,
             unsigned int memory_interval,
             bool follow_fork,
+            bool trace_pymalloc,
         ) except+
 
         @staticmethod

--- a/src/memray/_test.py
+++ b/src/memray/_test.py
@@ -1,10 +1,14 @@
 from ._memray import MemoryAllocator
 from ._memray import MmapAllocator
+from ._memray import PymallocDomain
+from ._memray import PymallocMemoryAllocator
 from ._memray import _cython_nested_allocation
 from ._memray import set_thread_name
 
 __all__ = [
     "MemoryAllocator",
+    "PymallocMemoryAllocator",
+    "PymallocDomain",
     "_cython_nested_allocation",
     "MmapAllocator",
     "set_thread_name",

--- a/src/memray/commands/run.py
+++ b/src/memray/commands/run.py
@@ -33,6 +33,7 @@ def _run_tracker(
     args: argparse.Namespace,
     post_run_message: Optional[str] = None,
     follow_fork: bool = False,
+    trace_python_allocators: bool = False,
 ) -> None:
     sys.argv = [args.script, *args.script_args]
     if args.run_as_module:
@@ -41,6 +42,8 @@ def _run_tracker(
         kwargs = {}
         if follow_fork:
             kwargs["follow_fork"] = True
+        if trace_python_allocators:
+            kwargs["trace_python_allocators"] = True
         tracker = Tracker(destination=destination, native_traces=args.native, **kwargs)
     except OSError as error:
         raise MemrayCommandError(str(error), exit_code=1)
@@ -164,6 +167,7 @@ def _run_with_file_output(args: argparse.Namespace) -> None:
             args=args,
             post_run_message=example_report_generation_message,
             follow_fork=args.follow_fork,
+            trace_python_allocators=args.trace_python_allocators,
         )
     except OSError as error:
         raise MemrayCommandError(str(error), exit_code=1)
@@ -213,6 +217,12 @@ class RunCommand:
             "--follow-fork",
             action="store_true",
             help="Record allocations in child processes forked from the tracked script",
+            default=False,
+        )
+        parser.add_argument(
+            "--trace-python-allocators",
+            action="store_true",
+            help="Record allocations made by the Pymalloc allocator",
             default=False,
         )
         parser.add_argument(

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -141,15 +141,15 @@ def test_cython_traceback(tmpdir):
 
     traceback = list(alloc1.stack_trace())
     assert traceback[-3:] == [
-        ("valloc", ANY, 85),
-        ("_cython_nested_allocation", ANY, 105),
-        ("test_cython_traceback", ANY, 132),
+        ("valloc", ANY, 97),
+        ("_cython_nested_allocation", ANY, 184),
+        ("test_cython_traceback", __file__, 132),
     ]
 
     traceback = list(alloc2.stack_trace())
     assert traceback[-3:] == [
-        ("_cython_nested_allocation", ANY, 105),
-        ("test_cython_traceback", ANY, 132),
+        ("_cython_nested_allocation", ANY, 184),
+        ("test_cython_traceback", __file__, 132),
     ]
 
     frees = [

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -64,6 +64,20 @@ class TestRunSubCommand:
             native_traces=True,
         )
 
+    def test_run_with_pymalloc_tracing(
+        self, getpid_mock, runpy_mock, tracker_mock, validate_mock
+    ):
+        getpid_mock.return_value = 0
+        assert 0 == main(["run", "--trace-python-allocators", "-m", "foobar"])
+        runpy_mock.run_module.assert_called_with(
+            "foobar", run_name="__main__", alter_sys=True
+        )
+        tracker_mock.assert_called_with(
+            destination=FileDestination("memray-foobar.0.bin", overwrite=False),
+            native_traces=False,
+            trace_python_allocators=True,
+        )
+
     def test_run_override_output(
         self, getpid_mock, runpy_mock, tracker_mock, validate_mock
     ):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -25,6 +25,24 @@ def filter_relevant_allocations(records, ranged=False):
             addresses.discard(record.address)
 
 
+def filter_relevant_pymalloc_allocations(records, size):
+    addresses = set()
+    filter_allocations = [
+        AllocatorType.PYMALLOC_MALLOC,
+        AllocatorType.PYMALLOC_REALLOC,
+        AllocatorType.PYMALLOC_CALLOC,
+    ]
+    filter_deallocations = [AllocatorType.PYMALLOC_FREE]
+    for record in records:
+        if record.allocator in filter_allocations and record.size == size:
+            yield record
+            addresses.add(record.address)
+        elif record.allocator in filter_deallocations:
+            if record.address in addresses:
+                yield record
+            addresses.discard(record.address)
+
+
 @dataclass
 class MockAllocationRecord:
     """Mimics :py:class:`memray._memray.AllocationRecord`."""


### PR DESCRIPTION
The Python allocators don't generally generate allocation events to the
system allocator. This is how Python normally runs and is directly
responsible of keeping it fast and this translates to profiling as well.
Sometimes, users may still be interested on the requests that the
interpreter does to the Python allocators and although this generates a
lot more data and makes profiling slower, it may help in some
situations. This acts also as an alternative way to run with
`PYTHONMALLOC=malloc` but without collating the data with the system
allocator.
