### PR TITLE
Ensure we can read a file with no allocations

### DIFF
--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -14,7 +14,7 @@
 namespace memray::tracking_api {
 
 const char MAGIC[] = "memray";
-const int CURRENT_HEADER_VERSION = 7;
+const int CURRENT_HEADER_VERSION = 8;
 
 using frame_id_t = size_t;
 using thread_id_t = unsigned long;
@@ -71,7 +71,7 @@ struct TrackerStats
     millis_t end_time{};
 };
 
-enum PythonAllocatorType {
+enum PythonAllocatorType : unsigned char {
     PYTHONALLOCATOR_PYMALLOC = 1,
     PYTHONALLOCATOR_PYMALLOC_DEBUG = 2,
     PYTHONALLOCATOR_MALLOC = 3,

--- a/tests/integration/test_tracking.py
+++ b/tests/integration/test_tracking.py
@@ -258,6 +258,31 @@ def test_tracking_with_SIGKILL(tmpdir):
     assert allocation.size == 1024
 
 
+def test_no_allocations(tmpdir):
+    """Verify that we can successfully read a file that has no allocations."""
+    # GIVEN
+    output = Path(tmpdir) / "test.bin"
+    subprocess_code = textwrap.dedent(
+        f"""
+        import os
+        from memray import Tracker
+        output = "{output}"
+        tracker = Tracker(output)
+        with tracker:
+            os._exit(0)
+    """
+    )
+
+    # WHEN
+    process = subprocess.run([sys.executable, "-c", subprocess_code], timeout=5)
+
+    # THEN
+    assert process.returncode == 0
+
+    records = list(FileReader(output).get_allocation_records())
+    assert not records
+
+
 class TestHighWatermark:
     def test_no_allocations_while_tracking(self, tmp_path):
         # GIVEN / WHEN


### PR DESCRIPTION
Due to how we handle trailing 0 in files, if a file has no allocations
we will fail correctly reading the Python allocator as currently is 4
bytes, but the last 3 are always 0. If there aren't any other records
after it we will incorrectly invalidate all trailing zeroes, which will
fail reading the Python allocator.

This technically requires a more complex fix, but for now we can make
a simple change and make the Python allocator 1 byte, which will not
suffer from this problem.
