### PR TITLE
Fix histogram when all allocations are the same size

### DIFF
--- a/news/133.bugfix.rst
+++ b/news/133.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the histogram used by the ``memray stats`` reporter to choose sane bin sizes when all captured allocations are the same size.

--- a/src/memray/reporters/stats.py
+++ b/src/memray/reporters/stats.py
@@ -86,8 +86,10 @@ def get_histogram_databins(data: List[int], bins: int) -> List[Tuple[int, int]]:
 
     low = math.log(min(data))
     high = math.log(max(data))
+    if low == high:
+        low = low / 2
     it = map(math.log, filter(lambda number: number != 0, data))
-    step = ((high - low) / bins) or low
+    step = (high - low) / bins
 
     # Determine the upper bound in bytes for each bin
     steps = [int(math.exp(low + step * (i + 1))) for i in range(bins)]

--- a/tests/unit/test_stats_reporter.py
+++ b/tests/unit/test_stats_reporter.py
@@ -302,6 +302,28 @@ def test_get_histogram_over_bound():
     assert expected_output == actual_output
 
 
+def test_get_histogram_all_allocations_same_size():
+    input_data = [10000000000, 10000000000, 10000000000]
+    expected_output = [
+        (316227, 0),
+        (999999, 0),
+        (3162277, 0),
+        (10000000, 0),
+        (31622776, 0),
+        (100000000, 0),
+        (316227766, 0),
+        (999999999, 0),
+        (3162277660, 0),
+        (10000000000, 3),
+    ]
+
+    # WHEN
+    actual_output = get_histogram_databins(input_data, bins=10)
+
+    # THEN
+    assert expected_output == actual_output
+
+
 def test_get_histogram_databins_invalid_bins():
     with pytest.raises(ValueError):
         _ = get_histogram_databins([], bins=0)  # invalid bins value


### PR DESCRIPTION
Previously we potentially chose a very large step, which resulted in
crazy bucket sizes.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>

Relates-to: #130 