### PR TITLE
Fix many bugs in the stats reporter

### DIFF
--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -2,9 +2,7 @@ Stats Reporter
 ==============
 
 The stats reporter generates high level statistics about the tracked process's
-memory allocations. By default, it computes these statistics for the moment when
-the tracked process's memory usage was at its peak, but it can optionally
-compute the stats for *all* allocations instead.
+memory allocations.
 
 .. image:: _static/images/stats_example.png
 
@@ -21,13 +19,6 @@ The output includes the following:
 * Stack trace and **size** of the top 'n' largest allocating locations by size (*default: 5*, configurable with the ``-n`` command line param)
 
 * Stack trace and **count** of the top 'n' largest allocating locations by number of allocations (*default: 5*, configurable with the ``-n`` command line param)
-
-.. note::
-
-    By default, the statistics are displayed only for the time when the memory
-    usage was at its peak. However, it is possible to use the ``-a`` command
-    line argument to consider all allocations throughout the life of the
-    process. Including all allocations slows this reporter down drastically.
 
 Basic Usage
 -----------

--- a/news/136.bugfix.1.rst
+++ b/news/136.bugfix.1.rst
@@ -1,0 +1,1 @@
+Fix a bug causing deallocations with ``free`` and ``munmap`` to be included in the reported "Total allocations" count of ``memray stats --include-all-allocations``.

--- a/news/136.bugfix.2.rst
+++ b/news/136.bugfix.2.rst
@@ -1,0 +1,1 @@
+Fix a bug causing memory freed by ``munmap`` to be incorrectly added into the reported "Total memory allocated" of ``memray stats --include-all-allocations``.

--- a/news/136.bugfix.3.rst
+++ b/news/136.bugfix.3.rst
@@ -1,0 +1,1 @@
+Fix the ``memray stats`` histogram to be based on the actual sizes of all allocations. Previously it only saw the sizes after a rollup by stack had already been performed, so it was binning allocation sizes that had already been summed.

--- a/news/136.bugfix.4.rst
+++ b/news/136.bugfix.4.rst
@@ -1,0 +1,1 @@
+Fix the two "largest allocating locations" sections in the ``memray stats`` report to actually aggregate by location. Previously they were aggregating by distinct stacks, so if two different paths hit the same line of code, it would be counted separately instead of together.

--- a/news/136.bugfix.5.rst
+++ b/news/136.bugfix.5.rst
@@ -1,0 +1,1 @@
+Exclude ``PYMALLOC_FREE`` from the allocator type distribution (other deallocators were already being ignored, but this recently added one was missed).

--- a/news/136.feature.rst
+++ b/news/136.feature.rst
@@ -1,0 +1,1 @@
+The ``memray stats`` reporter is now up to 50% faster, and its output is easier to interpret because it now processes all allocations by default.

--- a/news/136.removal.rst
+++ b/news/136.removal.rst
@@ -1,0 +1,1 @@
+Remove the ``--include-all-allocations`` / ``-a`` argument to the ``memray stats`` reporter. Previously this was too slow to be used by default, but now that it has been sped up, it doesn't make sense to use anything else. The old default behavior of only processing allocations that made up the high water mark of the application's memory usage was confusing and misleading.

--- a/src/memray/_memray.pyi
+++ b/src/memray/_memray.pyi
@@ -17,6 +17,7 @@ from typing import overload
 from memray._destination import FileDestination as FileDestination
 from memray._destination import SocketDestination as SocketDestination
 from memray._metadata import Metadata
+from memray._stats import Stats
 
 from . import Destination
 
@@ -94,9 +95,6 @@ class FileReader:
     def get_leaked_allocation_records(
         self, merge_threads: bool
     ) -> Iterable[AllocationRecord]: ...
-    def get_all_allocation_records_aggregated(
-        self, merge_threads: bool
-    ) -> Iterable[AllocationRecord]: ...
     def get_memory_snapshots(self) -> Iterable[MemorySnapshot]: ...
     def __enter__(self) -> Any: ...
     def __exit__(
@@ -109,6 +107,12 @@ class FileReader:
     def closed(self) -> bool: ...
     def close(self) -> None: ...
 
+def compute_statistics(
+    file_name: Union[str, Path],
+    *,
+    report_progress: bool = False,
+    num_largest: int = 5,
+) -> Stats: ...
 def dump_all_records(file_name: Union[str, Path]) -> None: ...
 
 class SocketReader:

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -1,5 +1,6 @@
 import collections
 import contextlib
+import heapq
 import os
 import pathlib
 import sys
@@ -16,6 +17,7 @@ from posix.time cimport CLOCK_MONOTONIC
 from posix.time cimport clock_gettime
 from posix.time cimport timespec
 
+from _memray.hooks cimport Allocator
 from _memray.hooks cimport isDeallocator
 from _memray.logging cimport setLogThreshold
 from _memray.record_reader cimport RecordReader
@@ -28,6 +30,7 @@ from _memray.sink cimport FileSink
 from _memray.sink cimport NullSink
 from _memray.sink cimport Sink
 from _memray.sink cimport SocketSink
+from _memray.snapshot cimport AllocationStatsAggregator
 from _memray.snapshot cimport HighWatermark
 from _memray.snapshot cimport HighWatermarkFinder
 from _memray.snapshot cimport Py_GetSnapshotAllocationRecords
@@ -39,6 +42,7 @@ from _memray.source cimport SocketSource
 from _memray.tracking_api cimport Tracker as NativeTracker
 from _memray.tracking_api cimport install_trace_function
 from cpython cimport PyErr_CheckSignals
+from libc.stdint cimport uint64_t
 from libcpp cimport bool
 from libcpp.limits cimport numeric_limits
 from libcpp.memory cimport make_shared
@@ -46,12 +50,14 @@ from libcpp.memory cimport make_unique
 from libcpp.memory cimport shared_ptr
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string as cppstring
+from libcpp.unordered_map cimport unordered_map
 from libcpp.utility cimport move
 from libcpp.vector cimport vector
 
 from ._destination import FileDestination
 from ._destination import SocketDestination
 from ._metadata import Metadata
+from ._stats import Stats
 
 include "_memray_test_utils.pyx"
 
@@ -344,6 +350,32 @@ def start_thread_trace(frame, event, arg):
     return start_thread_trace
 
 
+cdef millis_to_dt(millis):
+    return datetime.fromtimestamp(millis // 1000).replace(
+        microsecond=millis % 1000 * 1000)
+
+
+cdef _create_metadata(header, peak_memory):
+    stats = header["stats"]
+    allocator_id_to_name = {
+        PythonAllocatorType.PYTHON_ALLOCATOR_PYMALLOC: "pymalloc",
+        PythonAllocatorType.PYTHON_ALLOCATOR_PYMALLOC_DEBUG: "pymalloc debug",
+        PythonAllocatorType.PYTHON_ALLOCATOR_MALLOC: "malloc",
+        PythonAllocatorType.PYTHON_ALLOCATOR_OTHER: "unknown",
+    }
+    return Metadata(
+        start_time=millis_to_dt(stats["start_time"]),
+        end_time=millis_to_dt(stats["end_time"]),
+        total_allocations=stats["n_allocations"],
+        total_frames=stats["n_frames"],
+        peak_memory=peak_memory,
+        command_line=header["command_line"],
+        pid=header["pid"],
+        python_allocator=allocator_id_to_name[header["python_allocator"]],
+        has_native_traces=header["native_traces"],
+    )
+
+
 cdef class ProgressIndicator:
     cdef bool _report_progress
     cdef object _indicator
@@ -519,12 +551,7 @@ cdef class FileReader:
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.close()
 
-    def _aggregate_allocations(
-        self,
-        size_t records_to_process,
-        bool merge_threads,
-        bool ignore_frees,
-    ):
+    def _aggregate_allocations(self, size_t records_to_process, bool merge_threads):
         cdef SnapshotAllocationAggregator aggregator
         cdef shared_ptr[RecordReader] reader_sp = make_shared[RecordReader](
             unique_ptr[FileSource](new FileSource(self._path))
@@ -542,10 +569,7 @@ cdef class FileReader:
                 PyErr_CheckSignals()
                 ret = reader.nextRecord()
                 if ret == RecordResult.RecordResultAllocationRecord:
-                    if ignore_frees and isDeallocator(reader.getLatestAllocation().allocator):
-                        pass
-                    else:
-                        aggregator.addAllocation(reader.getLatestAllocation())
+                    aggregator.addAllocation(reader.getLatestAllocation())
                     records_to_process -= 1
                     progress_indicator.update(1)
                 elif ret == RecordResult.RecordResultMemoryRecord:
@@ -566,23 +590,12 @@ cdef class FileReader:
         self._ensure_not_closed()
         # If allocation 0 caused the peak, we need to process 1 record, etc
         cdef size_t max_records = self._high_watermark.index + 1
-        yield from self._aggregate_allocations(
-            max_records, merge_threads, ignore_frees=False
-        )
+        yield from self._aggregate_allocations(max_records, merge_threads)
 
     def get_leaked_allocation_records(self, merge_threads=True):
         self._ensure_not_closed()
         cdef size_t max_records = self._header["stats"]["n_allocations"]
-        yield from self._aggregate_allocations(
-            max_records, merge_threads, ignore_frees=False
-        )
-
-    def get_all_allocation_records_aggregated(self, merge_threads=True):
-        self._ensure_not_closed()
-        cdef size_t max_records = self._header["stats"]["n_allocations"]
-        yield from self._aggregate_allocations(
-            max_records, merge_threads, ignore_frees=True
-        )
+        yield from self._aggregate_allocations(max_records, merge_threads)
 
     def get_allocation_records(self):
         self._ensure_not_closed()
@@ -611,27 +624,99 @@ cdef class FileReader:
 
     @property
     def metadata(self):
-        def millis_to_dt(millis) -> datetime:
-            return datetime.fromtimestamp(millis // 1000).replace(
-                microsecond=millis % 1000 * 1000)
+        return _create_metadata(self._header, self._high_watermark.peak_memory)
 
-        stats = self._header["stats"]
-        allocator_id_to_name = {
-            PythonAllocatorType.PYTHON_ALLOCATOR_PYMALLOC: "pymalloc",
-            PythonAllocatorType.PYTHON_ALLOCATOR_PYMALLOC_DEBUG: "pymalloc debug",
-            PythonAllocatorType.PYTHON_ALLOCATOR_MALLOC: "malloc",
-            PythonAllocatorType.PYTHON_ALLOCATOR_OTHER: "unknown",
-        }
-        python_allocator = allocator_id_to_name[self._header["python_allocator"]]
-        return Metadata(start_time=millis_to_dt(stats["start_time"]),
-                        end_time=millis_to_dt(stats["end_time"]),
-                        total_allocations=stats["n_allocations"],
-                        total_frames=stats["n_frames"],
-                        peak_memory=self._high_watermark.peak_memory,
-                        command_line=self._header["command_line"],
-                        pid=self._header["pid"],
-                        python_allocator=python_allocator,
-                        has_native_traces=self._header["native_traces"])
+
+def compute_statistics(
+    file_name,
+    *,
+    report_progress=False,
+    num_largest=5,
+):
+    cdef shared_ptr[RecordReader] reader_sp = make_shared[RecordReader](
+        unique_ptr[FileSource](new FileSource(file_name))
+    )
+    cdef RecordReader* reader = reader_sp.get()
+
+    cdef header = reader.getHeader()
+    total = header["stats"]["n_allocations"] or None
+
+    cdef AllocationStatsAggregator aggregator
+    cdef ProgressIndicator progress_indicator = ProgressIndicator(
+        "Computing statistics",
+        total=total,
+        report_progress=report_progress,
+    )
+    with progress_indicator:
+        while True:
+            PyErr_CheckSignals()
+            ret = reader.nextRecord()
+            if ret == RecordResult.RecordResultAllocationRecord:
+                aggregator.addAllocation(reader.getLatestAllocation())
+                progress_indicator.update(1)
+            elif ret == RecordResult.RecordResultMemoryRecord:
+                pass
+            else:
+                break
+
+    # Ignore the n_allocations in the header, use our observed value.
+    header["stats"]["n_allocations"] = progress_indicator.num_processed
+
+    # Convert allocation counts by allocator/by size to Python dicts.
+    cdef dict tmp = aggregator.allocationCountByAllocator()
+    allocation_count_by_allocator = {AllocatorType(k).name: v for k, v in tmp.items()}
+    cdef dict allocation_count_by_size = aggregator.allocationCountBySize();
+
+    # We've aggregated sizes and counts by stack, but we want to aggregate them
+    # by source location instead. Ideally we wouldn't do this in Python, but
+    # there's currently no other way to look up a frame by ID.
+    size_and_count_by_location = collections.defaultdict(lambda: [0, 0])
+
+    # NOTE: We need to cast away the constness of the reference below
+    #       because Cython's iterator handling is not const-correct.
+    for location_key_and_size_and_count in <AllocationStatsAggregator.SizeAndCountByStack&>(
+        aggregator.sizeAndCountByStack()
+    ):
+        top_of_stack = reader.Py_GetStackFrame(
+            location_key_and_size_and_count.first.python_frame_id, 1
+        )
+        top_of_stack = top_of_stack or [("<unknown>", "<unknown>", 0)]
+        size_and_count = size_and_count_by_location[top_of_stack[0]]
+        size, count = location_key_and_size_and_count.second
+        size_and_count[0] += size
+        size_and_count[1] += count
+
+    # Now we've got sizes and counts by source location. Find the top locations.
+    locations_with_sizes = [
+        (size, loc)
+        for loc, (size, count) in size_and_count_by_location.items()
+    ]
+    top_locations_by_size = [
+        (loc, size)
+        for size, loc in heapq.nlargest(num_largest, locations_with_sizes)
+    ]
+
+    locations_with_counts = [
+        (count, loc)
+        for loc, (size, count) in size_and_count_by_location.items()
+    ]
+    top_locations_by_count = [
+        (loc, count)
+        for count, loc in heapq.nlargest(num_largest, locations_with_counts)
+    ]
+
+    # And we're done!
+    cdef uint64_t peak_memory = aggregator.peakBytesAllocated()
+    return Stats(
+        metadata=_create_metadata(header, peak_memory),
+        total_num_allocations=aggregator.totalAllocations(),
+        total_memory_allocated=aggregator.totalBytesAllocated(),
+        peak_memory_allocated=peak_memory,
+        allocation_count_by_size=allocation_count_by_size,
+        allocation_count_by_allocator=allocation_count_by_allocator,
+        top_locations_by_size=top_locations_by_size,
+        top_locations_by_count=top_locations_by_count,
+    )
 
 
 def dump_all_records(object file_name):

--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -615,6 +615,24 @@ error:
     return nullptr;
 }
 
+std::optional<frame_id_t>
+RecordReader::getLatestPythonFrameId(const Allocation& allocation) const
+{
+    if (0 == allocation.frame_index) {
+        return {};
+    }
+    return d_tree.nextNode(allocation.frame_index).first;
+}
+
+PyObject*
+RecordReader::Py_GetFrame(std::optional<frame_id_t> frame)
+{
+    if (!frame) {
+        Py_RETURN_NONE;
+    }
+    return d_frame_map.at(frame.value()).toPythonObject(d_pystring_cache);
+}
+
 HeaderRecord
 RecordReader::getHeader() const noexcept
 {

--- a/src/memray/_memray/record_reader.h
+++ b/src/memray/_memray/record_reader.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <stddef.h>
 #include <stdint.h>
 #include <string>
@@ -43,6 +44,8 @@ class RecordReader
             FrameTree::index_t index,
             size_t generation,
             size_t max_stacks = std::numeric_limits<size_t>::max());
+    std::optional<frame_id_t> getLatestPythonFrameId(const Allocation& allocation) const;
+    PyObject* Py_GetFrame(std::optional<frame_id_t> frame);
 
     RecordResult nextRecord();
     HeaderRecord getHeader() const noexcept;

--- a/src/memray/_memray/record_reader.pxd
+++ b/src/memray/_memray/record_reader.pxd
@@ -1,6 +1,7 @@
 from _memray.records cimport Allocation
 from _memray.records cimport HeaderRecord
 from _memray.records cimport MemoryRecord
+from _memray.records cimport optional_frame_id_t
 from _memray.source cimport Source
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -25,6 +26,8 @@ cdef extern from "record_reader.h" namespace "memray::api":
         object Py_GetStackFrame(int frame_id, size_t max_stacks) except+
         object Py_GetNativeStackFrame(int frame_id, size_t generation) except+
         object Py_GetNativeStackFrame(int frame_id, size_t generation, size_t max_stacks) except+
+        optional_frame_id_t getLatestPythonFrameId(const Allocation&) except+
+        object Py_GetFrame(optional_frame_id_t frame) except+
         HeaderRecord getHeader()
         object dumpAllRecords() except+
         string getThreadName(long int tid) except+

--- a/src/memray/_memray/records.pxd
+++ b/src/memray/_memray/records.pxd
@@ -41,3 +41,8 @@ cdef extern from "records.h" namespace "memray::tracking_api":
        size_t rss
        size_t heap
 
+
+cdef extern from "<optional>":
+   # Cython doesn't have libcpp.optional yet, so just declare this opaquely.
+   cdef cppclass optional_frame_id_t "std::optional<memray::tracking_api::frame_id_t>":
+       pass

--- a/src/memray/_memray/snapshot.cpp
+++ b/src/memray/_memray/snapshot.cpp
@@ -215,7 +215,9 @@ HighWatermarkFinder::getCurrentWatermark() const noexcept
 }
 
 void
-AllocationStatsAggregator::addAllocation(const Allocation& allocation)
+AllocationStatsAggregator::addAllocation(
+        const Allocation& allocation,
+        std::optional<frame_id_t> python_frame_id)
 {
     d_high_water_mark_finder.processAllocation(allocation);
     if (hooks::isDeallocator(allocation.allocator)) {
@@ -225,8 +227,7 @@ AllocationStatsAggregator::addAllocation(const Allocation& allocation)
     d_total_bytes_allocated += allocation.size;
     d_allocation_count_by_size[allocation.size] += 1;
     d_allocation_count_by_allocator[static_cast<int>(allocation.allocator)] += 1;
-    auto loc_key = LocationKey{allocation.frame_index, allocation.native_frame_id, NO_THREAD_INFO};
-    auto& size_and_count = d_size_and_count_by_stack[loc_key];
+    auto& size_and_count = d_size_and_count_by_location[python_frame_id];
     size_and_count.first += allocation.size;
     size_and_count.second += 1;
 }

--- a/src/memray/_memray/snapshot.h
+++ b/src/memray/_memray/snapshot.h
@@ -203,6 +203,53 @@ class HighWatermarkFinder
     IntervalTree<Allocation> d_mmap_intervals;
 };
 
+class AllocationStatsAggregator
+{
+  public:
+    typedef std::pair<uint64_t, uint64_t> SizeAndCount;
+    typedef std::unordered_map<LocationKey, SizeAndCount, index_thread_pair_hash> SizeAndCountByStack;
+
+    void addAllocation(const Allocation& allocation);
+
+    uint64_t totalAllocations()
+    {
+        return d_total_allocations;
+    }
+
+    uint64_t totalBytesAllocated()
+    {
+        return d_total_bytes_allocated;
+    }
+
+    uint64_t peakBytesAllocated()
+    {
+        return d_high_water_mark_finder.getHighWatermark().peak_memory;
+    }
+
+    const std::unordered_map<size_t, uint64_t>& allocationCountBySize()
+    {
+        return d_allocation_count_by_size;
+    }
+
+    const std::unordered_map<int, uint64_t>& allocationCountByAllocator()
+    {
+        return d_allocation_count_by_allocator;
+    }
+
+    const SizeAndCountByStack& sizeAndCountByStack()
+    {
+        return d_size_and_count_by_stack;
+    }
+
+  private:
+    SizeAndCountByStack d_size_and_count_by_stack;
+    std::unordered_map<size_t, uint64_t> d_allocation_count_by_size;
+    std::unordered_map<int, uint64_t> d_allocation_count_by_allocator;
+    HighWatermarkFinder d_high_water_mark_finder;
+    uint64_t d_total_allocations{};
+    uint64_t d_total_bytes_allocated{};
+};
+
 PyObject*
 Py_GetSnapshotAllocationRecords(
         const allocations_t& all_records,

--- a/src/memray/_memray/snapshot.pxd
+++ b/src/memray/_memray/snapshot.pxd
@@ -38,8 +38,8 @@ cdef extern from "snapshot.h" namespace "memray::api":
         uint64_t totalAllocations()
         uint64_t totalBytesAllocated()
         uint64_t peakBytesAllocated()
-        const unordered_map[size_t, uint64_t] allocationCountBySize()
-        const unordered_map[int, uint64_t] allocationCountByAllocator()
+        const unordered_map[size_t, uint64_t]& allocationCountBySize()
+        const unordered_map[int, uint64_t]& allocationCountByAllocator()
         const SizeAndCountByStack& sizeAndCountByStack()
 
     object Py_ListFromSnapshotAllocationRecords(const reduced_snapshot_map_t&) except+

--- a/src/memray/_memray/snapshot.pxd
+++ b/src/memray/_memray/snapshot.pxd
@@ -1,4 +1,5 @@
 from _memray.records cimport Allocation
+from _memray.records cimport optional_frame_id_t
 from libc.stdint cimport uint64_t
 from libcpp cimport bool
 from libcpp.unordered_map cimport unordered_map
@@ -32,15 +33,14 @@ cdef extern from "snapshot.h" namespace "memray::api":
         pass
 
     cdef cppclass AllocationStatsAggregator:
-        ctypedef pair[uint64_t, uint64_t] SizeAndCount
-        ctypedef unordered_map[LocationKey, SizeAndCount, index_thread_pair_hash] SizeAndCountByStack
-        void addAllocation(const Allocation&) except+
+        void addAllocation(const Allocation&, optional_frame_id_t python_frame_id) except+
         uint64_t totalAllocations()
         uint64_t totalBytesAllocated()
         uint64_t peakBytesAllocated()
         const unordered_map[size_t, uint64_t]& allocationCountBySize()
         const unordered_map[int, uint64_t]& allocationCountByAllocator()
-        const SizeAndCountByStack& sizeAndCountByStack()
+        vector[pair[uint64_t, optional_frame_id_t]] topLocationsBySize(size_t num_largest) except+
+        vector[pair[uint64_t, optional_frame_id_t]] topLocationsByCount(size_t num_largest) except+
 
     object Py_ListFromSnapshotAllocationRecords(const reduced_snapshot_map_t&) except+
     object Py_GetSnapshotAllocationRecords(const vector[Allocation]& all_records, size_t record_index, bool merge_threads) except+

--- a/src/memray/_stats.py
+++ b/src/memray/_stats.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+from ._metadata import Metadata
+
+
+@dataclass
+class Stats:
+    metadata: Metadata
+    total_num_allocations: int
+    total_memory_allocated: int
+    peak_memory_allocated: int
+    allocation_count_by_size: dict
+    allocation_count_by_allocator: dict
+    top_locations_by_size: list
+    top_locations_by_count: list

--- a/src/memray/_stats.pyi
+++ b/src/memray/_stats.pyi
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+from ._memray import AllocatorType
+from ._memray import PythonStackElement
+from ._metadata import Metadata
+
+@dataclass
+class Stats:
+    metadata: Metadata
+    total_num_allocations: int
+    total_memory_allocated: int
+    peak_memory_allocated: int
+    allocation_count_by_size: dict[int, int]
+    allocation_count_by_allocator: dict[AllocatorType, int]
+    top_locations_by_size: list[tuple[PythonStackElement, int]]
+    top_locations_by_count: list[tuple[PythonStackElement, int]]

--- a/src/memray/reporters/stats.py
+++ b/src/memray/reporters/stats.py
@@ -1,98 +1,38 @@
-import heapq
 import math
 from collections import Counter
-from dataclasses import dataclass
-from dataclasses import field
-from typing import IO
 from typing import Dict
-from typing import Generator
-from typing import Iterable
+from typing import Iterator
 from typing import List
-from typing import Optional
 from typing import Tuple
 
 import rich
 
-from memray import AllocationRecord
-from memray import AllocatorType
 from memray._memray import size_fmt
+from memray._stats import Stats
 
 
-@dataclass
-class _StatsData:
-    total_memory_allocated: int = 0
-    total_num_allocations: int = 0
-    allocation_size_array: List[int] = field(default_factory=list)
-    allocation_type_counter: Dict[str, int] = field(default_factory=dict)
-
-
-def get_stats_data(data: Iterable[AllocationRecord]) -> _StatsData:
-    shdata = _StatsData()
-    shdata.total_num_allocations = sum(alloc.n_allocations for alloc in data)
-    shdata.total_memory_allocated = int(sum(alloc.size for alloc in data))
-    shdata.allocation_size_array = [alloc.size for alloc in data if alloc.size]
-    shdata.allocation_type_counter = Counter(
-        AllocatorType(alloc.allocator).name for alloc in data
-    )
-    return shdata
-
-
-def get_top_allocations_by_size(
-    data: Iterable[AllocationRecord], num_largest: int
-) -> Generator[str, None, None]:
-    for record in heapq.nlargest(num_largest, data, key=lambda rec: rec.size):
-        stack_trace = record.stack_trace()
-        strace_string = ""
-        if stack_trace:
-            (function, file, line), *_ = stack_trace
-            strace_string = f"{function}:{file}:{line}"
-        else:
-            strace_string = "<stack trace unavailable>"
-
-        yield f"{strace_string} -> {size_fmt(record.size)}"
-
-
-def get_top_allocations_by_count(
-    data: Iterable[AllocationRecord], num_largest: int
-) -> Generator[str, None, None]:
-    for record in heapq.nlargest(num_largest, data, key=lambda rec: rec.n_allocations):
-        stack_trace = record.stack_trace()
-        strace_string = ""
-        if stack_trace:
-            (function, file, line), *_ = stack_trace
-            strace_string = f"{function}:{file}:{line}"
-        else:
-            strace_string = "<stack trace unavailable>"
-        yield f"{strace_string} -> {record.n_allocations}"
-
-
-def get_allocator_type_distribution(
-    alloc_type_counter: Dict[str, int]
-) -> Generator[str, None, None]:
-    for alloc_type, alloc_value in sorted(
-        alloc_type_counter.items(), key=lambda item: item[1], reverse=True
-    ):
-        yield f"{alloc_type}: {alloc_value}"
-
-
-def get_histogram_databins(data: List[int], bins: int) -> List[Tuple[int, int]]:
+def get_histogram_databins(data: Dict[int, int], bins: int) -> List[Tuple[int, int]]:
     if bins <= 0:
         raise ValueError(f"Invalid input bins={bins}, should be greater than 0")
 
-    low = math.log(min(data))
+    low = math.log(min(filter(None, data)))
     high = math.log(max(data))
     if low == high:
         low = low / 2
-    it = map(math.log, filter(lambda number: number != 0, data))
     step = (high - low) / bins
 
     # Determine the upper bound in bytes for each bin
     steps = [int(math.exp(low + step * (i + 1))) for i in range(bins)]
-    dist = Counter(min((x - low) // step, bins - 1) for x in it)
+    dist: Dict[int, int] = Counter()
+    for size, count in data.items():
+        bucket = min(int((math.log(size) - low) // step), bins - 1) if size else 0
+        dist[bucket] += count
     return [(steps[b], dist[b]) for b in range(bins)]
 
 
-def draw_histogram(data: List[int], bins: int, *, hist_scale_factor: int = 25) -> str:
+def draw_histogram(
+    data: Dict[int, int], bins: int, *, hist_scale_factor: int = 25
+) -> str:
     """
     @param data: list of allocation sizes
     @param bins: number of bins in the histogram
@@ -143,38 +83,26 @@ def draw_histogram(data: List[int], bins: int, *, hist_scale_factor: int = 25) -
 
 
 class StatsReporter:
-    def __init__(self, data: Iterable[AllocationRecord], num_largest: int):
-        self.data = list(data)
+    def __init__(self, stats: Stats, num_largest: int):
+        self._stats = stats
         if num_largest < 1:
             raise ValueError(f"Invalid input num_largest={num_largest}, should be >=1")
         self.num_largest = num_largest
 
-    @classmethod
-    def from_snapshot(
-        cls, allocations: Iterable[AllocationRecord], num_largest: int
-    ) -> "StatsReporter":
-        return cls(allocations, num_largest)
-
-    def render(
-        self,
-        *,
-        file: Optional[IO[str]] = None,
-    ) -> None:
-        shdata = self._get_stats_data()
-
+    def render(self) -> None:
         rich.print("📏 [bold]Total allocations:[/]")
-        print(f"\t{shdata.total_num_allocations}")
+        print(f"\t{self._stats.total_num_allocations}")
 
         print()
         rich.print("📦 [bold]Total memory allocated:[/]")
-        print(f"\t{size_fmt(shdata.total_memory_allocated)}")
+        print(f"\t{size_fmt(self._stats.total_memory_allocated)}")
 
         print()
         num_bins = 10
         histogram_scale_factor = 25
         rich.print("📊 [bold]Histogram of allocation size:[/]")
-        histogram = self._draw_histogram(
-            shdata.allocation_size_array,
+        histogram = draw_histogram(
+            self._stats.allocation_count_by_size,
             num_bins,
             hist_scale_factor=histogram_scale_factor,
         )
@@ -182,9 +110,7 @@ class StatsReporter:
 
         print()
         rich.print("📂 [bold]Allocator type distribution:[/]")
-        for entry in self._get_allocator_type_distribution(
-            shdata.allocation_type_counter
-        ):
+        for entry in self._get_allocator_type_distribution():
             print(f"\t {entry}")
 
         print()
@@ -202,21 +128,25 @@ class StatsReporter:
         for entry in self._get_top_allocations_by_count():
             print(f"\t- {entry}")
 
-    def _get_stats_data(self) -> _StatsData:
-        return get_stats_data(self.data)
+    @staticmethod
+    def _format_location(loc: Tuple[str, str, int]) -> str:
+        function, file, line = loc
+        if function == "<unknown>":
+            return "<stack trace unavailable>"
+        return f"{function}:{file}:{line}"
 
-    def _get_top_allocations_by_size(self) -> Generator[str, None, None]:
-        yield from get_top_allocations_by_size(self.data, self.num_largest)
+    def _get_top_allocations_by_size(self) -> Iterator[str]:
+        for location, size in self._stats.top_locations_by_size:
+            yield f"{self._format_location(location)} -> {size_fmt(size)}"
 
-    def _get_top_allocations_by_count(self) -> Generator[str, None, None]:
-        yield from get_top_allocations_by_count(self.data, self.num_largest)
+    def _get_top_allocations_by_count(self) -> Iterator[str]:
+        for location, count in self._stats.top_locations_by_count:
+            yield f"{self._format_location(location)} -> {count}"
 
-    def _get_allocator_type_distribution(
-        self, alloc_type_counter: Dict[str, int]
-    ) -> Generator[str, None, None]:
-        yield from get_allocator_type_distribution(alloc_type_counter)
-
-    def _draw_histogram(
-        self, data: List[int], bins: int, *, hist_scale_factor: int = 25
-    ) -> str:
-        return draw_histogram(data, bins, hist_scale_factor=hist_scale_factor)
+    def _get_allocator_type_distribution(self) -> Iterator[str]:
+        for allocator_name, count in sorted(
+            self._stats.allocation_count_by_allocator.items(),
+            key=lambda item: item[1],
+            reverse=True,
+        ):
+            yield f"{allocator_name}: {count}"


### PR DESCRIPTION
Remove the `--include-all-allocations` / `-a` option for the `stats`
reporter and have it process all allocations by default. Its default
behavior of only processing allocations that made up the high water mark
of the application's memory usage was confusing and misleading.

Previously when `-a` was provided, deallocations with `free` and
`munmap` were included in the reported count of "Total allocations".
This has been fixed.

Similarly, when `-a` was provided, memory freed by `munmap` (though not
`free`) was incorrectly being added to the count of total memory
allocated. This has been fixed.

The histogram has been fixed to work on the actual sizes of all
allocations. Previously it only saw the sizes after a rollup by stack
had already been performed, and it was therefore binning allocation
sizes that had already been summed.

Fix the two "largest allocating locations" sections to actually
aggregate by location. Previously they were aggregating by distinct
stack, so if the same line of code was reached by two different paths,
it would be counted separately instead of together.

Exclude `PYMALLOC_FREE` from the allocator type distribution (other
deallocators were already being ignored, but this recently added one was
missed).

Additionally, this fixes the bug introduced in #134 where `memray stats -a` was incorrectly handling any pointer that was reused after being reallocated. I haven't included a changelog entry for that one since it was never included in any released version.

Closes: #85 
Closes: #134 