### PR TITLE
Recognize and handle truncated capture files

### DIFF
--- a/news/129.bugfix.rst
+++ b/news/129.bugfix.rst
@@ -1,0 +1,1 @@
+Recognize when a capture file has been truncated (most likely because the tracked process was killed unexpectedly) and ignore any incomplete record at the end of the file.

--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -430,8 +430,16 @@ RecordReader::nextRecord()
         }
 
         switch (record_type_and_flags.record_type) {
-            case RecordType::UNINITIALIZED: {
-                // Skip it. All remaining bytes should be 0.
+            case RecordType::OTHER: {
+                switch (static_cast<OtherRecordType>(record_type_and_flags.flags)) {
+                    case OtherRecordType::TRAILER: {
+                        return RecordResult::END_OF_FILE;
+                    } break;
+                    default: {
+                        if (d_input->is_open()) LOG(ERROR) << "Invalid record subtype";
+                        return RecordResult::ERROR;
+                    } break;
+                }
             } break;
             case RecordType::ALLOCATION: {
                 AllocationRecord record;
@@ -681,8 +689,17 @@ RecordReader::dumpAllRecords()
         }
 
         switch (record_type_and_flags.record_type) {
-            case RecordType::UNINITIALIZED: {
-                // Skip it. All remaining bytes should be 0.
+            case RecordType::OTHER: {
+                switch (static_cast<OtherRecordType>(record_type_and_flags.flags)) {
+                    case OtherRecordType::TRAILER: {
+                        printf("TRAILER\n");
+                        Py_RETURN_NONE;  // Treat as EOF
+                    } break;
+                    default: {
+                        printf("UNKNOWN OTHER RECORD TYPE %d\n", (int)record_type_and_flags.flags);
+                        Py_RETURN_NONE;
+                    } break;
+                }
             } break;
             case RecordType::ALLOCATION_WITH_NATIVE: {
                 printf("ALLOCATION_WITH_NATIVE ");

--- a/src/memray/_memray/record_writer.cpp
+++ b/src/memray/_memray/record_writer.cpp
@@ -73,6 +73,16 @@ RecordWriter::writeHeader(bool seek_to_start)
     return true;
 }
 
+bool
+RecordWriter::writeTrailer()
+{
+    std::lock_guard<std::mutex> lock(d_mutex);
+    // The FileSource will ignore trailing 0x00 bytes. This non-zero trailer
+    // marks the boundary between bytes we wrote and padding bytes.
+    RecordTypeAndFlags token{RecordType::OTHER, int(OtherRecordType::TRAILER)};
+    return writeSimpleType(token);
+}
+
 std::unique_lock<std::mutex>
 RecordWriter::acquireLock()
 {

--- a/src/memray/_memray/record_writer.h
+++ b/src/memray/_memray/record_writer.h
@@ -50,6 +50,7 @@ class RecordWriter
     bool inline writeRecordUnsafe(const UnresolvedNativeFrame& record);
     bool inline writeRecordUnsafe(const MemoryMapStart&);
     bool writeHeader(bool seek_to_start);
+    bool writeTrailer();
 
     std::unique_lock<std::mutex> acquireLock();
     std::unique_ptr<RecordWriter> cloneInChildProcess();

--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -21,7 +21,7 @@ using thread_id_t = unsigned long;
 using millis_t = long long;
 
 enum class RecordType : unsigned char {
-    UNINITIALIZED = 0,
+    OTHER = 0,
     ALLOCATION = 1,
     ALLOCATION_WITH_NATIVE = 2,
     FRAME_INDEX = 3,
@@ -36,10 +36,14 @@ enum class RecordType : unsigned char {
     CONTEXT_SWITCH = 12,
 };
 
+enum class OtherRecordType : unsigned char {
+    TRAILER = 1,
+};
+
 struct RecordTypeAndFlags
 {
     RecordTypeAndFlags()
-    : record_type(RecordType::UNINITIALIZED)
+    : record_type(RecordType::OTHER)
     , flags(0)
     {
     }

--- a/src/memray/_memray/source.h
+++ b/src/memray/_memray/source.h
@@ -39,9 +39,12 @@ class FileSource : public Source
 
   private:
     void _close();
+    void findReadableSize();
     const std::string& d_file_name;
     std::shared_ptr<std::ifstream> d_raw_stream;
     std::shared_ptr<std::istream> d_stream;
+    std::streamoff d_readable_size{};
+    std::streamoff d_bytes_read{};
 };
 
 class SocketBuf : public std::streambuf

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -304,6 +304,7 @@ Tracker::~Tracker()
     if (d_trace_python_allocators) {
         unregisterPymallocHooks();
     }
+    d_writer->writeTrailer();
     d_writer->writeHeader(true);
     d_writer.reset();
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -463,6 +463,7 @@ class TestParseSubcommand:
             "SEGMENT",
             "MEMORY_RECORD",
             "CONTEXT_SWITCH",
+            "TRAILER",
         ]
         code_file = tmp_path / "code.py"
         program = textwrap.dedent(


### PR DESCRIPTION
Make the `RecordWriter` finish a capture file by writing a non-zero
trailer byte that the `RecordReader` will ignore. When the `FileSource`
reads a (non-compressed) capture file, have it ignore any trailing zero
bytes without returning them to the caller. If the caller attempts to
read into them, treat it as though EOF has been reached instead.

When a trailer byte is encountered by the reader, treat it as EOF,
rather than continuing to request bytes from the reader.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>
