### PR TITLE
Ensure the Tracker is deactivated after a fork without "follow_fork"

### DIFF
--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -716,6 +716,7 @@ Tracker::childFork()
         // Note that the old tracker's hooks may still be installed. This is
         // OK, as long as they always check the (static) isActive() flag before
         // calling any methods on the now null tracker singleton.
+        Tracker::deactivate();
         d_instance = nullptr;
         RecursionGuard::isActive = false;
         return;


### PR DESCRIPTION
If we try to flush pending frames to disk in a forked process that has
been created without `follow_fork=True` we will miserably fail when
trying to get hold of the tracker and call
`Tracker::getTracker()->popFrame` or any other member function. We are
supposed to protect against this in the `forget_python_stack` function
but that's down by checking if the Tracker is deactivated or not by
calling `Tracker::isActive()`. Unfortunately, in `Tracker::childFork()`
we are missing a call to `Tracker::deactivate` if ``follow_fork`` has
not been passed.

As a consequence, we enter `emitPendingPushesAndPops` and hell goes
loose.

Closes: #195 
