### PR TITLE
Require rich >= 11.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ class BuildMemray(build_ext_orig):
 install_requires = [
     "jinja2",
     "typing_extensions; python_version < '3.8.0'",
-    "rich",
+    "rich >= 11.2.0",
 ]
 docs_requires = [
     "bump2version",


### PR DESCRIPTION
This is the earliest version to support `Progress.get_default_columns`.

Closes #156 