### PR TITLE
Update stats in capture files as records are written

### DIFF
--- a/src/memray/_memray/record_reader.h
+++ b/src/memray/_memray/record_reader.h
@@ -29,6 +29,7 @@ class RecordReader
 {
   public:
     enum class RecordResult {
+        STATS_RECORD,
         ALLOCATION_RECORD,
         MEMORY_RECORD,
         ERROR,
@@ -48,6 +49,7 @@ class RecordReader
     HeaderRecord getHeader() const noexcept;
     PyObject* dumpAllRecords();
     std::string getThreadName(thread_id_t tid);
+    TrackerStats getLatestStats() const noexcept;
     Allocation getLatestAllocation() const noexcept;
     MemoryRecord getLatestMemoryRecord() const noexcept;
 
@@ -81,6 +83,7 @@ class RecordReader
     std::vector<UnresolvedNativeFrame> d_native_frames{};
     DeltaEncodedFields d_last;
     std::unordered_map<thread_id_t, std::string> d_thread_names;
+    TrackerStats d_latest_stats;
     Allocation d_latest_allocation;
     MemoryRecord d_latest_memory_record;
 
@@ -120,6 +123,9 @@ class RecordReader
 
     [[nodiscard]] bool parseContextSwitch(thread_id_t* tid);
     [[nodiscard]] bool processContextSwitch(thread_id_t tid);
+
+    [[nodiscard]] bool parseTrackerStats(TrackerStats* record);
+    [[nodiscard]] bool processTrackerStats(const TrackerStats& record);
 
     size_t getAllocationFrameIndex(const AllocationRecord& record);
 };

--- a/src/memray/_memray/record_reader.pxd
+++ b/src/memray/_memray/record_reader.pxd
@@ -1,6 +1,7 @@
 from _memray.records cimport Allocation
 from _memray.records cimport HeaderRecord
 from _memray.records cimport MemoryRecord
+from _memray.records cimport TrackerStats
 from _memray.source cimport Source
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -12,6 +13,7 @@ cdef extern from "record_reader.h" namespace "memray::api":
     cdef enum RecordResult 'memray::api::RecordReader::RecordResult':
         RecordResultAllocationRecord 'memray::api::RecordReader::RecordResult::ALLOCATION_RECORD'
         RecordResultMemoryRecord 'memray::api::RecordReader::RecordResult::MEMORY_RECORD'
+        RecordResultStatsRecord 'memray::api::RecordReader::RecordResult::STATS_RECORD'
         RecordResultError 'memray::api::RecordReader::RecordResult::ERROR'
         RecordResultEndOfFile 'memray::api::RecordReader::RecordResult::END_OF_FILE'
 
@@ -30,3 +32,4 @@ cdef extern from "record_reader.h" namespace "memray::api":
         string getThreadName(long int tid) except+
         Allocation getLatestAllocation()
         MemoryRecord getLatestMemoryRecord()
+        TrackerStats getLatestStats()

--- a/src/memray/_memray/record_writer.h
+++ b/src/memray/_memray/record_writer.h
@@ -21,6 +21,8 @@ class RecordWriter
             const std::string& command_line,
             bool native_traces);
 
+    ~RecordWriter();
+
     RecordWriter(RecordWriter& other) = delete;
     RecordWriter(RecordWriter&& other) = delete;
     void operator=(const RecordWriter&) = delete;
@@ -161,7 +163,7 @@ bool inline RecordWriter::writeRecordUnsafe(const MemoryRecord& record)
 {
     RecordTypeAndFlags token{RecordType::MEMORY_RECORD, 0};
     return writeSimpleType(token) && writeVarint(record.rss)
-           && writeVarint(record.ms_since_epoch - d_stats.start_time);
+           && writeVarint(record.ms_since_epoch - d_header.start_time);
 }
 
 bool inline RecordWriter::writeRecordUnsafe(const ContextSwitch& record)

--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -14,14 +14,14 @@
 namespace memray::tracking_api {
 
 const char MAGIC[] = "memray";
-const int CURRENT_HEADER_VERSION = 7;
+const int CURRENT_HEADER_VERSION = 8;
 
 using frame_id_t = size_t;
 using thread_id_t = unsigned long;
 using millis_t = long long;
 
 enum class RecordType : unsigned char {
-    UNINITIALIZED = 0,
+    OTHER = 0,
     ALLOCATION = 1,
     ALLOCATION_WITH_NATIVE = 2,
     FRAME_INDEX = 3,
@@ -36,10 +36,15 @@ enum class RecordType : unsigned char {
     CONTEXT_SWITCH = 12,
 };
 
+enum class OtherRecordType : unsigned char {
+    PADDING = 0,
+    STATS = 1,
+};
+
 struct RecordTypeAndFlags
 {
     RecordTypeAndFlags()
-    : record_type(RecordType::UNINITIALIZED)
+    : record_type(RecordType::OTHER)
     , flags(0)
     {
     }
@@ -61,10 +66,9 @@ static_assert(sizeof(RecordTypeAndFlags) == 1);
 
 struct TrackerStats
 {
+    millis_t time{};
     size_t n_allocations{0};
     size_t n_frames{0};
-    millis_t start_time{};
-    millis_t end_time{};
 };
 
 enum PythonAllocatorType {
@@ -79,7 +83,7 @@ struct HeaderRecord
     char magic[sizeof(MAGIC)];
     int version{};
     bool native_traces{false};
-    TrackerStats stats{};
+    millis_t start_time{};
     std::string command_line;
     int pid{-1};
     PythonAllocatorType python_allocator;

--- a/src/memray/_memray/records.pxd
+++ b/src/memray/_memray/records.pxd
@@ -19,15 +19,14 @@ cdef extern from "records.h" namespace "memray::tracking_api":
        vector[Frame] stack_trace
 
    struct TrackerStats:
+       long long time
        size_t n_allocations
        size_t n_frames
-       long long start_time
-       long long end_time
 
    struct HeaderRecord:
        int version
        bool native_traces
-       TrackerStats stats
+       long long start_time
        string command_line
        int pid
        int python_allocator

--- a/src/memray/_memray/sink.h
+++ b/src/memray/_memray/sink.h
@@ -15,6 +15,7 @@ class Sink
     virtual ~Sink(){};
     virtual bool writeAll(const char* data, size_t length) = 0;
     virtual bool seek(off_t offset, int whence) = 0;
+    virtual bool allocateStats(tracking_api::TrackerStats**) = 0;
     virtual std::unique_ptr<Sink> cloneInChildProcess() = 0;
 };
 
@@ -30,6 +31,7 @@ class FileSink : public memray::io::Sink
 
     bool writeAll(const char* data, size_t length) override;
     bool seek(off_t offset, int whence) override;
+    bool allocateStats(tracking_api::TrackerStats**) override;
     std::unique_ptr<Sink> cloneInChildProcess() override;
 
   private:
@@ -48,6 +50,9 @@ class FileSink : public memray::io::Sink
     char* d_buffer{nullptr};
     char* d_bufferEnd{nullptr};  // exclusive
     char* d_bufferNeedle{nullptr};
+
+    char* d_statsMapping{nullptr};
+    tracking_api::TrackerStats* d_stats{nullptr};
 };
 
 class SocketSink : public Sink
@@ -63,6 +68,7 @@ class SocketSink : public Sink
 
     bool writeAll(const char* data, size_t length) override;
     bool seek(off_t offset, int whence) override;
+    bool allocateStats(tracking_api::TrackerStats**) override;
     std::unique_ptr<Sink> cloneInChildProcess() override;
 
   private:
@@ -78,6 +84,8 @@ class SocketSink : public Sink
     const size_t BUFFER_SIZE{PIPE_BUF};
     std::unique_ptr<char[]> d_buffer{nullptr};
     char* d_bufferNeedle{nullptr};
+
+    tracking_api::TrackerStats d_stats;
 };
 
 class NullSink : public Sink
@@ -86,7 +94,11 @@ class NullSink : public Sink
     ~NullSink() override;
     bool writeAll(const char* data, size_t length) override;
     bool seek(off_t offset, int whence) override;
+    bool allocateStats(tracking_api::TrackerStats**) override;
     std::unique_ptr<Sink> cloneInChildProcess() override;
+
+  private:
+    tracking_api::TrackerStats d_stats;
 };
 
 }  // namespace memray::io

--- a/src/memray/_memray/socket_reader_thread.cpp
+++ b/src/memray/_memray/socket_reader_thread.cpp
@@ -23,7 +23,8 @@ BackgroundSocketReader::backgroundThreadWorker()
                 break;
             }
 
-            case RecordResult::MEMORY_RECORD: {
+            case RecordResult::MEMORY_RECORD:
+            case RecordResult::STATS_RECORD: {
                 break;
             }
             case RecordResult::END_OF_FILE:

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -276,7 +276,7 @@ Tracker::Tracker(
         pthread_atfork(&prepareFork, &parentFork, &childFork);
     });
 
-    if (!d_writer->writeHeader(false)) {
+    if (!d_writer->writeHeader()) {
         throw IoError{"Failed to write output header"};
     }
     updateModuleCache();
@@ -304,7 +304,6 @@ Tracker::~Tracker()
     if (d_trace_python_allocators) {
         unregisterPymallocHooks();
     }
-    d_writer->writeHeader(true);
     d_writer.reset();
 
     // Note: this must not be unset before the hooks are uninstalled.

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -463,6 +463,7 @@ class TestParseSubcommand:
             "SEGMENT",
             "MEMORY_RECORD",
             "CONTEXT_SWITCH",
+            "TRACKER_STATS",
         ]
         code_file = tmp_path / "code.py"
         program = textwrap.dedent(


### PR DESCRIPTION
This will allow us to have an accurate count of records even in the case where a process is killed early by a signal.