### PR TITLE
Ping to version 1 of the Pypi publish action

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -81,7 +81,7 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels, build_wheels_macos, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -90,6 +90,6 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
As instructed by the action itself:

    You are using "pypa/gh-action-pypi-publish@master". The "master" branch
    of this project has been sunset and will not receive any updates, not
    even security bug fixes. Please, make sure to use a supported version.
    If you want to pin to v1 major version, use
    "pypa/gh-action-pypi-publish@release/v1". If you feel adventurous, you
    may opt to use use "pypa/gh-action-pypi-publish@unstable/v1" instead. A
    more general recommendation is to pin to exact tags or commit shas.

So we must pin to the v1 version of the action.
