### PR TITLE
Add conda-forge badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ![PyPI - Implementation](https://img.shields.io/pypi/implementation/memray)
 ![PyPI](https://img.shields.io/pypi/v/memray)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/memray)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/memray.svg)](https://anaconda.org/conda-forge/memray)
 [![Tests](https://github.com/bloomberg/memray/actions/workflows/build.yml/badge.svg)](https://github.com/bloomberg/memray/actions/workflows/build.yml)
 ![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)
 


### PR DESCRIPTION
Followup of #32.

**Describe your changes**
Add a badge to the README file pointing to the conda-forge memray package (and showing the package version available on conda-forge).

**Testing performed**
n/a

**Additional context**
We could add more text to the installation instructions in the README if it is of interest.

---

Here is how it looks like:

<img width="784" alt="image" src="https://user-images.githubusercontent.com/1772435/187579551-7d42530f-c676-4ad5-80e3-6a80bd5551b4.png">

