### PR TITLE
docs: Fix changelog for 1.5.0 release

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -8,7 +8,7 @@ Changelog
 
 .. towncrier release notes start
 
-Memray 1.4.1 (2022-12-09)
+Memray 1.5.0 (2022-12-09)
 -------------------------
 
 Features


### PR DESCRIPTION
This was accidentally documented as 1.4.1.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>
