### PR TITLE
Exclude libbacktrace from our built wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -261,5 +261,4 @@ setup(
     cmdclass={
         "build_ext": BuildMemray,
     },
-    package_data={"memray": ["py.typed"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from sys import version_info
 
 from Cython.Build import cythonize
 from setuptools import Extension
-from setuptools import find_namespace_packages
+from setuptools import find_packages
 from setuptools import setup
 from setuptools.command.build_ext import build_ext as build_ext_orig
 
@@ -237,7 +237,7 @@ setup(
     ],
     license="Apache 2.0",
     package_dir={"": "src"},
-    packages=find_namespace_packages(where="src"),
+    packages=find_packages(where="src"),
     ext_modules=cythonize(
         [MEMRAY_EXTENSION],
         include_path=["src/memray"],


### PR DESCRIPTION
Remove vendored libbacktrace from our built wheel. Using `find_namespace_packages` instead of `find_packages` results in
`src/vendor/` being picked up as a namespace package called `vendor` and included in the wheel that we build. This is only needed at build time, and shouldn't be installed.

Also, remove `package_data` from our `setuptools.setup()` call. This is redundant, as we're already providing `include_package_data=True`, which includes every data file listed in the manifest, including `py.typed`.