### PR TITLE
Always leverage fast unwinding to obtain the native stack

### DIFF
--- a/news/141.bugfix.rst
+++ b/news/141.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where aggregating native call stacks could give misleading results on aarch64 under some circumstances.

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -247,7 +247,7 @@ PythonStackTracker::popPythonFrame()
 std::atomic<bool> Tracker::d_active = false;
 std::unique_ptr<Tracker> Tracker::d_instance_owner;
 std::atomic<Tracker*> Tracker::d_instance = nullptr;
-MEMRAY_FAST_TLS thread_local size_t NativeTrace::MAX_SIZE{64};
+MEMRAY_FAST_TLS thread_local size_t NativeTrace::MAX_SIZE{128};
 
 Tracker::Tracker(
         std::unique_ptr<RecordWriter> record_writer,

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -317,7 +317,7 @@
    write(buf)
    ...
    fun:backtrace
-   fun:unwind
+   fun:fill
    ...
 }
 {
@@ -326,7 +326,7 @@
    msync(start)
    ...
    fun:backtrace
-   fun:unwind
+   fun:fill
    ...
 }
 {
@@ -334,7 +334,7 @@
    Memcheck:Cond
    ...
    fun:backtrace
-   fun:unwind
+   fun:fill
    ...
 }
 


### PR DESCRIPTION
Seems that libunwind just chokes if the function that calls unw_get_reg
is not inlined in aarch64. Additionally, there are some problems with
inlined functions that call libunwind's APIs in powerpc and other
architectures.

To avoid all this trouble, leverage just the fast unwinding APIs, which
will make the program counters more consistent and will eliminate the
inline shenanigans.

Closes: https://github.com/bloomberg/memray/issues/126