### PR TITLE
Fix inconsistency in cli documentation regarding --trace-python-allocators 

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -23,7 +23,7 @@ Features
 - Capture allocations made through the C99 ``aligned_alloc`` function. (#79)
 - By default the capture file will now be compressed using LZ4 after tracking completes. This temporarily requires extra disk space while the compression runs, but results in roughly 75% less disk space required in the end. Compression can be disabled with ``--no-compress``. (#82)
 - Speed up tracking by around 5% by building with link-time optimization (LTO). (#91)
-- Add a new ``--track-python-allocators`` option to ``memray run`` that allows tracking all allocations made using the Python allocators. This will result in bigger output files and slower profiling but it allows getting insights about all of the interpreter's memory allocations. (#92)
+- Add a new ``--trace-python-allocators`` option to ``memray run`` that allows tracking all allocations made using the Python allocators. This will result in bigger output files and slower profiling but it allows getting insights about all of the interpreter's memory allocations. (#92)
 
 
 Bug Fixes

--- a/docs/python_allocators.rst
+++ b/docs/python_allocators.rst
@@ -124,7 +124,7 @@ How can I deactivate ``pymalloc``
 
 To deactivate ``pymalloc`` you can set the ``PYTHONMALLOC=malloc`` environment
 variable or execute Python with ``-Xdev``. Or, you can pass the
-``--track-python-allocators`` flag to ``memray run`` so that, even though
+``--trace-python-allocators`` flag to ``memray run`` so that, even though
 ``pymalloc`` is still used, Memray sees every call to the ``pymalloc``
 allocator instead of only the ones where it needs to make a request to the
 system allocator.

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -97,7 +97,7 @@ with Memray, while still allowing Memray to show you each place where your
 program needs to acquire more memory.
 
 You can ask Memray to show you each individual object being created and
-destroyed, instead, by proving the ``--track-python-allocators`` argument to
+destroyed, instead, by proving the ``--trace-python-allocators`` argument to
 the ``run`` subcommand. This records a lot more data and makes profiling much
 slower. It will show you all allocations, even ones that don't result in your
 program requesting more memory from the system because the interpreter already
@@ -111,7 +111,7 @@ especially when tracking down memory leaks.
 
 .. code:: shell
 
-  memray run --track-python-allocators example.py
+  memray run --trace-python-allocators example.py
 
 .. caution:: 
   Tracking the Python allocators will result in much larger report files and


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #121*

**Describe your changes**
The docs said `--track-python-allocators`, the cli supports `--trace-python-allocators`. Now they agree.

closes #121
