### PR TITLE
tests: Fix an incorrect line number

### DIFF
--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -143,7 +143,7 @@ def test_cython_traceback(tmpdir):
 
     traceback = list(alloc1.stack_trace())
     assert traceback == [
-        ("valloc", sys.modules["memray._test"].__file__, 41),
+        ("valloc", sys.modules["memray._test"].__file__, 42),
         ("test_cython_traceback", __file__, 134),
     ]
 


### PR DESCRIPTION
This line number is incorrect because two pull requests had a subtle conflict that wasn't caught by CI, because we don't enforce rebasing before the CI runs tests.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>
