### PR TITLE
Handle our profile function getting uninstalled

### DIFF
--- a/news/176.bugfix.rst
+++ b/news/176.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent a use-after-free bug that could result in a crash if ``sys.setprofile()`` was called while Memray was tracking. Now if ``sys.setprofile()`` is called, all future allocations on that thread will report unknown Python stacks, instead of potentially incorrect stacks.

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -63,33 +63,15 @@ thread_id()
 
 // Tracker interface
 
-// If a TLS variable has not been constructed, accessing it will cause it to be
-// constructed. That's normally great, but we need to prevent that from
-// happening unexpectedly for the TLS vector owned by this class.
-//
-// Methods of this class can be called during thread teardown. It's possible
-// that, after the TLS vector for a dying thread has already been destroyed,
-// libpthread makes a call to free() that calls into our Tracker, and if it
-// does, we must prevent it touching the vector again and re-constructing it.
-// Otherwise, it would be re-constructed immediately but its destructor would
-// be added to this thread's list of finalizers after all the finalizers for
-// the thread already ran.  If that happens, the vector will be free()d before
-// its destructor runs. Worse, its destructor will remain on the list of
-// finalizers for the current thread's pthread struct, and its destructor will
-// later be run on that already free()d memory if this thread's pthread struct
-// is ever reused. When that happens it tends to cause heap corruption, because
-// another vector is placed at the same location as the original one, and the
-// vector destructor runs twice on it (once for the newly created vector, and
-// once for the vector that had been created before the thread died and the
-// pthread struct was reused).
-//
-// To prevent that, we create the vector in one method, pushLazilyEmittedFrame.
-// All other methods access a pointer called `d_stack` that is set to the TLS
-// stack when it is created by pushLazilyEmittedFrame, and set to a null
-// pointer when the TLS stack is destroyed.
-//
-// This can result in this class being constructed during thread teardown, but
-// that doesn't cause the same problem because it has a trivial destructor.
+// This class must have a trivial destructor (and therefore all its instance
+// attributes must be POD). This is required because the libc implementation
+// can perform allocations even after the thread local variables for a thread
+// have been destroyed. If a TLS variable that is not trivially destructable is
+// accessed after that point by our allocation hooks, it will be resurrected,
+// and then it will be freed when the thread dies, but its destructor either
+// won't be called at all, or will be called on freed memory when some
+// arbitrary future thread is destroyed (if the pthread struct is reused for
+// another thread).
 class PythonStackTracker
 {
   private:
@@ -277,30 +259,11 @@ void
 PythonStackTracker::pushLazilyEmittedFrame(const LazilyEmittedFrame& frame)
 {
     // Note: this function does not require the GIL.
-    if (d_stack) {
-        d_stack->push_back(frame);
-        return;
+    if (!d_stack) {
+        d_stack = new std::vector<LazilyEmittedFrame>;
+        d_stack->reserve(1024);
     }
-
-    struct StackCreator
-    {
-        std::vector<LazilyEmittedFrame> stack;
-
-        StackCreator()
-        {
-            const size_t INITIAL_PYTHON_STACK_FRAMES = 1024;
-            stack.reserve(INITIAL_PYTHON_STACK_FRAMES);
-            PythonStackTracker::getUnsafe().d_stack = &stack;
-        }
-        ~StackCreator()
-        {
-            PythonStackTracker::getUnsafe().d_stack = nullptr;
-        }
-    };
-
-    MEMRAY_FAST_TLS static thread_local StackCreator t_stack_creator;
-    t_stack_creator.stack.push_back(frame);
-    assert(d_stack);  // The above call sets d_stack if it wasn't already set.
+    d_stack->push_back(frame);
 }
 
 void
@@ -433,6 +396,8 @@ PythonStackTracker::clear()
         d_num_pending_pops += d_stack->back().emitted;
         d_stack->pop_back();
     }
+    delete d_stack;
+    d_stack = nullptr;
     emitPendingPops();
 }
 

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -75,6 +75,14 @@ int
 PyTraceFunction(PyObject* obj, PyFrameObject* frame, int what, PyObject* arg);
 
 /**
+ * Trampoline that serves as the initial profiling function for each thread.
+ *
+ * This performs some one-time setup, then installs PyTraceFunction.
+ */
+int
+PyTraceTrampoline(PyObject* obj, PyFrameObject* frame, int what, PyObject* arg);
+
+/**
  * Installs the trace function in the current thread.
  *
  * This function installs the trace function in the current thread using the C-API.
@@ -82,6 +90,15 @@ PyTraceFunction(PyObject* obj, PyFrameObject* frame, int what, PyObject* arg);
  * */
 void
 install_trace_function();
+
+/**
+ * Drop any references to frames on this thread's stack.
+ *
+ * This should be called when either the thread is dying or our profile
+ * function is being uninstalled from it.
+ */
+void
+forget_python_stack();
 
 class NativeTrace
 {

--- a/src/memray/_memray/tracking_api.pxd
+++ b/src/memray/_memray/tracking_api.pxd
@@ -5,6 +5,7 @@ from libcpp.string cimport string
 
 
 cdef extern from "tracking_api.h" namespace "memray::tracking_api":
+    void forget_python_stack() except*
     void install_trace_function() except*
 
     cdef cppclass Tracker:

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -869,6 +869,88 @@ def test_cython_frame_in_pre_existing_thread_stack_when_restarting_tracking(tmp_
     assert alloc2_funcs[:2] == ["valloc", "thread_body"]
 
 
+def test_allocation_after_unsetting_profile_function(tmp_path):
+    """After tracking starts, unset the profile function then allocate.
+
+    Make sure that the stack for the allocation is unknown.
+    """
+    # GIVEN
+    allocator = MemoryAllocator()
+    output = tmp_path / "test.bin"
+
+    def func():
+        allocator.valloc(1234)
+        allocator.free()
+        sys.setprofile(None)
+        allocator.valloc(1234)
+        allocator.free()
+
+    # WHEN
+    with Tracker(output):
+        func()
+
+    # THEN
+    allocations = list(FileReader(output).get_allocation_records())
+
+    vallocs = [
+        event
+        for event in allocations
+        if event.size == 1234 and event.allocator == AllocatorType.VALLOC
+    ]
+    assert len(vallocs) == 2
+
+    first, second = vallocs
+    alloc1_funcs = [frame[0] for frame in first.stack_trace()]
+    alloc2_funcs = [frame[0] for frame in second.stack_trace()]
+
+    assert alloc1_funcs == [
+        "valloc",
+        "func",
+        "test_allocation_after_unsetting_profile_function",
+    ]
+    assert alloc2_funcs == []
+
+
+def test_allocation_in_thread_after_unsetting_profile_function(tmp_path):
+    """In a thread, unset the profile function then allocate.
+
+    Make sure that the stack for the allocation is unknown.
+    """
+    # GIVEN
+    allocator = MemoryAllocator()
+    output = tmp_path / "test.bin"
+
+    def func():
+        allocator.valloc(1234)
+        allocator.free()
+        sys.setprofile(None)
+        allocator.valloc(1234)
+        allocator.free()
+
+    # WHEN
+    with Tracker(output):
+        thread = threading.Thread(target=func)
+        thread.start()
+        thread.join()
+
+    # THEN
+    allocations = list(FileReader(output).get_allocation_records())
+
+    vallocs = [
+        event
+        for event in allocations
+        if event.size == 1234 and event.allocator == AllocatorType.VALLOC
+    ]
+    assert len(vallocs) == 2
+
+    first, second = vallocs
+    alloc1_funcs = [frame[0] for frame in first.stack_trace()]
+    alloc2_funcs = [frame[0] for frame in second.stack_trace()]
+
+    assert alloc1_funcs[:2] == ["valloc", "func"]
+    assert alloc2_funcs == []
+
+
 class TestMmap:
     @classmethod
     def allocating_function(cls):


### PR DESCRIPTION
Previously, we would retain references to frames that were on the stack
in a given thread, but without our profile function we wouldn't know
when those frames were popped and it was no longer safe to reference
them.

After this change, we are able to detect when our profile function is
deregistered (either because a new one has been installed or because the
thread state the profile function was registered with is dying). This
gives us a hook to invalidate our cached frames to prevent this
use-after-free bug.