### PR TITLE
Respect `--trace-python-allocators` in live mode

### DIFF
--- a/news/283.bugfix.rst
+++ b/news/283.bugfix.rst
@@ -1,0 +1,1 @@
+``memray run --live`` and ``memray run --live-remote`` silently dropped the ``--trace-python-allocators`` flag. This has been fixed, and the flag is now properly propagated from the CLI to the tracker.


### PR DESCRIPTION
We had always intended this to be supported, but the flag was not properly propagated from the command line to the tracker. Correct this, and add tests to prevent a regression.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>