### PR TITLE
Fix missing allocations in `memray stats` histogram

### DIFF
--- a/news/95.bugfix.rst
+++ b/news/95.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug in the :doc:`stats reporter <stats>` that could result in the largest allocations being omitted from the histogram.

--- a/src/memray/reporters/stats.py
+++ b/src/memray/reporters/stats.py
@@ -91,7 +91,7 @@ def get_histogram_databins(data: List[int], bins: int) -> List[Tuple[int, int]]:
 
     # Determine the upper bound in bytes for each bin
     steps = [int(math.exp(low + step * (i + 1))) for i in range(bins)]
-    dist = Counter((x - low) // step for x in it)
+    dist = Counter(min((x - low) // step, bins - 1) for x in it)
     return [(steps[b], dist[b]) for b in range(bins)]
 
 
@@ -112,7 +112,6 @@ def draw_histogram(data: List[int], bins: int, *, hist_scale_factor: int = 25) -
         )
 
     data_bins = get_histogram_databins(data, bins=bins)
-
     max_data_bin = max([t[1] for t in data_bins])
     scaled_data_bins = [
         math.ceil((v / max_data_bin) * hist_scale_factor) for _, v in data_bins

--- a/tests/unit/test_stats_reporter.py
+++ b/tests/unit/test_stats_reporter.py
@@ -232,7 +232,7 @@ def test_get_histogram_databins():
         (32299, 3),
         (116099, 2),
         (417312, 6),
-        (1500000, 1),
+        (1500000, 2),
     ]
 
     # WHEN
@@ -274,6 +274,34 @@ def test_get_histogram_databins_rounding():
     assert expected_output == actual_output
 
 
+def test_get_histogram_over_bound():
+    """Data chosen to provoke a scenario where the computed allocation exceeds the upper limit.
+
+    In particular, so that:
+        Counter(min((x - low) // step, bins-1) for x in it) will default to placing it in the
+        last bin instead of creating a new record out of range of the bins.
+    """
+    input_data = [10000000000, 536, 536, 592, 576, 4486]
+    expected_output = [
+        (2859, 4),
+        (15252, 1),
+        (81360, 0),
+        (434009, 0),
+        (2315167, 0),
+        (12349970, 0),
+        (65879369, 0),
+        (351425246, 0),
+        (1874633954, 0),
+        (10000000000, 1),
+    ]
+
+    # WHEN
+    actual_output = get_histogram_databins(input_data, bins=10)
+
+    # THEN
+    assert expected_output == actual_output
+
+
 def test_get_histogram_databins_invalid_bins():
     with pytest.raises(ValueError):
         _ = get_histogram_databins([], bins=0)  # invalid bins value
@@ -305,7 +333,7 @@ def test_draw_histogram():
 \t< 31.542KB : 3 ▇▇▇▇▇▇▇▇▇▇▇▇▇
 \t< 113.378KB: 2 ▇▇▇▇▇▇▇▇▇
 \t< 407.531KB: 6 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
-\t<=1.431MB  : 1 ▇▇▇▇▇
+\t<=1.431MB  : 2 ▇▇▇▇▇▇▇▇▇
 \t----------------------------------------
 \tmax: 1.431MB"""
 
@@ -341,7 +369,7 @@ def test_draw_histogram_smaller_scale_factor():
 \t< 31.542KB : 3 ▇▇▇
 \t< 113.378KB: 2 ▇▇
 \t< 407.531KB: 6 ▇▇▇▇▇
-\t<=1.431MB  : 1 ▇
+\t<=1.431MB  : 2 ▇▇
 \t--------------------
 \tmax: 1.431MB"""
 


### PR DESCRIPTION
Signed-off-by: Jingkai Tan <tjingkai@bloomberg.net>

Fixes #84.

**Describe your changes**
Cap the known valid range to ensure that anything greater than the second to last bucket will appear in the last bucket.

**Testing performed**
Ensured that output is as expected (missing mmap allocation shows up)
```
🕙12:30:27 ❯ memray stats output.bin
📏 Total allocations:
	9

📦 Total memory allocated:
	9.313GB

📊 Histogram of allocation size:
	min: 536.000B
	----------------------------------------
	< 2.792KB  : 4 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 14.895KB : 1 ▇▇▇▇▇▇▇
	< 79.453KB : 0
	< 423.837KB: 0
	< 2.208MB  : 0
	< 11.778MB : 0
	< 62.827MB : 0
	< 335.145MB: 0
	< 1.746GB  : 0
	<=9.313GB  : 1 ▇▇▇▇▇▇▇
	----------------------------------------
	max: 9.313GB

📂 Allocator type distribution:
	 MALLOC: 5
	 MMAP: 1

🥇 Top 5 largest allocating locations (by size):
	- <module>:../test.py:3 -> 9.313GB
	- _call_with_frames_removed:<frozen importlib._bootstrap>:219 -> 4.381KB
	- _run_tracker:/home/jingkai/Documents/github/memray/memray/src/memray/commands/run.py:60 -> 592.000B
	- _run_code:/usr/lib/python3.8/runpy.py:80 -> 576.000B
	- run_path:/usr/lib/python3.8/runpy.py:265 -> 536.000B

🥇 Top 5 largest allocating locations (by number of allocations):
	- _call_with_frames_removed:<frozen importlib._bootstrap>:219 -> 4
	- <module>:../test.py:3 -> 1
	- run_path:/usr/lib/python3.8/runpy.py:265 -> 1
	- _run_module_code:/usr/lib/python3.8/runpy.py:97 -> 1
	- _run_tracker:/home/jingkai/Documents/github/memray/memray/src/memray/commands/run.py:60 -> 1
```


