### PR TITLE
Revert "Avoid inlining `exact_unwind`" to fix unwinding in aarch64

### DIFF
--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -110,7 +110,6 @@ class NativeTrace
         if (size == MAX_SIZE) {
             d_data.resize(0);
             size = exact_unwind();
-            skip += 1;  // skip the non-inlined exact_unwind frame
             MAX_SIZE = MAX_SIZE * 2 > size ? MAX_SIZE * 2 : size;
             d_data.resize(MAX_SIZE);
         }
@@ -144,9 +143,7 @@ class NativeTrace
         return unw_backtrace((void**)data, MAX_SIZE);
     }
 
-    // This can not be inlined as some architectures (e.g. ppc64le) don't
-    // support inlining functions that call setjmp()
-    __attribute__((noinline)) size_t inline exact_unwind()
+    __attribute__((always_inline)) size_t inline exact_unwind()
     {
         unw_context_t context;
         if (unw_getcontext(&context) < 0) {


### PR DESCRIPTION
Reverts bloomberg/memray#52

Seems that libunwind just chokes if the function that calls `unw_get_reg` is not inlined in aarch64. The original change was made as a best-effort to better support powerpc but given that powerpc doesn't even fully work but aarch64 does, we prefer to support aarch64 here.

Closes: #126 