### PR TITLE
Ensure the access to the FrameCollection class is synchronised

### DIFF
--- a/news/251.bugfix
+++ b/news/251.bugfix
@@ -1,0 +1,1 @@
+Fix a crash that can happen when two different threads try to register frames at the same time without the GIL held.


### PR DESCRIPTION
When we need to register a new Python frame that we have not seen before
or when we need to get the ID of an existing Python frame, we use the
FrameCollection class that manages the collection of known Python
frames. The mutation of this data structure was previously protected by
the GIL as we only do these operations on the Python tracing function,
but since the introduction of lazy frame registering, now operations
over the FrameCollection can happen under the allocation/deallocation
hooks directly, and therefore access is now non synchronised.

This problem is still very difficult to trigger because the only
situation when a race will occur is when two threads compete to write
and read from the FrameCollection at the same time and for this to
happen at least one of these threads needs to make native allocations
without the GIL held with pending frames that the frame collection has
never seen.

Closes #249
