### PR TITLE
Make some source cleanup

### DIFF
--- a/src/memray/_memray/compat.cpp
+++ b/src/memray/_memray/compat.cpp
@@ -14,7 +14,7 @@ setprofileAllThreads(Py_tracefunc func, PyObject* arg)
     {
 #if PY_VERSION_HEX >= 0x03090000
         if (_PyEval_SetProfile(tstate, func, arg) < 0) {
-            _PyErr_WriteUnraisableMsg("in PyEval_SetProfileAllThreads", NULL);
+            _PyErr_WriteUnraisableMsg("in PyEval_SetProfileAllThreads", nullptr);
         }
 #else
         // For 3.7 and 3.8, backport _PyEval_SetProfile from 3.9

--- a/src/memray/_memray/frame_tree.h
+++ b/src/memray/_memray/frame_tree.h
@@ -58,9 +58,9 @@ class FrameTree
         frame_id_t frame_id;
         index_t child_index;
 
-        bool operator<(frame_id_t frame_id) const
+        bool operator<(frame_id_t the_frame_id) const
         {
-            return this->frame_id < frame_id;
+            return this->frame_id < the_frame_id;
         }
     };
 

--- a/src/memray/_memray/logging.cpp
+++ b/src/memray/_memray/logging.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <stdexcept>
-#include <string>
 
 #include "logging.h"
 

--- a/src/memray/_memray/macho_shenanigans.cpp
+++ b/src/memray/_memray/macho_shenanigans.cpp
@@ -1,5 +1,4 @@
 #include <cstring>
-#include <dlfcn.h>
 
 #include "hooks.h"
 #include "linker_shenanigans.h"

--- a/src/memray/_memray/macho_utils.h
+++ b/src/memray/_memray/macho_utils.h
@@ -96,7 +96,7 @@ struct DynamicInfoTable
         return symbol_table && string_table && dynsym_table;
     }
 
-    const char* getSymbol(uintptr_t section_offset, unsigned long index) const
+    [[nodiscard]] const char* getSymbol(uintptr_t section_offset, unsigned long index) const
     {
         auto index_into_symtable = (dynsym_table + section_offset)[index];
         if (index_into_symtable & (INDIRECT_SYMBOL_ABS | INDIRECT_SYMBOL_LOCAL)) {

--- a/src/memray/_memray/native_resolver.cpp
+++ b/src/memray/_memray/native_resolver.cpp
@@ -199,7 +199,7 @@ MemorySegment::filename() const
 
 ResolvedFrame::ResolvedFrame(
         const MemorySegment::Frame& frame,
-        std::shared_ptr<StringStorage> d_string_storage)
+        const std::shared_ptr<StringStorage>& d_string_storage)
 : d_string_storage(d_string_storage)
 , d_symbol_index(d_string_storage->internString(frame.symbol))
 , d_file_index(d_string_storage->internString(frame.filename))
@@ -496,7 +496,7 @@ unwindHere()
         return 0;
     };
 
-    struct backtrace_state* state = backtrace_create_state("", 1, err_callback, NULL);
+    struct backtrace_state* state = backtrace_create_state("", 1, err_callback, nullptr);
     if (!state) {
         return {};
     }

--- a/src/memray/_memray/native_resolver.h
+++ b/src/memray/_memray/native_resolver.h
@@ -93,7 +93,9 @@ class ResolvedFrame
 {
   public:
     // Constructors
-    ResolvedFrame(const MemorySegment::Frame& frame, std::shared_ptr<StringStorage> string_storage);
+    ResolvedFrame(
+            const MemorySegment::Frame& frame,
+            const std::shared_ptr<StringStorage>& string_storage);
 
     // Methods
     PyObject* toPythonObject(python_helpers::PyUnicode_Cache& pystring_cache) const;

--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -6,10 +6,8 @@
 #include <cinttypes>
 #include <cstdio>
 #include <stdexcept>
-#include <string_view>
 #include <unordered_map>
 
-#include "exceptions.h"
 #include "hooks.h"
 #include "logging.h"
 #include "record_reader.h"
@@ -20,7 +18,6 @@ namespace memray::api {
 
 using namespace tracking_api;
 using namespace io;
-using namespace exception;
 
 namespace {  // unnamed
 
@@ -717,7 +714,7 @@ RecordReader::dumpAllRecords()
 
     while (true) {
         if (0 != PyErr_CheckSignals()) {
-            return NULL;
+            return nullptr;
         }
 
         RecordTypeAndFlags record_type_and_flags;

--- a/src/memray/_memray/record_reader.h
+++ b/src/memray/_memray/record_reader.h
@@ -89,13 +89,13 @@ class RecordReader
     DeltaEncodedFields d_last;
     std::unordered_map<thread_id_t, std::string> d_thread_names;
     Allocation d_latest_allocation;
-    MemoryRecord d_latest_memory_record;
+    MemoryRecord d_latest_memory_record{};
 
     // Methods
     [[nodiscard]] bool parseFramePush(FramePush* record);
     [[nodiscard]] bool processFramePush(const FramePush& record);
 
-    [[nodiscard]] bool parseFramePop(FramePop* record, unsigned int flags);
+    [[nodiscard]] static bool parseFramePop(FramePop* record, unsigned int flags);
     [[nodiscard]] bool processFramePop(const FramePop& record);
 
     [[nodiscard]] bool parseFrameIndex(tracking_api::pyframe_map_val_t* pyframe_val, unsigned int flags);
@@ -110,7 +110,7 @@ class RecordReader
     [[nodiscard]] bool parseNativeAllocationRecord(NativeAllocationRecord* record, unsigned int flags);
     [[nodiscard]] bool processNativeAllocationRecord(const NativeAllocationRecord& record);
 
-    [[nodiscard]] bool parseMemoryMapStart();
+    [[nodiscard]] static bool parseMemoryMapStart();
     [[nodiscard]] bool processMemoryMapStart();
 
     [[nodiscard]] bool parseSegmentHeader(std::string* filename, size_t* num_segments, uintptr_t* addr);

--- a/src/memray/_memray/record_writer.cpp
+++ b/src/memray/_memray/record_writer.cpp
@@ -18,7 +18,7 @@ getPythonAllocator()
 #else
     const char* name = "";
 #endif
-    std::string allocator_name = name != NULL ? name : "";
+    std::string allocator_name = name != nullptr ? name : "";
     if (allocator_name == "pymalloc") {
         return PythonAllocatorType::PYTHONALLOCATOR_PYMALLOC;
     }

--- a/src/memray/_memray/sink.cpp
+++ b/src/memray/_memray/sink.cpp
@@ -6,8 +6,6 @@
 
 #include <arpa/inet.h>
 #include <fcntl.h>
-#include <netdb.h>
-#include <stdexcept>
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -279,6 +277,12 @@ SocketSink::writeAll(const char* data, size_t length)
 bool
 SocketSink::flush()
 {
+    return _flush();
+}
+
+bool
+SocketSink::_flush()
+{
     const char* data = d_buffer.get();
     size_t length = d_bufferNeedle - data;
 
@@ -315,7 +319,7 @@ SocketSink::cloneInChildProcess()
 SocketSink::~SocketSink()
 {
     if (d_socket_open) {
-        flush();
+        _flush();
         ::close(d_socket_fd);
         d_socket_open = false;
     }

--- a/src/memray/_memray/sink.h
+++ b/src/memray/_memray/sink.h
@@ -73,6 +73,7 @@ class SocketSink : public Sink
   private:
     size_t freeSpaceInBuffer();
     void open();
+    bool _flush();
 
     const std::string d_host;
     uint16_t d_port;

--- a/src/memray/_memray/snapshot.cpp
+++ b/src/memray/_memray/snapshot.cpp
@@ -13,7 +13,9 @@ LocationKey::operator==(const LocationKey& rhs) const
 
 Interval::Interval(uintptr_t begin, uintptr_t end)
 : begin(begin)
-, end(end){};
+, end(end)
+{
+}
 
 std::optional<Interval>
 Interval::intersection(const Interval& other) const

--- a/src/memray/_memray/source.cpp
+++ b/src/memray/_memray/source.cpp
@@ -1,13 +1,10 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-#include <arpa/inet.h>
 #include <cerrno>
-#include <cstdio>
 #include <cstring>
 #include <iostream>
 #include <netdb.h>
-#include <sstream>
 #include <stdexcept>
 #include <sys/socket.h>
 #include <unistd.h>


### PR DESCRIPTION
 Update the source files to use C++ idioms, remove unused headers, remove
 shadowing variables, remove empty declarations, make member functions
 static when possible and fix small bugs due to calling virtual functions
in destructors.