### PR TITLE
Grow capture files with `posix_fallocate`

### DIFF
--- a/news/117.bugfix.rst
+++ b/news/117.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a crash with SIGBUS when the file system fills up while ``memray run`` is writing a capture file.


### PR DESCRIPTION
Previously we were using lseek + write to grow our capture files, but
that resulted in SIGBUS being raised when a disk had filled up, rather
than an error code being returned (since it created sparse files that
would actually grow to require more disk space only as we `memcpy`'d
data into our memory-mapped array.

Instead, use `posix_fallocate` to grow our capture file. As long as this
call succeeds, it is guaranteed that future copies into our memory
mapped array will succeed.

Closes #116 