### PR TITLE
ci: Split docs building from linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,37 +101,21 @@ jobs:
         run: |
           make dev-install pycoverage
 
-  lint_and_docs:
-    name: "Lint and Docs"
+  lint:
+    name: "Lint"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - name: Set up dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -qy clang-format npm libunwind-dev liblz4-dev pkg-config
-      - name: Install Python dependencies
+      - name: Install linting dependencies
         run: |
           python3 -m pip install -r requirements-extra.txt
-      - name: Install Package
-        run: |
-          python3 -m pip install -e .
       - name: Lint sources
         run: |
-          make lint
-          python3 -m pre_commit run --all-files --hook-stage pre-push
-      - name: Build docs
-        run: |
-          towncrier build --version 99.99 --name memray --keep
-          make docs
+          make lint MYPYPATH=src
 
   valgrind:
     name: "Valgrind & Helgrind"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -194,3 +194,24 @@ jobs:
         with:
           skip_existing: true
           password: ${{ secrets.PYPI_PASSWORD }}
+
+  upload_docs:
+    needs: [build_docs]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        name: Unstash docs tarball
+        with:
+          name: github-pages
+      - name: Extract docs tarball
+        run: |
+          mkdir -p docs/_build/html
+          tar xvf artifact.tar --directory docs/_build/html
+      - name: Publish docs to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: docs/_build/html
+          single-commit: true

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -139,6 +139,44 @@ jobs:
           name: dist
           path: ./wheelhouse/*.whl
 
+  build_docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qy libunwind-dev liblz4-dev pkg-config
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install -r requirements-extra.txt
+      - name: Install Package
+        run: |
+          python3 -m pip install -e .
+      - name: Build docs
+        run: |
+          towncrier build --version 99.99 --name memray --keep
+          make docs
+      - name: Create docs tarball
+        run: |
+          python3 -m pip install -e .
+          tar \
+            --dereference --hard-dereference \
+            --directory docs/_build/html \
+            --exclude=.buildinfo \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            .
+      - name: Stash docs tarball
+        uses: actions/upload-artifact@v3
+        with:
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+
   upload_pypi:
     needs: [build_wheels, build_wheels_macos, build_sdist]
     runs-on: ubuntu-latest

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,4 +1,6 @@
 mypy
+jinja2 >= 2.9
+ipython
 bump2version
 towncrier
 pre-commit


### PR DESCRIPTION
This lays the groundwork for automatically uploading documentation when a release is cut.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>
