### PR TITLE
Mark frames from the import system as irrelevant

### DIFF
--- a/news/268.feature
+++ b/news/268.feature
@@ -1,0 +1,1 @@
+Consider frames from the import system as "irrelevant" in the generated flamegraphs.

--- a/src/memray/reporters/flamegraph.py
+++ b/src/memray/reporters/flamegraph.py
@@ -58,7 +58,10 @@ def create_framegraph_node_from_stack_frame(
         "children": {},
         "n_allocations": 0,
         "thread_id": 0,
-        "interesting": is_frame_interesting(stack_frame),
+        "interesting": (
+            is_frame_interesting(stack_frame)
+            and not is_frame_from_import_system(stack_frame)
+        ),
         **kwargs,
     }
 

--- a/src/memray/reporters/templates/flamegraph.html
+++ b/src/memray/reporters/templates/flamegraph.html
@@ -14,7 +14,7 @@
 <div class="form-check mr-3">
   <input class="form-check-input" type="checkbox" data-toggle="tooltip" id="hideUninteresting"
           title="Hide CPython eval frames and other, memray-related frames" checked>
-    <label class="form-check-label text-white bg-dark">Hide Non-Relevant Frames</label>
+    <label class="form-check-label text-white bg-dark">Hide Irrelevant Frames</label>
 </div>
 <div class="form-check mr-3">
   <input class="form-check-input" type="checkbox" data-toggle="tooltip" id="hideImportSystem"
@@ -53,7 +53,7 @@
   Hovering over the frame you can also see the overall memory allocated in the given frame and its children and the number of times allocations have occurred.
 </p>
 <p>
-  The <b>Show/Hide Non-Relevant Frames</b> button can be used to reveal and hide frames which contain allocations in code which might not be
+  The <b>Show/Hide Irrelevant Frames</b> button can be used to reveal and hide frames which contain allocations in code which might not be
   relevant for the application. These include frames in the CPython eval loop as well as frames introduced by memray during the analysis.
 </p>
 <p>

--- a/tests/unit/test_flamegraph_reporter.py
+++ b/tests/unit/test_flamegraph_reporter.py
@@ -950,7 +950,7 @@ class TestFlameGraphReporter:
                 {
                     "children": [],
                     "import_system": True,
-                    "interesting": True,
+                    "interesting": False,
                     "location": ["me", "&lt;frozen importlib&gt;", "4"],
                     "n_allocations": 1,
                     "name": "me at <frozen importlib>:4",
@@ -1020,7 +1020,7 @@ class TestFlameGraphReporter:
                         }
                     ],
                     "import_system": True,
-                    "interesting": True,
+                    "interesting": False,
                     "location": ["grandparent", "&lt;frozen importlib&gt;", "4"],
                     "n_allocations": 1,
                     "name": "grandparent at <frozen importlib>:4",
@@ -1084,7 +1084,7 @@ class TestFlameGraphReporter:
                                         }
                                     ],
                                     "import_system": True,
-                                    "interesting": True,
+                                    "interesting": False,
                                     "location": [
                                         "parent",
                                         "&lt;frozen " "importlib&gt;",
@@ -1181,7 +1181,7 @@ class TestFlameGraphReporter:
                                 }
                             ],
                             "import_system": True,
-                            "interesting": True,
+                            "interesting": False,
                             "location": ["parent_one", "&lt;frozen importlib&gt;", "8"],
                             "n_allocations": 1,
                             "name": "parent_one at <frozen importlib>:8",
@@ -1317,7 +1317,7 @@ class TestFlameGraphReporter:
                         },
                     ],
                     "import_system": True,
-                    "interesting": True,
+                    "interesting": False,
                     "location": ["grandparent", "&lt;frozen importlib&gt;", "4"],
                     "n_allocations": 2,
                     "name": "grandparent at <frozen importlib>:4",


### PR DESCRIPTION
To reduce the noise of the import system frames, mark them as irrelevant
so they are hidden by default unless the checkbox to hide irrelevant
frames is not marked. Additionally, rename the checkbox from
"hide non-relevant" to "hide irrelevant" for clarity.
