### PR TITLE
Ignore ENAMETOOLONG in checking if `-c` is a file

### DIFF
--- a/src/memray/commands/run.py
+++ b/src/memray/commands/run.py
@@ -298,8 +298,9 @@ class RunCommand:
             parser.error("The --live-port argument requires --live-remote")
         if args.follow_fork is True and (args.live_mode or args.live_remote_mode):
             parser.error("--follow-fork cannot be used with the live TUI")
-        if args.run_as_cmd and pathlib.Path(args.script).exists():
-            parser.error("remove the option -c to run a file")
+        with contextlib.suppress(OSError):
+            if args.run_as_cmd and pathlib.Path(args.script).exists():
+                parser.error("remove the option -c to run a file")
 
         self.validate_target_file(args)
 


### PR DESCRIPTION
We want to tell the user that they're doing the wrong thing if they do
`memray run -c foo.py`, but that check can fail with `ENAMETOOLONG` if
the argument given to `-c` is too long to possibly be a file path.

Just ignore any OS error that occurs when doing this check, since this
check is just a nice-to-have anyway, to provide a nice error message for
something that would have gone on to fail anyway.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>