### PR TITLE
Add 'csv' format to the 'transform' reporter

### DIFF
--- a/docs/transform.rst
+++ b/docs/transform.rst
@@ -72,6 +72,32 @@ allocated do not appear in the graph by default.
 Check the `gprof2dot documentation <https://github.com/jrfonseca/gprof2dot>`_ for more
 information on how to use the tool.
 
+csv
+~~~
+
+This format allows you to produce a `comma separated values
+<https://en.wikipedia.org/wiki/Comma-separated_values>`_ file with all the
+allocations that contributed to the process's memory high water mark. This can
+be very useful to analyze the information using other data analysis tools and
+libraries such as `pandas <https://pandas.pydata.org>`_.
+
+Every row in the CSV file represents a call stack where memory that contributed
+to the process's memory high water mark was allocated.
+
+The available columns are:
+
+* ``allocator``: the name of the allocator that performed the allocations.
+* ``num_allocations``: the number of different allocations performed at this
+  location by this thread and not deallocated before the high water mark.
+* ``size``: the total size in bytes of the allocations performed at this
+  location by this thread and not deallocated before the high water mark.
+* ``tid``: the thread id of the thread that performed the allocations.
+* ``thread_name``: the name of the thread that performed the allocations.
+* ``stack_trace``: the stack trace of the allocations. The stack trace is
+  represented as a ``|`` separated list of stack frames (most recent call
+  first), where each stack frame in the list has the following format:
+  ``<function_name>;<file_name>;<line_number>``.
+
 CLI Reference
 -------------
 

--- a/src/memray/commands/transform.py
+++ b/src/memray/commands/transform.py
@@ -25,9 +25,10 @@ class TransformCommand(HighWatermarkCommand):
         )
 
     def prepare_parser(self, parser: argparse.ArgumentParser) -> None:
+        formats = ", ".join(TransformReporter.SUFFIX_MAP)
         parser.add_argument(
             "format",
-            help="Format to use for the report",
+            help=f"Format to use for the report. Available formats: {formats}",
         )
         parser.add_argument(
             "-o",

--- a/tests/unit/test_transform_reporter.py
+++ b/tests/unit/test_transform_reporter.py
@@ -1,3 +1,4 @@
+import csv
 import json
 from io import StringIO
 
@@ -178,3 +179,197 @@ class TestGprof2DotTransformReporter:
             "functions": [],
             "version": 0,
         }
+
+
+class TestCSVTransformReporter:
+    HEADER = [
+        "allocator",
+        "num_allocations",
+        "size",
+        "tid",
+        "thread_name",
+        "stack_trace",
+    ]
+
+    def test_empty_report(self):
+        # GIVEN
+        reporter = TransformReporter(
+            [], format="csv", memory_records=[], native_traces=False
+        )
+        output = StringIO()
+
+        # WHEN
+        reporter.render_as_csv(output)
+        output.seek(0)
+
+        # THEN
+        header, *output_data = tuple(csv.reader(output))
+        assert header == self.HEADER
+        assert output_data == []
+
+    def test_single_allocation(self):
+        # GIVEN
+        peak_allocations = [
+            MockAllocationRecord(
+                tid=1,
+                address=0x1000000,
+                size=1024,
+                allocator=AllocatorType.MALLOC,
+                stack_id=1,
+                n_allocations=1,
+                _stack=[
+                    ("me", "fun.py", 12),
+                ],
+            ),
+        ]
+        output = StringIO()
+
+        reporter = TransformReporter(
+            peak_allocations, format="csv", memory_records=[], native_traces=False
+        )
+
+        # WHEN
+        reporter.render_as_csv(output)
+        output.seek(0)
+
+        # THEN
+        header, *output_data = tuple(csv.reader(output))
+        assert header == self.HEADER
+        assert output_data == [["MALLOC", "1", "1024", "1", "0x1", "me;fun.py;12"]]
+
+    def test_single_native_allocation(self):
+        # GIVEN
+        peak_allocations = [
+            MockAllocationRecord(
+                tid=1,
+                address=0x1000000,
+                size=1024,
+                allocator=AllocatorType.MALLOC,
+                stack_id=1,
+                n_allocations=1,
+                _hybrid_stack=[
+                    ("me", "fun.c", 12),
+                ],
+            ),
+        ]
+        output = StringIO()
+
+        reporter = TransformReporter(
+            peak_allocations, format="csv", memory_records=[], native_traces=True
+        )
+
+        # WHEN
+        reporter.render_as_csv(output)
+        output.seek(0)
+
+        # THEN
+        header, *output_data = tuple(csv.reader(output))
+        assert header == self.HEADER
+        assert output_data == [["MALLOC", "1", "1024", "1", "0x1", "me;fun.c;12"]]
+
+    def test_multiple_allocations(self):
+        # GIVEN
+        peak_allocations = [
+            MockAllocationRecord(
+                tid=1,
+                address=0x1000000,
+                size=1024,
+                allocator=AllocatorType.MALLOC,
+                stack_id=1,
+                n_allocations=1,
+                _stack=[
+                    ("me", "foo.py", 12),
+                ],
+            ),
+            MockAllocationRecord(
+                tid=1,
+                address=0x1100000,
+                size=2048,
+                allocator=AllocatorType.VALLOC,
+                stack_id=2,
+                n_allocations=10,
+                _stack=[
+                    ("you", "bar.py", 21),
+                ],
+            ),
+        ]
+
+        output = StringIO()
+
+        reporter = TransformReporter(
+            peak_allocations, format="csv", memory_records=[], native_traces=False
+        )
+
+        # WHEN
+        reporter.render_as_csv(output)
+        output.seek(0)
+
+        # THEN
+        header, *output_data = tuple(csv.reader(output))
+        assert header == self.HEADER
+        assert output_data == [
+            ["MALLOC", "1", "1024", "1", "0x1", "me;foo.py;12"],
+            ["VALLOC", "10", "2048", "1", "0x1", "you;bar.py;21"],
+        ]
+
+    def test_empty_stack_trace(self):
+        # GIVEN
+        peak_allocations = [
+            MockAllocationRecord(
+                tid=1,
+                address=0x1000000,
+                size=1024,
+                allocator=AllocatorType.MALLOC,
+                stack_id=1,
+                n_allocations=1,
+                _stack=[],
+            ),
+        ]
+        output = StringIO()
+
+        reporter = TransformReporter(
+            peak_allocations, format="csv", memory_records=[], native_traces=False
+        )
+
+        # WHEN
+        reporter.render_as_csv(output)
+        output.seek(0)
+
+        # THEN
+        header, *output_data = tuple(csv.reader(output))
+        assert header == self.HEADER
+        assert output_data == [["MALLOC", "1", "1024", "1", "0x1", ""]]
+
+    def test_multiple_stack_frames(self):
+        # GIVEN
+        peak_allocations = [
+            MockAllocationRecord(
+                tid=1,
+                address=0x1000000,
+                size=1024,
+                allocator=AllocatorType.MALLOC,
+                stack_id=1,
+                n_allocations=1,
+                _stack=[
+                    ("me", "foo.py", 12),
+                    ("you", "bar.py", 21),
+                ],
+            ),
+        ]
+        output = StringIO()
+
+        reporter = TransformReporter(
+            peak_allocations, format="csv", memory_records=[], native_traces=False
+        )
+
+        # WHEN
+        reporter.render_as_csv(output)
+        output.seek(0)
+
+        # THEN
+        header, *output_data = tuple(csv.reader(output))
+        assert header == self.HEADER
+
+        assert output_data == [
+            ["MALLOC", "1", "1024", "1", "0x1", "me;foo.py;12|you;bar.py;21"]
+        ]


### PR DESCRIPTION
When there are a lot of different allocations, some of the reporters that
we currently offer do not allow for a very granular inspection of the
data. This can happen for example when certain libraries like TensorFlow
or sklearn or pandas are imported as the number of allocations
goes easily to several thousand. In these situations, reporters like the
summary reporter are not helpful as the number of rows to display needs
to be really high and is not easy to analyze.

To allow other more specialized data analysis tools to work with the
data, add a new 'csv' output format to the 'transform' reporter that
will dump a comma-separated-value file with every allocation in the high
watermark as a row with columns representing different properties
of every allocation. The stack trace will be represented as a string
joined with characters that are illegal in function names.

Closes: #239

Signed-off-by: Pablo Galindo <pablogsal@gmail.com>
