### PR TITLE
Detect the greenlet module and try to handle it

### DIFF
--- a/news/185.feature.rst
+++ b/news/185.feature.rst
@@ -1,0 +1,1 @@
+Add experimental support for Greenlet.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
-greenlet
+Cython
+greenlet; python_version < '3.11'
 pytest
 pytest-cov

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
+greenlet
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ lint_requires = [
 
 test_requires = [
     "Cython",
-    "greenlet",
+    "greenlet; python_version < '3.11'",
     "pytest",
     "pytest-cov",
 ]

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ lint_requires = [
 
 test_requires = [
     "Cython",
+    "greenlet",
     "pytest",
     "pytest-cov",
 ]

--- a/src/memray/_memray.pyi
+++ b/src/memray/_memray.pyi
@@ -166,6 +166,8 @@ class Tracker:
         exctb: Optional[TracebackType],
     ) -> bool: ...
 
+def greenlet_trace(event: str, args: Any) -> None: ...
+
 class PymallocDomain(enum.IntEnum):
     PYMALLOC_RAW: int
     PYMALLOC_MEM: int

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -393,6 +393,15 @@ def greenlet_trace_function(event, args):
         handle_greenlet_switch(args[0], args[1])
 
 
+def print_greenlet_warning():
+    pprint(
+        ":warning: [bold red]Memray support for Greenlet is experimental[/] :warning:\n"
+        "[yellow]Please report any issues at https://github.com/bloomberg/memray/issues[/]\n"
+        "\n",
+        file=sys.stderr,
+    )
+
+
 cdef millis_to_dt(millis):
     return datetime.fromtimestamp(millis // 1000).replace(
         microsecond=millis % 1000 * 1000)

--- a/src/memray/_memray/hooks.cpp
+++ b/src/memray/_memray/hooks.cpp
@@ -277,7 +277,12 @@ dlopen(const char* filename, int flag) noexcept
     assert(hooks::dlopen);
 
     void* ret = hooks::dlopen(filename, flag);
-    if (ret) tracking_api::Tracker::invalidate_module_cache();
+    if (ret) {
+        tracking_api::Tracker::invalidate_module_cache();
+        if (filename && 0 != strstr(filename, "/_greenlet.")) {
+            tracking_api::begin_tracking_greenlets();
+        }
+    }
     return ret;
 }
 

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -358,6 +358,18 @@ PythonStackTracker::installGreenletTraceFunctionIfNeeded()
 
     // Note: guarded by the GIL
     d_greenlet_hooks_installed = true;
+
+    static bool warned = false;
+    if (!warned) {
+        warned = true;
+
+        PyObject* ret = PyObject_CallMethod(_memray, "print_greenlet_warning", nullptr);
+        Py_XDECREF(ret);
+        if (!ret) {
+            PyErr_Print();
+            _exit(1);
+        }
+    }
 }
 
 void

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -102,6 +102,18 @@ install_trace_function();
 void
 forget_python_stack();
 
+/**
+ * Sets a flag to enable integration with the `greenlet` module.
+ */
+void
+begin_tracking_greenlets();
+
+/**
+ * Handle a notification of control switching from one greenlet to another.
+ */
+void
+handle_greenlet_switch(PyObject* from, PyObject* to);
+
 class NativeTrace
 {
   public:

--- a/src/memray/_memray/tracking_api.pxd
+++ b/src/memray/_memray/tracking_api.pxd
@@ -7,6 +7,8 @@ from libcpp.string cimport string
 cdef extern from "tracking_api.h" namespace "memray::tracking_api":
     void forget_python_stack() except*
     void install_trace_function() except*
+    void begin_tracking_greenlets() except+
+    void handle_greenlet_switch(object, object) except+
 
     cdef cppclass Tracker:
         @staticmethod

--- a/tests/integration/test_greenlet.py
+++ b/tests/integration/test_greenlet.py
@@ -1,0 +1,192 @@
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from memray import AllocatorType
+from memray import FileReader
+from tests.utils import filter_relevant_allocations
+
+
+def test_integration_with_greenlet(tmpdir):
+    """Verify that we can track Python stacks when greenlet is in use."""
+    # GIVEN
+    output = Path(tmpdir) / "test.bin"
+    subprocess_code = textwrap.dedent(
+        f"""
+        import mmap
+        import sys
+        import gc
+
+        import greenlet
+
+        from memray import Tracker
+        from memray._test import MemoryAllocator
+
+
+        def apple():
+            banana()
+
+
+        def banana():
+            allocator.valloc(1024 * 10)
+            animal.switch()
+            allocator.valloc(1024 * 30)
+
+
+        def ant():
+            allocator.valloc(1024 * 20)
+            fruit.switch()
+            allocator.valloc(1024 * 40)
+            bat()
+            allocator.valloc(1024 * 60)
+
+
+        def bat():
+            allocator.valloc(1024 * 50)
+
+
+        def test():
+            fruit.switch()
+            assert fruit.dead
+            animal.switch()
+            assert animal.dead
+            allocator.valloc(1024 * 70)
+
+
+        allocator = MemoryAllocator()
+        output = "{output}"
+
+        with Tracker(output):
+            fruit = greenlet.greenlet(apple)
+            animal = greenlet.greenlet(ant)
+            test()
+        """
+    )
+
+    # WHEN
+    subprocess.run([sys.executable, "-Xdev", "-c", subprocess_code], timeout=5)
+
+    # THEN
+    reader = FileReader(output)
+    records = list(reader.get_allocation_records())
+    vallocs = [
+        record
+        for record in filter_relevant_allocations(records)
+        if record.allocator == AllocatorType.VALLOC
+    ]
+
+    def stack(alloc):
+        return [frame[0] for frame in alloc.stack_trace()]
+
+    assert stack(vallocs[0]) == ["valloc", "banana", "apple"]
+    assert vallocs[0].size == 10 * 1024
+
+    assert stack(vallocs[1]) == ["valloc", "ant"]
+    assert vallocs[1].size == 20 * 1024
+
+    assert stack(vallocs[2]) == ["valloc", "banana", "apple"]
+    assert vallocs[2].size == 30 * 1024
+
+    assert stack(vallocs[3]) == ["valloc", "ant"]
+    assert vallocs[3].size == 40 * 1024
+
+    assert stack(vallocs[4]) == ["valloc", "bat", "ant"]
+    assert vallocs[4].size == 50 * 1024
+
+    assert stack(vallocs[5]) == ["valloc", "ant"]
+    assert vallocs[5].size == 60 * 1024
+
+    assert stack(vallocs[6]) == ["valloc", "test", "<module>"]
+    assert vallocs[6].size == 70 * 1024
+
+
+def test_importing_greenlet_after_tracking_starts(tmpdir):
+    # GIVEN
+    output = Path(tmpdir) / "test.bin"
+    subprocess_code = textwrap.dedent(
+        f"""
+        import mmap
+        import sys
+        import gc
+
+        from memray import Tracker
+        from memray._test import MemoryAllocator
+
+
+        def apple():
+            banana()
+
+
+        def banana():
+            allocator.valloc(1024 * 10)
+            animal.switch()
+            allocator.valloc(1024 * 30)
+
+
+        def ant():
+            allocator.valloc(1024 * 20)
+            fruit.switch()
+            allocator.valloc(1024 * 40)
+            bat()
+            allocator.valloc(1024 * 60)
+
+
+        def bat():
+            allocator.valloc(1024 * 50)
+
+
+        def test():
+            fruit.switch()
+            assert fruit.dead
+            animal.switch()
+            assert animal.dead
+            allocator.valloc(1024 * 70)
+
+
+        allocator = MemoryAllocator()
+        output = "{output}"
+
+        with Tracker(output):
+            import greenlet
+            fruit = greenlet.greenlet(apple)
+            animal = greenlet.greenlet(ant)
+            test()
+        """
+    )
+
+    # WHEN
+    subprocess.run([sys.executable, "-Xdev", "-c", subprocess_code], timeout=5)
+
+    # THEN
+    reader = FileReader(output)
+    records = list(reader.get_allocation_records())
+    vallocs = [
+        record
+        for record in filter_relevant_allocations(records)
+        if record.allocator == AllocatorType.VALLOC
+    ]
+
+    def stack(alloc):
+        return [frame[0] for frame in alloc.stack_trace()]
+
+    assert stack(vallocs[0]) == ["valloc", "banana", "apple"]
+    assert vallocs[0].size == 10 * 1024
+
+    assert stack(vallocs[1]) == ["valloc", "ant"]
+    assert vallocs[1].size == 20 * 1024
+
+    assert stack(vallocs[2]) == ["valloc", "banana", "apple"]
+    assert vallocs[2].size == 30 * 1024
+
+    assert stack(vallocs[3]) == ["valloc", "ant"]
+    assert vallocs[3].size == 40 * 1024
+
+    assert stack(vallocs[4]) == ["valloc", "bat", "ant"]
+    assert vallocs[4].size == 50 * 1024
+
+    assert stack(vallocs[5]) == ["valloc", "ant"]
+    assert vallocs[5].size == 60 * 1024
+
+    assert stack(vallocs[6]) == ["valloc", "test", "<module>"]
+    assert vallocs[6].size == 70 * 1024

--- a/tests/integration/test_greenlet.py
+++ b/tests/integration/test_greenlet.py
@@ -3,9 +3,15 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
+
 from memray import AllocatorType
 from memray import FileReader
 from tests.utils import filter_relevant_allocations
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info >= (3, 11), reason="Greenlet does not yet support Python 3.11"
+)
 
 
 def test_integration_with_greenlet(tmpdir):


### PR DESCRIPTION
Attempt to detect when the `greenlet` module is used (whether it has
already been imported at the point when tracking starts, or it gets
imported after tracking has started). If we discover that the `greenlet`
module is in use, register a callback to discover greenlet switch events
and react to them.  Unfortunately, this callback needs to be registered
once per thread, and the only place where we can reasonably register it
in a background thread is when our profile function is called, so we may
miss greenlet switches if they occur before any Python calls.

If we detect Greenlet, print a warning that this support is experimental.

Closes: #166 