### PR TITLE
Fix an uninitialized variable

### DIFF
--- a/src/memray/_memray/inject.cpp
+++ b/src/memray/_memray/inject.cpp
@@ -26,7 +26,7 @@ connect_client(const uint16_t port)
         return -1;
     }
 
-    int sockfd;
+    int sockfd = -1;
     for (const struct addrinfo* curr_address = all_addresses; curr_address != nullptr;
          curr_address = curr_address->ai_next)
     {


### PR DESCRIPTION
This could be used uninitialized if for some reason `getaddrinfo` fails
to return any interfaces. That shouldn't happen, but we should
initialize this anyway.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>
