### PR TITLE
attach: Return an int from the trampoline function

### DIFF
--- a/src/memray/_memray/inject.cpp
+++ b/src/memray/_memray/inject.cpp
@@ -223,7 +223,7 @@ thread_body(void* arg)
 }  // unnamed namespace
 }  // namespace memray
 
-extern "C" __attribute__((visibility("default"))) const char*
+extern "C" __attribute__((visibility("default"))) int
 memray_spawn_client(int port)
 {
     // Running Python code directly in the point of attaching can lead to
@@ -232,11 +232,5 @@ memray_spawn_client(int port)
     // or doing some other operation that is not reentrant. Instead, we spawn
     // a new thread that will try to grab the GIL and run the code there.
     pthread_t thread;
-    const int rc = pthread_create(&thread, nullptr, &memray::thread_body, (void*)(uintptr_t)port);
-    if (0 != rc) {
-        return "MEMRAY: Failed to create thread!";
-    }
-
-    // Note: this string is used as a sentinel in attach.py!
-    return "MEMRAY: thread successfully created.";
+    return pthread_create(&thread, nullptr, &memray::thread_body, (void*)(uintptr_t)port);
 }

--- a/src/memray/commands/_attach.gdb
+++ b/src/memray/commands/_attach.gdb
@@ -32,6 +32,6 @@ commands 1 2 3 4 5 6 7 8
     call (void*)dlopen($libpath, $rtld_now)
     p (char*)dlerror()
     eval "sharedlibrary %s", $libpath
-    call (const char*)memray_spawn_client($port)
+    p (int)memray_spawn_client($port) ? "FAILURE" : "SUCCESS"
 end
 continue

--- a/src/memray/commands/_attach.lldb
+++ b/src/memray/commands/_attach.lldb
@@ -21,7 +21,7 @@ expr auto $dlerror = $dlsym($rtld_default, "dlerror")
 expr auto $dll = ((void*(*)(const char*, int))$dlopen)($libpath, $rtld_now)
 p ((char*(*)(void))$dlerror)()
 expr auto $spawn = $dlsym($dll, "memray_spawn_client")
-p ((const char*(*)(int))$spawn)($port)
+p ((int(*)(int))$spawn)($port) ? "FAILURE" : "SUCCESS"
 DONE
 
 continue

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -111,7 +111,7 @@ def inject(debugger: str, pid: int, port: int, verbose: bool) -> str | None:
         print(f"debugger return code: {returncode}")
         print(f"debugger output:\n{output}")
 
-    if returncode == 0 and "MEMRAY: thread successfully created." in output:
+    if returncode == 0 and ' = "SUCCESS"' in output:
         return None
 
     # An error occurred. Give the best message we can. This is hacky; we don't

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -258,6 +258,15 @@
    ...
 }
 
+{
+   <insert_a_suppression_name_here>
+   Helgrind:Race
+   fun:*Tracker*BackgroundThread*start*
+   ...
+   fun:start_thread
+   fun:clone
+}
+
 # Python GIL false positives
 
 {


### PR DESCRIPTION
Previously we were returning a `const char*` pointer to a string literal, which we would then print in the debugger and check for in the `memray attach` code to ensure that it was printed. But, under some mysterious circumstances `gdb` could fail to print out the string that we've returned a pointer to, with "Address 0x7a1e7b90 out of bounds".

I don't really understand the root cause, but we can work around the issue by returning something simpler instead. We'll return just an int rather than a pointer to memory in the process we've attached to, and we'll make the debugger sessions either exit with an error code (gdb) or print a sentinel string we can recognize (lldb) if an error occurred.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>
