### PR TITLE
Remove a decref of a borrowed reference

### DIFF
--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -331,13 +331,11 @@ PythonStackTracker::pythonFrameToStack(PyFrameObject* current_frame)
 
         const char* function = PyUnicode_AsUTF8(code->co_name);
         if (function == nullptr) {
-            Py_DECREF(code);
             return {};
         }
 
         const char* filename = PyUnicode_AsUTF8(code->co_filename);
         if (filename == nullptr) {
-            Py_DECREF(code);
             return {};
         }
 


### PR DESCRIPTION
In an initial implementation of this function `code` was an owned
reference and needed to be decref'd, but in the final version it's
a borrowed reference and must not be decref'd. This went unnoticed
because the bug is on an error path that we never hit.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>