### PR TITLE
Consider macOS to be fully supported

### DIFF
--- a/docs/supported_environments.rst
+++ b/docs/supported_environments.rst
@@ -18,7 +18,7 @@ Supported operating systems
 
 You will have the best Memray experience on Linux.
 
-We have experimental support for macOS 11 or newer. We cannot support older
+We also support macOS 11 or newer. We cannot support older
 macOS versions, as they don't provide a C++17 compatible runtime. Although all
 features work on macOS, the way that macOS applications and Python libraries
 are typically distributed often results in subpar native stacks on Mac. See

--- a/news/194.feature
+++ b/news/194.feature
@@ -1,0 +1,1 @@
+Memray is now fully supported on macOS, and the warnings that macOS support is experimental have been dropped.

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -367,14 +367,6 @@ cdef class Tracker:
         else:
             raise TypeError("destination must be a SocketDestination or FileDestination")
 
-    def __init__(self, object file_name=None, *, object destination=None,
-                  bool native_traces=False, unsigned int memory_interval_ms = 10,
-                  bool follow_fork=False, bool trace_python_allocators=False):
-        if sys.platform == "darwin":
-            pprint(":warning: [bold red] Memray support in MacOS is still experimental [/]:warning:", file=sys.stderr)
-            pprint("[yellow]Please report any issues at https://github.com/bloomberg/memray/issues[/]", file=sys.stderr)
-            pprint("", file=sys.stderr)
-
     def __cinit__(self, object file_name=None, *, object destination=None,
                   bool native_traces=False, unsigned int memory_interval_ms = 10,
                   bool follow_fork=False, bool trace_python_allocators=False):


### PR DESCRIPTION
Previously this warning would be printed each time a `Tracker` was constructed, which caused a lot of noise when `pytest-memray` was being used, since it creates one `Tracker` per pytest test. Now it will only be printed at most once per Python interpreter run.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>

Closes #194