### PR TITLE
Don't call Tracker::popFrames unnecessarily

### DIFF
--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -198,8 +198,10 @@ PythonStackTracker::emitPendingPushesAndPops()
     auto first_to_emit = it.base();
 
     // Emit pending pops
-    Tracker::getTracker()->popFrames(d_num_pending_pops);
-    d_num_pending_pops = 0;
+    if (d_num_pending_pops) {
+        Tracker::getTracker()->popFrames(d_num_pending_pops);
+        d_num_pending_pops = 0;
+    }
 
     // Emit pending pushes
     for (auto to_emit = first_to_emit; to_emit != d_stack->end(); ++to_emit) {


### PR DESCRIPTION
This code was written to avoid an extra branch by unconditionally calling `popFrames` even if no frames need to be popped. When it was originally written that was a reasonable choice, because `popFrames` contained a loop and calling `popFrames(0)` wound up being a no-op because the loop condition was always false. That loop was later moved into the `RecordWriter`, and now calling `popFrames(0)` incurs an expensive mutex lock that we don't need to pay for, as well as a TLS fetch and a virtual method call.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>