### PR TITLE
Improve the docs for `--no-compress`

### DIFF
--- a/src/memray/commands/run.py
+++ b/src/memray/commands/run.py
@@ -241,18 +241,18 @@ class RunCommand:
             action="store_true",
             default=False,
         )
-        parser.add_argument(
+        compression = parser.add_mutually_exclusive_group()
+        compression.add_argument(
             "--compress-on-exit",
             help="Compress the resulting file using lz4 after tracking completes",
-            dest="compress_on_exit",
             default=True,
             action="store_true",
         )
-        parser.add_argument(
+        compression.add_argument(
             "--no-compress",
             help="Do not compress the resulting file using lz4",
-            dest="compress_on_exit",
-            action="store_false",
+            default=False,
+            action="store_true",
         )
         parser.add_argument(
             "-c",
@@ -292,6 +292,9 @@ class RunCommand:
             )
 
     def run(self, args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+        if args.no_compress:
+            args.compress_on_exit = False
+
         if args.live_port is not None and not args.live_remote_mode:
             parser.error("The --live-port argument requires --live-remote")
         if args.follow_fork is True and (args.live_mode or args.live_remote_mode):


### PR DESCRIPTION
`sphinx-argparse` wanted to document `--no-compress` as having a default
value of `True`, which isn't correct. I think it's confused by the fact
that `--no-compress` has a `dest="compress_on_exit"`, which another
argument sets up with `default=True`.

Regardless, the reason we gave these things different names was so that
we could support multiple different compression options in the future.
Pre-factor this into a mutually exclusive group of compression related
options, and have `--no-compress` toggle off the one that defaults
to `True`. We would have needed to do something like this in the future
if we ever added another compression option, and this gets the Sphinx
docs looking the way we want now.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>