### PR TITLE
Allow attaching Memray to a running process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,23 +49,28 @@ jobs:
     - name: Set up dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -qy libunwind-dev liblz4-dev pkg-config npm
+        sudo apt-get install -qy libunwind-dev liblz4-dev pkg-config npm gdb lldb
     - name: Install Python dependencies
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install tox tox-gh-actions
+    - name: Disable ptrace security restrictions
+      run: |
+        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
     - name: Run tox
       run: tox . -e py310-cov -vvv
 
   test_in_alpine:
     name: 'Test in Alpine Linux'
     runs-on: ubuntu-latest
-    container: python:3.10-alpine
+    container:
+      image: python:3.10-alpine
+      options: --cap-add=SYS_PTRACE
     steps:
     - uses: actions/checkout@v3
     - name: Set up dependencies
       run: |
-        apk add --update build-base libunwind-dev lz4-dev musl-dev python3-dev
+        apk add --update build-base libunwind-dev lz4-dev musl-dev python3-dev gdb lldb
     - name: Install Python dependencies
       run: |
         python3 -m pip install --upgrade pip

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      - name: Disable ptrace security restrictions
+        run: |
+          echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.2
         env:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -32,10 +32,10 @@ include .flake8
 include src/memray/py.typed
 
 recursive-include src/vendor *
-recursive-include src/memray *.pxd
 recursive-include src/memray *.py
 recursive-include src/memray *.pyi
 recursive-include src/memray *.html *.js *.css
 recursive-include src/memray *.pyx *.pxd
+recursive-include src/memray *.gdb *.lldb
 recursive-include src/memray/_memray *
 recursive-include tools *.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,10 @@ manylinux-x86_64-image = "manylinux2010"
 manylinux-i686-image = "manylinux2010"
 
 [tool.cibuildwheel.linux]
-before-all = "yum install -y libunwind-devel lz4-devel"
+before-all = [
+  "yum install -y libunwind-devel lz4-devel gdb",
+  "yum install -y lldb || echo 'lldb is not available'",
+]
 
 [tool.cibuildwheel.macos]
 before-all = [
@@ -67,4 +70,8 @@ before-all = [
   "cd lz4",
   "make",
   "make install"
+]
+before-test = [
+  "codesign --remove-signature /Library/Frameworks/Python.framework/Versions/*/bin/python3 || true",
+  "codesign --remove-signature /Library/Frameworks/Python.framework/Versions/*/Resources/Python.app/Contents/MacOS/Python || true",
 ]

--- a/setup.py
+++ b/setup.py
@@ -258,6 +258,19 @@ MEMRAY_TEST_EXTENSION = Extension(
     undef_macros=UNDEF_MACROS,
 )
 
+MEMRAY_INJECT_EXTENSION = Extension(
+    name="memray._inject",
+    sources=[
+        "src/memray/_memray/inject.cpp",
+    ],
+    language="c++",
+    extra_compile_args=["-std=c++17", "-Wall", *EXTRA_COMPILE_ARGS],
+    extra_link_args=["-std=c++17", *EXTRA_LINK_ARGS],
+    define_macros=DEFINE_MACROS,
+    undef_macros=UNDEF_MACROS,
+    py_limited_api=True,
+)
+
 
 if not (IS_LINUX or IS_MAC):
     raise RuntimeError(f"memray does not support this platform ({platform})")
@@ -295,7 +308,7 @@ setup(
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     ext_modules=cythonize(
-        [MEMRAY_EXTENSION, MEMRAY_TEST_EXTENSION],
+        [MEMRAY_EXTENSION, MEMRAY_TEST_EXTENSION, MEMRAY_INJECT_EXTENSION],
         include_path=["src/memray"],
         compiler_directives=COMPILER_DIRECTIVES,
     ),

--- a/src/memray/_memray.pyi
+++ b/src/memray/_memray.pyi
@@ -184,3 +184,6 @@ class SymbolicSupport(enum.IntEnum):
     TOTAL: int
 
 def get_symbolic_support() -> SymbolicSupport: ...
+
+RTLD_NOW: int
+RTLD_DEFAULT: int

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -920,3 +920,12 @@ def get_symbolic_support():
             return SymbolicSupport.FUNCTION_NAME_ONLY
         return SymbolicSupport.TOTAL
     return SymbolicSupport.NONE
+
+
+cdef extern from "<dlfcn.h>":
+    int _RTLD_NOW "RTLD_NOW"
+    void* _RTLD_DEFAULT "RTLD_DEFAULT"
+
+
+RTLD_NOW = _RTLD_NOW
+RTLD_DEFAULT = <long long>_RTLD_DEFAULT

--- a/src/memray/_memray/CMakeLists.txt
+++ b/src/memray/_memray/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 add_library(
   _memray STATIC
   ${MEMRAY_LINKER_FILE}
+  inject.cpp
   compat.cpp
   hooks.cpp
   logging.cpp

--- a/src/memray/_memray/inject.cpp
+++ b/src/memray/_memray/inject.cpp
@@ -234,8 +234,9 @@ memray_spawn_client(int port)
     pthread_t thread;
     const int rc = pthread_create(&thread, nullptr, &memray::thread_body, (void*)(uintptr_t)port);
     if (0 != rc) {
-        return "Failed to create thread!";
+        return "MEMRAY: Failed to create thread!";
     }
 
-    return nullptr;
+    // Note: this string is used as a sentinel in attach.py!
+    return "MEMRAY: thread successfully created.";
 }

--- a/src/memray/_memray/inject.cpp
+++ b/src/memray/_memray/inject.cpp
@@ -1,0 +1,241 @@
+#define Py_LIMITED_API 0x03070000
+#include "Python.h"
+
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <iostream>
+
+namespace memray {
+namespace {  // unnamed
+
+int
+connect_client(const uint16_t port)
+{
+    struct addrinfo hints = {};
+    struct addrinfo* all_addresses = nullptr;
+
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    const std::string port_str = std::to_string(port);
+    const int rv = ::getaddrinfo(nullptr, port_str.c_str(), &hints, &all_addresses);
+    if (rv != 0) {
+        std::cerr << "getaddrinfo() failed while trying to attach Memray: " << ::gai_strerror(rv);
+        return -1;
+    }
+
+    int sockfd;
+    for (const struct addrinfo* curr_address = all_addresses; curr_address != nullptr;
+         curr_address = curr_address->ai_next)
+    {
+        sockfd = ::socket(curr_address->ai_family, curr_address->ai_socktype, curr_address->ai_protocol);
+        if (sockfd == -1) {
+            continue;
+        }
+
+        if (::connect(sockfd, curr_address->ai_addr, curr_address->ai_addrlen) == -1) {
+            ::close(sockfd);
+            sockfd = -1;
+            continue;
+        }
+        break;
+    }
+    ::freeaddrinfo(all_addresses);
+    return sockfd;
+}
+
+bool
+sendall(const int fd, std::string_view data)
+{
+    size_t length = data.size();
+    while (length) {
+        const ssize_t ret = ::send(fd, data.data(), length, 0);
+        if (ret < 0 && errno != EINTR) {
+            return false;
+        } else if (ret >= 0) {
+            data.remove_prefix(ret);
+            length -= ret;
+        }
+    }
+    return true;
+}
+
+bool
+recvall(const int fd, std::string* data)
+{
+    data->clear();
+
+    char buf[4096];
+    while (true) {
+        const ssize_t ret = ::recv(fd, buf, sizeof(buf), 0);
+        if (ret < 0 && errno != EINTR) {
+            return false;
+        } else if (ret > 0) {
+            *data += std::string_view(buf, ret);
+        } else if (ret == 0) {
+            return true;
+        }
+    }
+}
+
+// Clear the error indicator, return a string representing the error.
+std::string
+Memray_PyErr_ToString()
+{
+    std::string ret;
+
+    if (!PyErr_Occurred()) {
+        return ret;
+    }
+
+    PyObject* type;
+    PyObject* val;
+    PyObject* tb;
+    PyErr_Fetch(&type, &val, &tb);
+    PyErr_NormalizeException(&type, &val, &tb);
+
+    PyObject* exc_repr = PyObject_Repr(val);
+    if (!exc_repr) {
+        PyErr_Clear();
+        ret = "unknown exception (`repr(exc)` failed)!";
+    } else {
+        PyObject* utf8 = PyUnicode_AsUTF8String(exc_repr);
+        if (!utf8) {
+            PyErr_Clear();
+            ret = "unknown exception (`repr(exc).encode('utf-8')` failed)!";
+        } else {
+            ret = PyBytes_AsString(utf8);
+        }
+        Py_XDECREF(utf8);
+    }
+    Py_XDECREF(exc_repr);
+
+    Py_XDECREF(type);
+    Py_XDECREF(val);
+    Py_XDECREF(tb);
+
+    return ret;
+}
+
+bool
+run_script_impl(const std::string& script, std::string* errmsg)
+{
+    int rc;
+
+    PyObject* builtins = nullptr;
+    PyObject* globals = nullptr;
+    PyObject* code = nullptr;
+    PyObject* mod = nullptr;
+    bool success = false;
+
+    builtins = PyImport_ImportModule("builtins");
+    if (!builtins) {
+        goto done;
+    }
+
+    globals = PyDict_New();
+    if (!globals) {
+        goto done;
+    }
+
+    // Needed on 3.7 to avoid ImportError('__import__ not found')
+    rc = PyDict_SetItemString(globals, "__builtins__", builtins);
+    if (0 != rc) {
+        goto done;
+    }
+
+    code = Py_CompileString(script.data(), "_memray_attach_hook.py", Py_file_input);
+    if (!code) {
+        goto done;
+    }
+
+    mod = PyEval_EvalCode(code, globals, globals);
+    if (!mod) {
+        goto done;
+    }
+
+    success = true;
+
+done:
+    Py_XDECREF(mod);
+    Py_XDECREF(code);
+    Py_XDECREF(globals);
+    Py_XDECREF(builtins);
+
+    *errmsg = Memray_PyErr_ToString();
+    return success;
+}
+
+bool
+run_script(const std::string& script, std::string* errmsg)
+{
+    if (!Py_IsInitialized()) {
+        *errmsg = "Python is not initialized";
+        return false;
+    }
+
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+    const bool ret = run_script_impl(script, errmsg);
+    PyGILState_Release(gstate);
+    return ret;
+}
+
+void
+run_client(const uint16_t port)
+{
+    const int sock = connect_client(port);
+    if (sock == -1) {
+        std::cerr << "memray attach failed!" << std::endl;
+        return;
+    }
+
+    std::string script;
+    if (!recvall(sock, &script)) {
+        std::cerr << "memray attach socket read error!" << std::endl;
+        return;
+    }
+
+    std::string errmsg;
+    bool success = run_script(script.c_str(), &errmsg);
+
+    if (!success) {
+        sendall(sock, errmsg);
+    }
+    ::close(sock);
+}
+
+extern "C" void*
+thread_body(void* arg)
+{
+    int rc = pthread_detach(pthread_self());
+    if (0 != rc) {
+        std::cerr << "Failed to detach thread!" << std::endl;
+    }
+
+    uint16_t port = reinterpret_cast<uintptr_t>(arg);
+    run_client(port);
+    return nullptr;
+}
+
+}  // unnamed namespace
+}  // namespace memray
+
+extern "C" __attribute__((visibility("default"))) const char*
+memray_spawn_client(int port)
+{
+    // Running Python code directly in the point of attaching can lead to
+    // crashes as we don't know if the interpreter is ready to execute code.
+    // For instance, we can be in the middle of modifying the GC linked list
+    // or doing some other operation that is not reentrant. Instead, we spawn
+    // a new thread that will try to grab the GIL and run the code there.
+    pthread_t thread;
+    const int rc = pthread_create(&thread, nullptr, &memray::thread_body, (void*)(uintptr_t)port);
+    if (0 != rc) {
+        return "Failed to create thread!";
+    }
+
+    return nullptr;
+}

--- a/src/memray/commands/__init__.py
+++ b/src/memray/commands/__init__.py
@@ -14,6 +14,7 @@ from memray._errors import MemrayCommandError
 from memray._errors import MemrayError
 from memray._memray import set_log_level
 
+from . import attach
 from . import flamegraph
 from . import live
 from . import parse
@@ -64,6 +65,7 @@ _COMMANDS: List[Command] = [
     summary.SummaryCommand(),
     stats.StatsCommand(),
     transform.TransformCommand(),
+    attach.AttachCommand(),
 ]
 
 

--- a/src/memray/commands/_attach.gdb
+++ b/src/memray/commands/_attach.gdb
@@ -1,13 +1,20 @@
+p "MEMRAY: Attached to process."
+
 set unwindonsignal on
 sharedlibrary libc
 sharedlibrary libdl
 sharedlibrary musl
 sharedlibrary libpython
 info sharedlibrary
+
+p "MEMRAY: Checking if process is Python 3.7+."
+
 p PyMem_Malloc
 p PyMem_Calloc
 p PyMem_Realloc
 p PyMem_Free
+
+p "MEMRAY: Process is Python 3.7+."
 
 # When updating this list, also update the "commands" call below,
 # and the breakpoints hardcoded for lldb in attach.py

--- a/src/memray/commands/_attach.gdb
+++ b/src/memray/commands/_attach.gdb
@@ -1,0 +1,30 @@
+set unwindonsignal on
+sharedlibrary libc
+sharedlibrary libdl
+sharedlibrary musl
+sharedlibrary libpython
+info sharedlibrary
+p PyMem_Malloc
+p PyMem_Calloc
+p PyMem_Realloc
+p PyMem_Free
+
+# When updating this list, also update the "commands" call below,
+# and the breakpoints hardcoded for lldb in attach.py
+b malloc
+b calloc
+b realloc
+b free
+b PyMem_Malloc
+b PyMem_Calloc
+b PyMem_Realloc
+b PyMem_Free
+# Apply commands to all 8 breakpoints above
+commands 1 2 3 4 5 6 7 8
+    disable breakpoints
+    call (void*)dlopen($libpath, $rtld_now)
+    p (char*)dlerror()
+    eval "sharedlibrary %s", $libpath
+    call (const char*)memray_spawn_client($port)
+end
+continue

--- a/src/memray/commands/_attach.lldb
+++ b/src/memray/commands/_attach.lldb
@@ -1,0 +1,21 @@
+p ((void*(*)(size_t))PyMem_Malloc)
+p ((void*(*)(size_t, size_t))PyMem_Calloc)
+p ((void*(*)(void *, size_t))PyMem_Realloc)
+p ((void(*)(void*))PyMem_Free)
+
+# When adding new breakpoints, also update _attach.gdb
+breakpoint set -b malloc -b calloc -b realloc -b free -b PyMem_Malloc -b PyMem_Calloc -b PyMem_Realloc -b PyMem_Free
+
+# Set commands to execute when breakpoint is reached
+breakpoint command add -e true
+breakpoint disable
+expr auto $dlsym = (void* (*)(void*, const char*))&dlsym
+expr auto $dlopen = $dlsym($rtld_default, "dlopen")
+expr auto $dlerror = $dlsym($rtld_default, "dlerror")
+expr auto $dll = ((void*(*)(const char*, int))$dlopen)($libpath, $rtld_now)
+p ((char*(*)(void))$dlerror)()
+expr auto $spawn = $dlsym($dll, "memray_spawn_client")
+p ((const char*(*)(int))$spawn)($port)
+DONE
+
+continue

--- a/src/memray/commands/_attach.lldb
+++ b/src/memray/commands/_attach.lldb
@@ -1,7 +1,13 @@
+p "MEMRAY: Attached to process."
+
+p "MEMRAY: Checking if process is Python 3.7+."
+
 p ((void*(*)(size_t))PyMem_Malloc)
 p ((void*(*)(size_t, size_t))PyMem_Calloc)
 p ((void*(*)(void *, size_t))PyMem_Realloc)
 p ((void(*)(void*))PyMem_Free)
+
+p "MEMRAY: Process is Python 3.7+."
 
 # When adding new breakpoints, also update _attach.gdb
 breakpoint set -b malloc -b calloc -b realloc -b free -b PyMem_Malloc -b PyMem_Calloc -b PyMem_Realloc -b PyMem_Free

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -1,0 +1,347 @@
+import argparse
+import contextlib
+import os
+import pathlib
+import shlex
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import threading
+
+import memray
+from memray._errors import MemrayCommandError
+
+from .live import LiveCommand
+from .run import _get_free_port
+
+GDB_SCRIPT = pathlib.Path(__file__).parent / "_attach.gdb"
+LLDB_SCRIPT = pathlib.Path(__file__).parent / "_attach.lldb"
+RTLD_DEFAULT = memray._memray.RTLD_DEFAULT
+RTLD_NOW = memray._memray.RTLD_NOW
+PAYLOAD = """
+import atexit
+
+import memray
+
+
+def deactivate_last_tracker():
+    tracker = getattr(memray, "_last_tracker", None)
+    if not tracker:
+        return
+
+    memray._last_tracker = None
+    tracker.__exit__(None, None, None)
+
+
+if not hasattr(memray, "_last_tracker"):
+    # This only needs to be registered the first time we attach.
+    atexit.register(deactivate_last_tracker)
+
+deactivate_last_tracker()
+
+tracker = {tracker_call}
+try:
+    tracker.__enter__()
+except:
+    # Prevent the exception from keeping the tracker alive.
+    # This way resources are cleaned up ASAP.
+    del tracker
+    raise
+
+memray._last_tracker = tracker
+"""
+
+
+def inject(debugger: str, pid: int, port: int, verbose: bool) -> bool:
+    """Executes a file in a running Python process."""
+    injecter = pathlib.Path(memray.__file__).parent / "_inject.abi3.so"
+    assert injecter.exists()
+
+    gdb_cmd = [
+        "gdb",
+        "-batch",
+        "-p",
+        str(pid),
+        "-nx",
+        "-nw",
+        "-iex=set auto-solib-add off",
+        f"-ex=set $rtld_now={RTLD_NOW}",
+        f'-ex=set $libpath="{injecter}"',
+        f"-ex=set $port={port}",
+        f"-x={GDB_SCRIPT}",
+    ]
+
+    lldb_cmd = [
+        "lldb",
+        "--batch",
+        "-p",
+        str(pid),
+        "--no-lldbinit",
+        "-o",
+        f'expr char $libpath[]="{injecter}"',
+        "-o",
+        f"expr int $port={port}",
+        "-o",
+        f"expr void* $rtld_default=(void*){RTLD_DEFAULT}",
+        "-o",
+        f"expr int $rtld_now={RTLD_NOW}",
+        "--source",
+        f"{LLDB_SCRIPT}",
+    ]
+
+    cmd = gdb_cmd if debugger == "gdb" else lldb_cmd
+    if verbose:
+        if sys.version_info >= (3, 8):
+            print("Debugger command line:", shlex.join(cmd))
+        else:
+            print("Debugger command line:", cmd)
+
+    try:
+        output = subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT)
+        returncode = 0
+    except subprocess.CalledProcessError as exc:
+        output = exc.output
+        returncode = exc.returncode
+
+    if verbose:
+        print(f"debugger return code: {returncode}")
+        print(f"debugger output:\n{output}")
+
+    return (
+        returncode == 0
+        and "error:" not in output
+        and "unrecognized option" not in output
+        and "Operation not permitted" not in output
+        and "attach failed" not in output
+        and "Error in sourced command file" not in output
+    )
+
+
+def _gdb_available(verbose: bool) -> bool:
+    if not shutil.which("gdb"):
+        if verbose:
+            print("No gdb executable found")
+        return False
+    return True
+
+
+def _lldb_available(verbose: int) -> bool:
+    # We need a version of lldb that supports `--batch`. This should be lldb
+    # 3.5.2 or newer, but the version string format doesn't appear consistent
+    # between macOS and Linux, so it's safer to just check the help output to
+    # make sure that option is documented.
+    try:
+        help_str = subprocess.check_output(
+            ["lldb", "--help"],
+            text=True,
+            stderr=subprocess.STDOUT,
+        )
+    except FileNotFoundError:
+        if verbose:
+            print("No lldb executable found")
+        return False
+    except subprocess.CalledProcessError as exc:
+        if verbose:
+            print(f"`lldb --version` failed: {exc.output}")
+        return False
+
+    if "--batch" not in help_str:
+        if verbose:
+            print("lldb does not support --batch, which we require")
+        return False
+
+    return True
+
+
+def debugger_available(debugger: str, verbose: bool = False) -> bool:
+    return {"gdb": _gdb_available, "lldb": _lldb_available}[debugger](verbose=verbose)
+
+
+def recvall(sock: socket.socket) -> str:
+    return b"".join(iter(lambda: sock.recv(4096), b"")).decode("utf-8")
+
+
+class ErrorReaderThread(threading.Thread):
+    def __init__(self, sock: socket.socket) -> None:
+        self._sock = sock
+        super().__init__()
+
+    def run(self) -> None:
+        try:
+            err = recvall(self._sock)
+        except OSError as e:
+            err = f"Unexpected exception: {e!r}"
+
+        if not err:
+            self.error = None
+            return
+
+        self.error = err
+        os.kill(os.getpid(), signal.SIGINT)
+
+
+class AttachCommand:
+    """Remotely monitor allocations in a text-based interface"""
+
+    def prepare_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "-o",
+            "--output",
+            help="Create a capture file instead of starting a live tracking session",
+        )
+        parser.add_argument(
+            "-f",
+            "--force",
+            help="If the output file already exists, overwrite it",
+            action="store_true",
+            default=False,
+        )
+
+        parser.add_argument(
+            "--native",
+            help="Track native (C/C++) stack frames as well",
+            action="store_true",
+            dest="native",
+            default=False,
+        )
+        parser.add_argument(
+            "--follow-fork",
+            action="store_true",
+            help="Record allocations in child processes forked from the tracked script",
+            default=False,
+        )
+        parser.add_argument(
+            "--trace-python-allocators",
+            action="store_true",
+            help="Record allocations made by the Pymalloc allocator",
+            default=False,
+        )
+        compression = parser.add_mutually_exclusive_group()
+        compression.add_argument(
+            "--compress-on-exit",
+            help="Compress the resulting file using lz4 after tracking completes",
+            default=True,
+            action="store_true",
+        )
+        compression.add_argument(
+            "--no-compress",
+            help="Do not compress the resulting file using lz4",
+            default=False,
+            action="store_true",
+        )
+
+        parser.add_argument(
+            "--method",
+            help="Method to use for injecting code into the process to track",
+            type=str,
+            default="auto",
+            choices=["auto", "gdb", "lldb"],
+        )
+
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Print verbose debugging information.",
+            action="store_true",
+        )
+
+        parser.add_argument(
+            "pid",
+            help="Remote pid to attach to",
+            type=int,
+        )
+
+    def run(self, args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+        verbose = args.verbose
+
+        if args.method == "auto":
+            if debugger_available("lldb", verbose=verbose):
+                args.method = "lldb"
+            elif debugger_available("gdb", verbose=verbose):
+                args.method = "gdb"
+            else:
+                raise MemrayCommandError(
+                    "Cannot find a supported lldb or gdb executable.",
+                    exit_code=1,
+                )
+        elif not debugger_available(args.method, verbose=verbose):
+            raise MemrayCommandError(
+                f"Cannot find a supported {args.method} executable.",
+                exit_code=1,
+            )
+
+        destination: memray.Destination
+        if args.output:
+            live_port = None
+            destination = memray.FileDestination(
+                path=os.path.abspath(args.output),
+                overwrite=args.force,
+                compress_on_exit=not args.no_compress,
+            )
+        else:
+            live_port = _get_free_port()
+            destination = memray.SocketDestination(server_port=live_port)
+
+        tracker_call = (
+            f"memray.Tracker(destination=memray.{destination!r},"
+            f" native_traces={args.native},"
+            f" follow_fork={args.follow_fork},"
+            f" trace_python_allocators={args.trace_python_allocators})"
+        )
+
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        with contextlib.closing(server):
+            server.bind(("localhost", 0))
+            server.listen(1)
+            sidechannel_port = server.getsockname()[1]
+
+            if not inject(args.method, args.pid, sidechannel_port, verbose=verbose):
+                raise MemrayCommandError(
+                    "Failed to attach to remote process.",
+                    exit_code=1,
+                )
+
+            client = server.accept()[0]
+
+        client.sendall(PAYLOAD.format(tracker_call=tracker_call).encode("utf-8"))
+        client.shutdown(socket.SHUT_WR)
+
+        if not live_port:
+            err = recvall(client)
+            if err:
+                raise MemrayCommandError(
+                    f"Failed to start tracking in remote process: {err}",
+                    exit_code=1,
+                )
+            return
+
+        # If an error prevents the tracked process from binding a server to
+        # live_port, the TUI will hang forever trying to connect. Handle this
+        # by spawning a background thread that watches for an error report over
+        # the side channel and raises a SIGINT to interrupt the TUI if it sees
+        # one. This can race, though: in some cases the TUI will also see an
+        # error (if no header is sent over the socket), and the background
+        # thread may raise a SIGINT that we see only after the live TUI has
+        # already exited. If so we must ignore the extra KeyboardInterrupt.
+        error_reader = ErrorReaderThread(client)
+        error_reader.start()
+        live = LiveCommand()
+
+        with contextlib.suppress(KeyboardInterrupt):
+            try:
+                try:
+                    live.start_live_interface(live_port)
+                finally:
+                    # Note: may get a spurious KeyboardInterrupt!
+                    error_reader.join()
+            except (Exception, KeyboardInterrupt):
+                remote_err = error_reader.error
+                if not remote_err:
+                    raise  # Propagate the exception
+
+                raise MemrayCommandError(
+                    f"Failed to start tracking in remote process: {remote_err}",
+                    exit_code=1,
+                ) from None

--- a/tests/integration/test_attach.py
+++ b/tests/integration/test_attach.py
@@ -1,0 +1,116 @@
+import subprocess
+import sys
+
+import pytest
+
+from memray import AllocatorType
+from memray import FileReader
+from memray.commands.attach import debugger_available
+from tests.utils import filter_relevant_allocations
+
+PROGRAM = """
+import sys
+import threading
+
+from memray._test import MemoryAllocator
+
+stop_bg_thread = threading.Event()
+
+
+def bg_thread_body():
+    bg_allocator = MemoryAllocator()
+    while not stop_bg_thread.is_set():
+        bg_allocator.malloc(1024)
+        bg_allocator.free()
+
+
+def foo():
+    bar()
+
+
+def bar():
+    baz()
+
+
+def baz():
+    allocator = MemoryAllocator()
+    allocator.valloc(1024)
+    allocator.free()
+
+
+# attach waits for a call to an allocator or deallocator, so we can't just
+# block waiting for a signal. Allocate and free in a loop in the background.
+bg_thread = threading.Thread(target=bg_thread_body)
+bg_thread.start()
+
+print("ready")
+for line in sys.stdin:
+    if not stop_bg_thread.is_set():
+        stop_bg_thread.set()
+        bg_thread.join()
+    foo()
+"""
+
+
+@pytest.mark.parametrize("method", ["lldb", "gdb"])
+def test_basic_attach(tmp_path, method):
+    if not debugger_available(method):
+        pytest.skip(f"a supported {method} debugger isn't installed")
+
+    # GIVEN
+    output = tmp_path / "test.bin"
+    tracked_process = subprocess.Popen(
+        [sys.executable, "-uc", PROGRAM],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    # Help the type checker out...
+    assert tracked_process.stdin is not None
+    assert tracked_process.stdout is not None
+
+    assert tracked_process.stdout.readline() == "ready\n"
+    attach_cmd = [
+        sys.executable,
+        "-m",
+        "memray",
+        "attach",
+        "--verbose",
+        "--method",
+        method,
+        "-o",
+        str(output),
+        str(tracked_process.pid),
+    ]
+
+    # WHEN
+    try:
+        subprocess.check_output(attach_cmd, stderr=subprocess.STDOUT, text=True)
+    except subprocess.CalledProcessError as exc:
+        if "Couldn't write extended state status" in exc.output:
+            # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=898048
+            pytest.xfail("gdb < 8 does not support this CPU")
+        else:
+            print(exc.output)
+            raise
+    finally:
+        tracked_process.stdin.write("1\n")
+        tracked_process.stdin.close()
+        tracked_process.wait()
+
+    # THEN
+    assert "" == tracked_process.stdout.read()
+    assert tracked_process.returncode == 0
+
+    reader = FileReader(output)
+    records = list(reader.get_allocation_records())
+    vallocs = [
+        record
+        for record in filter_relevant_allocations(records)
+        if record.allocator == AllocatorType.VALLOC
+    ]
+
+    (valloc,) = vallocs
+    functions = [f[0] for f in valloc.stack_trace()]
+    assert functions == ["valloc", "baz", "bar", "foo", "<module>"]


### PR DESCRIPTION
Use a debugger (currently gdb or lldb) to inject code to initiate Memray tracking into an already-running process, provided that the process is running in an environment where `memray` can be imported.

Closes #218 