### PR TITLE
Uodate the test suite to the latest version of 'rich'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ class BuildMemray(build_ext_orig):
 install_requires = [
     "jinja2",
     "typing_extensions; python_version < '3.8.0'",
-    "rich < 11.0.0",
+    "rich",
 ]
 docs_requires = [
     "bump2version",

--- a/tests/unit/test_summary_reporter.py
+++ b/tests/unit/test_summary_reporter.py
@@ -32,9 +32,9 @@ def test_with_multiple_allocations():
     # THEN
     expected = [
         "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓",
-        "┃ Location                            ┃ <Total ┃ Total ┃   Own ┃   Own ┃ Allo… ┃",
-        "┃                                     ┃ Memor… ┃ Memo… ┃ Memo… ┃ Memo… ┃ Count ┃",
-        "┃                                     ┃        ┃     % ┃       ┃     % ┃       ┃",
+        "┃                                     ┃        ┃ Total ┃       ┃   Own ┃       ┃",
+        "┃                                     ┃ <Total ┃ Memo… ┃   Own ┃ Memo… ┃ Allo… ┃",
+        "┃ Location                            ┃ Memor… ┃     % ┃ Memo… ┃     % ┃ Count ┃",
         "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩",
         "│ function4 at /src/lel_4.py          │ 1.000… │ 20.0… │ 1.00… │ 20.0… │     5 │",
         "│ function5 at /src/lel_5.py          │ 1.000… │ 20.0… │ 0.00… │ 0.00% │     5 │",
@@ -77,9 +77,9 @@ def test_with_multiple_allocations_and_native_traces():
     # THEN
     expected = [
         "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓",
-        "┃ Location                            ┃ <Total ┃ Total ┃   Own ┃   Own ┃ Allo… ┃",
-        "┃                                     ┃ Memor… ┃ Memo… ┃ Memo… ┃ Memo… ┃ Count ┃",
-        "┃                                     ┃        ┃     % ┃       ┃     % ┃       ┃",
+        "┃                                     ┃        ┃ Total ┃       ┃   Own ┃       ┃",
+        "┃                                     ┃ <Total ┃ Memo… ┃   Own ┃ Memo… ┃ Allo… ┃",
+        "┃ Location                            ┃ Memor… ┃     % ┃ Memo… ┃     % ┃ Count ┃",
         "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩",
         "│ parent at fun.pyx                   │ 4.990… │ 100.… │ 0.00… │ 0.00% │    15 │",
         "│ grandparent at fun.c                │ 4.990… │ 100.… │ 0.00… │ 0.00% │    15 │",
@@ -117,9 +117,9 @@ def test_sort_column():
     # THEN
     expected = [
         "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓",
-        "┃ Location                            ┃  Total ┃ Total ┃  <Own ┃   Own ┃ Allo… ┃",
-        "┃                                     ┃ Memory ┃ Memo… ┃ Memo… ┃ Memo… ┃ Count ┃",
-        "┃                                     ┃        ┃     % ┃       ┃     % ┃       ┃",
+        "┃                                     ┃        ┃ Total ┃       ┃   Own ┃       ┃",
+        "┃                                     ┃  Total ┃ Memo… ┃  <Own ┃ Memo… ┃ Allo… ┃",
+        "┃ Location                            ┃ Memory ┃     % ┃ Memo… ┃     % ┃ Count ┃",
         "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩",
         "│ function4 at /src/lel_4.py          │ 1.000… │ 20.0… │ 1.00… │ 20.0… │     5 │",
         "│ function3 at /src/lel_3.py          │ 1023.… │ 20.0… │ 1023… │ 20.0… │     4 │",
@@ -160,9 +160,9 @@ def test_max_rows():
     # THEN
     expected = [
         "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓",
-        "┃ Location                            ┃ <Total ┃ Total ┃   Own ┃   Own ┃ Allo… ┃",
-        "┃                                     ┃ Memor… ┃ Memo… ┃ Memo… ┃ Memo… ┃ Count ┃",
-        "┃                                     ┃        ┃     % ┃       ┃     % ┃       ┃",
+        "┃                                     ┃        ┃ Total ┃       ┃   Own ┃       ┃",
+        "┃                                     ┃ <Total ┃ Memo… ┃   Own ┃ Memo… ┃ Allo… ┃",
+        "┃ Location                            ┃ Memor… ┃     % ┃ Memo… ┃     % ┃ Count ┃",
         "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩",
         "│ function4 at /src/lel_4.py          │ 1.000… │ 20.0… │ 1.00… │ 20.0… │     5 │",
         "│ function5 at /src/lel_5.py          │ 1.000… │ 20.0… │ 0.00… │ 0.00% │     5 │",

--- a/tests/unit/test_tui_reporter.py
+++ b/tests/unit/test_tui_reporter.py
@@ -749,9 +749,9 @@ class TestTUITable:
         # THEN
         expected = [
             "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓",
-            "┃ Location                            ┃ <Total ┃ Total ┃   Own ┃   Own ┃ Allo… ┃",
-            "┃                                     ┃ Memor… ┃ Memo… ┃ Memo… ┃ Memo… ┃ Count ┃",
-            "┃                                     ┃        ┃     % ┃       ┃     % ┃       ┃",
+            "┃                                     ┃        ┃ Total ┃       ┃   Own ┃       ┃",
+            "┃                                     ┃ <Total ┃ Memo… ┃   Own ┃ Memo… ┃ Allo… ┃",
+            "┃ Location                            ┃ Memor… ┃     % ┃ Memo… ┃     % ┃ Count ┃",
             "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩",
             "└─────────────────────────────────────┴────────┴───────┴───────┴───────┴───────┘",
         ]
@@ -784,9 +784,9 @@ class TestTUITable:
         # THEN
         expected = [
             "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓",
-            "┃ Location                            ┃ <Total ┃ Total ┃   Own ┃   Own ┃ Allo… ┃",
-            "┃                                     ┃ Memor… ┃ Memo… ┃ Memo… ┃ Memo… ┃ Count ┃",
-            "┃                                     ┃        ┃     % ┃       ┃     % ┃       ┃",
+            "┃                                     ┃        ┃ Total ┃       ┃   Own ┃       ┃",
+            "┃                                     ┃ <Total ┃ Memo… ┃   Own ┃ Memo… ┃ Allo… ┃",
+            "┃ Location                            ┃ Memor… ┃     % ┃ Memo… ┃     % ┃ Count ┃",
             "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩",
             "│ function1 at /src/lel.py            │ 1.000… │ 100.… │ 1.00… │ 100.… │     1 │",
             "└─────────────────────────────────────┴────────┴───────┴───────┴───────┴───────┘",
@@ -821,9 +821,9 @@ class TestTUITable:
         # THEN
         expected = [
             "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓",
-            "┃ Location                            ┃ <Total ┃ Total ┃   Own ┃   Own ┃ Allo… ┃",
-            "┃                                     ┃ Memor… ┃ Memo… ┃ Memo… ┃ Memo… ┃ Count ┃",
-            "┃                                     ┃        ┃     % ┃       ┃     % ┃       ┃",
+            "┃                                     ┃        ┃ Total ┃       ┃   Own ┃       ┃",
+            "┃                                     ┃ <Total ┃ Memo… ┃   Own ┃ Memo… ┃ Allo… ┃",
+            "┃ Location                            ┃ Memor… ┃     % ┃ Memo… ┃     % ┃ Count ┃",
             "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩",
             "│ function4 at /src/lel_4.py          │ 5.000… │ 33.3… │ 5.00… │ 33.3… │     1 │",
             "│ function3 at /src/lel_3.py          │ 4.000… │ 26.6… │ 4.00… │ 26.6… │     1 │",
@@ -862,9 +862,9 @@ class TestTUITable:
         # THEN
         expected = [
             "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓",
-            "┃ Location                            ┃ <Total ┃ Total ┃   Own ┃   Own ┃ Allo… ┃",
-            "┃                                     ┃ Memor… ┃ Memo… ┃ Memo… ┃ Memo… ┃ Count ┃",
-            "┃                                     ┃        ┃     % ┃       ┃     % ┃       ┃",
+            "┃                                     ┃        ┃ Total ┃       ┃   Own ┃       ┃",
+            "┃                                     ┃ <Total ┃ Memo… ┃   Own ┃ Memo… ┃ Allo… ┃",
+            "┃ Location                            ┃ Memor… ┃     % ┃ Memo… ┃     % ┃ Count ┃",
             "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩",
             "│ function0 at /src/lel_0.py          │ 1.000… │ 6.67% │ 1.00… │ 6.67% │     1 │",
             "└─────────────────────────────────────┴────────┴───────┴───────┴───────┴───────┘",
@@ -901,9 +901,9 @@ class TestTUITable:
         # THEN
         expected = [
             "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓",
-            "┃ Location                            ┃ <Total ┃ Total ┃   Own ┃   Own ┃ Allo… ┃",
-            "┃                                     ┃ Memor… ┃ Memo… ┃ Memo… ┃ Memo… ┃ Count ┃",
-            "┃                                     ┃        ┃     % ┃       ┃     % ┃       ┃",
+            "┃                                     ┃        ┃ Total ┃       ┃   Own ┃       ┃",
+            "┃                                     ┃ <Total ┃ Memo… ┃   Own ┃ Memo… ┃ Allo… ┃",
+            "┃ Location                            ┃ Memor… ┃     % ┃ Memo… ┃     % ┃ Count ┃",
             "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩",
             "│ function3 at /src/lel_3.py          │ 4.000… │ 26.6… │ 4.00… │ 26.6… │     1 │",
             "└─────────────────────────────────────┴────────┴───────┴───────┴───────┴───────┘",
@@ -940,9 +940,9 @@ class TestTUITable:
         # THEN
         expected = [
             "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓",
-            "┃ Location                            ┃ <Total ┃ Total ┃   Own ┃   Own ┃ Allo… ┃",
-            "┃                                     ┃ Memor… ┃ Memo… ┃ Memo… ┃ Memo… ┃ Count ┃",
-            "┃                                     ┃        ┃     % ┃       ┃     % ┃       ┃",
+            "┃                                     ┃        ┃ Total ┃       ┃   Own ┃       ┃",
+            "┃                                     ┃ <Total ┃ Memo… ┃   Own ┃ Memo… ┃ Allo… ┃",
+            "┃ Location                            ┃ Memor… ┃     % ┃ Memo… ┃     % ┃ Count ┃",
             "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩",
             "│ function4 at /src/lel_4.py          │ 5.000… │ 33.3… │ 5.00… │ 33.3… │     5 │",
             "│ function3 at /src/lel_3.py          │ 4.000… │ 26.6… │ 4.00… │ 26.6… │     4 │",
@@ -995,9 +995,9 @@ class TestTUITable:
         # THEN
         expected = [
             "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓",
-            "┃ Location                            ┃ <Total ┃ Total ┃   Own ┃   Own ┃ Allo… ┃",
-            "┃                                     ┃ Memor… ┃ Memo… ┃ Memo… ┃ Memo… ┃ Count ┃",
-            "┃                                     ┃        ┃     % ┃       ┃     % ┃       ┃",
+            "┃                                     ┃        ┃ Total ┃       ┃   Own ┃       ┃",
+            "┃                                     ┃ <Total ┃ Memo… ┃   Own ┃ Memo… ┃ Allo… ┃",
+            "┃ Location                            ┃ Memor… ┃     % ┃ Memo… ┃     % ┃ Count ┃",
             "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩",
             "│ parent at fun.py                    │ 30.00… │ 100.… │ 0.00… │ 0.00% │     3 │",
             "│ grandparent at fun.py               │ 30.00… │ 100.… │ 0.00… │ 0.00% │     3 │",
@@ -1039,8 +1039,7 @@ class TestTUILayout:
 
         # THEN
         expected = [
-            "Memray live tracking                                    Fri Jan  1 00:00:00 "
-            "2021",
+            "Memray live tracking                                    Fri Jan  1 00:00:00 2021",
             "                                               ╭─ Memory ──────────────────────╮",
             "(∩｀-´)⊃━☆ﾟ.*…PID: 123      CMD: python3       │                             … │",
             "                            some_program.py    │                             … │",
@@ -1050,9 +1049,9 @@ class TestTUILayout:
             "Current heap size: 15.000KB                         Max heap size seen: 15.000KB",
             "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸",
             "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓",
-            "┃ Location                            ┃ <Total ┃ Total ┃   Own ┃   Own ┃ Allo… ┃",
-            "┃                                     ┃ Memor… ┃ Memo… ┃ Memo… ┃ Memo… ┃ Count ┃",
-            "┃                                     ┃        ┃     % ┃       ┃     % ┃       ┃",
+            "┃                                     ┃        ┃ Total ┃       ┃   Own ┃       ┃",
+            "┃                                     ┃ <Total ┃ Memo… ┃   Own ┃ Memo… ┃ Allo… ┃",
+            "┃ Location                            ┃ Memor… ┃     % ┃ Memo… ┃     % ┃ Count ┃",
             "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩",
             "│ function4 at /src/lel_4.py          │ 5.000… │ 33.3… │ 5.00… │ 33.3… │     5 │",
             "│ function3 at /src/lel_3.py          │ 4.000… │ 26.6… │ 4.00… │ 26.6… │     4 │",


### PR DESCRIPTION
Rich introduced some formatting changes in version 11.0.0 and we pinned
the version so the test suite didn't break with the new formatting.
There is really no reason other than this why we couldn't run with a
newer version and we are missing a bunch of general improvements in the
library.

This commit updates the test suite to cope with the new formatting in
the latest versions of `rich`.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
