### PR TITLE
Make frame IDs start at 0 and count up by 1

### DIFF
--- a/src/memray/_memray/record_reader.h
+++ b/src/memray/_memray/record_reader.h
@@ -73,7 +73,6 @@ class RecordReader
     const bool d_track_stacks;
     HeaderRecord d_header;
     pyframe_map_t d_frame_map{};
-    FrameCollection<Frame> d_allocation_frames{1, 2};
     stack_traces_t d_stack_traces{};
     FrameTree d_tree{};
     mutable python_helpers::PyUnicode_Cache d_pystring_cache{};

--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -244,10 +244,6 @@ template<typename FrameType>
 class FrameCollection
 {
   public:
-    explicit FrameCollection(const frame_id_t& starting_index, const unsigned int& index_increment)
-    : d_index_increment{index_increment}
-    , d_current_frame_id{starting_index} {};
-
     template<typename T>
     auto getIndex(T&& frame) -> std::pair<frame_id_t, bool>
     {
@@ -255,15 +251,14 @@ class FrameCollection
         if (it == d_frame_map.end()) {
             frame_id_t frame_id =
                     d_frame_map.emplace(std::forward<T>(frame), d_current_frame_id).first->second;
-            d_current_frame_id += d_index_increment;
+            d_current_frame_id++;
             return std::make_pair(frame_id, true);
         }
         return std::make_pair(it->second, false);
     }
 
   private:
-    const unsigned int d_index_increment;
-    frame_id_t d_current_frame_id;
+    frame_id_t d_current_frame_id{};
     std::unordered_map<FrameType, frame_id_t, typename FrameType::Hash> d_frame_map{};
 };
 

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -286,7 +286,7 @@ class Tracker
     };
 
     // Data members
-    FrameCollection<RawFrame> d_frames{0, 2};
+    FrameCollection<RawFrame> d_frames;
     static std::atomic<bool> d_active;
     static std::unique_ptr<Tracker> d_instance_owner;
     static std::atomic<Tracker*> d_instance;


### PR DESCRIPTION
Previously these were able to start at an arbitrary user-controlled
number and count up by an arbitrary user-controlled number, but we're no
longer leveraging that feature for anything, so we can drop the
complexity.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>
