### PR TITLE
Revamp tracker locking

### DIFF
--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -44,9 +44,6 @@ from _memray.socket_reader_thread cimport BackgroundSocketReader
 from _memray.source cimport FileSource
 from _memray.source cimport SocketSource
 from _memray.tracking_api cimport Tracker as NativeTracker
-from _memray.tracking_api cimport begin_tracking_greenlets
-from _memray.tracking_api cimport forget_python_stack
-from _memray.tracking_api cimport handle_greenlet_switch
 from _memray.tracking_api cimport install_trace_function
 from cpython cimport PyErr_CheckSignals
 from libc.stdint cimport uint64_t
@@ -296,7 +293,7 @@ cdef class ProfileFunctionGuard:
         deregistered when the PyThreadState is destroyed, so we can also use
         this to perform some cleanup when a thread dies.
         """
-        forget_python_stack()
+        NativeTracker.forgetPythonStack()
 
 
 cdef class Tracker:
@@ -405,7 +402,7 @@ cdef class Tracker:
         threading.setprofile(start_thread_trace)
 
         if "greenlet._greenlet" in sys.modules:
-            begin_tracking_greenlets()
+            NativeTracker.beginTrackingGreenlets()
 
         NativeTracker.createTracker(
             move(writer),
@@ -431,7 +428,7 @@ def start_thread_trace(frame, event, arg):
 
 def greenlet_trace_function(event, args):
     if event in {"switch", "throw"}:
-        handle_greenlet_switch(args[0], args[1])
+        NativeTracker.handleGreenletSwitch(args[0], args[1])
 
 
 def print_greenlet_warning():

--- a/src/memray/_memray/frame_tree.h
+++ b/src/memray/_memray/frame_tree.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <iostream>
-#include <mutex>
 #include <vector>
 
 #include "records.h"
@@ -13,7 +12,6 @@ class FrameTree
 
     inline std::pair<frame_id_t, index_t> nextNode(index_t index) const
     {
-        std::lock_guard<std::mutex> lock(d_mutex);
         assert(1 <= index && index <= d_graph.size());
         return std::make_pair(d_graph[index].frame_id, d_graph[index].parent_index);
     }
@@ -23,7 +21,6 @@ class FrameTree
     template<typename T>
     size_t getTraceIndex(const T& stack_trace, const tracecallback_t& callback)
     {
-        std::lock_guard<std::mutex> lock(d_mutex);
         index_t index = 0;
         for (const auto& frame : stack_trace) {
             index = getTraceIndexUnsafe(index, frame, callback);
@@ -33,7 +30,6 @@ class FrameTree
 
     size_t getTraceIndex(index_t parent_index, frame_id_t frame)
     {
-        std::lock_guard<std::mutex> lock(d_mutex);
         return getTraceIndexUnsafe(parent_index, frame, tracecallback_t());
     }
 
@@ -70,7 +66,6 @@ class FrameTree
         index_t parent_index;
         std::vector<DescendentEdge> children;
     };
-    mutable std::mutex d_mutex;
     std::vector<Node> d_graph{{0, 0, {}}};
 };
 }  // namespace memray::tracking_api

--- a/src/memray/_memray/hooks.cpp
+++ b/src/memray/_memray/hooks.cpp
@@ -277,7 +277,7 @@ dlopen(const char* filename, int flag) noexcept
     if (ret) {
         tracking_api::Tracker::invalidate_module_cache();
         if (filename && nullptr != strstr(filename, "/_greenlet.")) {
-            tracking_api::begin_tracking_greenlets();
+            tracking_api::Tracker::beginTrackingGreenlets();
         }
     }
     return ret;

--- a/src/memray/_memray/record_writer.cpp
+++ b/src/memray/_memray/record_writer.cpp
@@ -61,7 +61,6 @@ RecordWriter::setMainTidAndSkippedFrames(thread_id_t main_tid, size_t skipped_fr
 bool
 RecordWriter::writeHeader(bool seek_to_start)
 {
-    std::lock_guard<std::mutex> lock(d_mutex);
     if (seek_to_start) {
         // If we can't seek to the beginning to the stream (e.g. dealing with a socket), just give
         // up.
@@ -86,17 +85,10 @@ RecordWriter::writeHeader(bool seek_to_start)
 bool
 RecordWriter::writeTrailer()
 {
-    std::lock_guard<std::mutex> lock(d_mutex);
     // The FileSource will ignore trailing 0x00 bytes. This non-zero trailer
     // marks the boundary between bytes we wrote and padding bytes.
     RecordTypeAndFlags token{RecordType::OTHER, int(OtherRecordType::TRAILER)};
     return writeSimpleType(token);
-}
-
-std::unique_lock<std::mutex>
-RecordWriter::acquireLock()
-{
-    return std::unique_lock<std::mutex>(d_mutex);
 }
 
 std::unique_ptr<RecordWriter>

--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -5,7 +5,6 @@
 
 #include <fstream>
 #include <mutex>
-#include <shared_mutex>
 #include <stddef.h>
 #include <string>
 #include <tuple>
@@ -262,13 +261,9 @@ class FrameCollection
     template<typename T>
     auto getIndex(T&& frame) -> std::pair<frame_id_t, bool>
     {
-        std::shared_lock<std::shared_mutex> r_lock(d_mutex);
         bool inserted = false;
         auto it = d_frame_map.find(frame);
         if (it == d_frame_map.end()) {
-            r_lock.unlock();
-            std::unique_lock<std::shared_mutex> w_lock(d_mutex);
-
             std::tie(it, inserted) = d_frame_map.emplace(std::forward<T>(frame), d_current_frame_id);
             if (inserted) {
                 d_current_frame_id++;
@@ -280,7 +275,6 @@ class FrameCollection
   private:
     frame_id_t d_current_frame_id{};
     std::unordered_map<FrameType, frame_id_t, typename FrameType::Hash> d_frame_map{};
-    std::shared_mutex d_mutex;
 };
 
 using pyrawframe_map_val_t = std::pair<frame_id_t, RawFrame>;

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -1119,7 +1119,7 @@ PyTraceFunction(
 }
 
 void
-forget_python_stack()
+Tracker::forgetPythonStack()
 {
     if (!Tracker::isActive()) {
         return;
@@ -1130,14 +1130,14 @@ forget_python_stack()
 }
 
 void
-begin_tracking_greenlets()
+Tracker::beginTrackingGreenlets()
 {
     assert(PyGILState_Check());
     PythonStackTracker::s_greenlet_tracking_enabled = true;
 }
 
 void
-handle_greenlet_switch(PyObject* from, PyObject* to)
+Tracker::handleGreenletSwitch(PyObject* from, PyObject* to)
 {
     PythonStackTracker::get().handleGreenletSwitch(from, to);
 }

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -797,16 +797,21 @@ Tracker::computeMainTidSkip()
     return num_frames - 1;
 }
 
+bool
+Tracker::areNativeTracesEnabled()
+{
+    return PythonStackTracker::s_native_tracking_enabled;
+}
+
 void
-Tracker::trackAllocationImpl(void* ptr, size_t size, hooks::Allocator func)
+Tracker::trackAllocationImpl(void* ptr, size_t size, hooks::Allocator func, const NativeTrace& trace)
 {
     PythonStackTracker::get().emitPendingPushesAndPops();
 
     if (d_unwind_native_frames) {
-        NativeTrace trace;
         frame_id_t native_index = 0;
         // Skip the internal frames so we don't need to filter them later.
-        if (trace.fill(2)) {
+        if (trace.size()) {
             native_index = d_native_trace_tree.getTraceIndex(trace, [&](frame_id_t ip, uint32_t index) {
                 return d_writer->writeRecord(UnresolvedNativeFrame{ip, index});
             });

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -786,11 +786,6 @@ Tracker::computeMainTidSkip()
 void
 Tracker::trackAllocationImpl(void* ptr, size_t size, hooks::Allocator func)
 {
-    if (RecursionGuard::isActive || !Tracker::isActive()) {
-        return;
-    }
-    RecursionGuard guard;
-
     PythonStackTracker::get().emitPendingPushesAndPops();
 
     if (d_unwind_native_frames) {
@@ -819,11 +814,6 @@ Tracker::trackAllocationImpl(void* ptr, size_t size, hooks::Allocator func)
 void
 Tracker::trackDeallocationImpl(void* ptr, size_t size, hooks::Allocator func)
 {
-    if (RecursionGuard::isActive || !Tracker::isActive()) {
-        return;
-    }
-    RecursionGuard guard;
-
     AllocationRecord record{reinterpret_cast<uintptr_t>(ptr), size, func};
     if (!d_writer->writeThreadSpecificRecord(thread_id(), record)) {
         std::cerr << "Failed to write output, deactivating tracking" << std::endl;
@@ -834,7 +824,6 @@ Tracker::trackDeallocationImpl(void* ptr, size_t size, hooks::Allocator func)
 void
 Tracker::invalidate_module_cache_impl()
 {
-    RecursionGuard guard;
     d_patcher.overwrite_symbols();
     updateModuleCacheImpl();
 }

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -564,9 +564,10 @@ Tracker::Tracker(
     if (!d_writer->writeHeader(false)) {
         throw IoError{"Failed to write output header"};
     }
-    updateModuleCache();
 
     RecursionGuard guard;
+    updateModuleCacheImpl();
+
     PythonStackTracker::s_native_tracking_enabled = native_traces;
     PythonStackTracker::installProfileHooks();
     if (d_trace_python_allocators) {
@@ -835,7 +836,7 @@ Tracker::invalidate_module_cache_impl()
 {
     RecursionGuard guard;
     d_patcher.overwrite_symbols();
-    updateModuleCache();
+    updateModuleCacheImpl();
 }
 
 #ifdef __linux__

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -320,8 +320,8 @@ class Tracker
 
     // Data members
     FrameCollection<RawFrame> d_frames;
-    static std::unique_ptr<Tracker> d_instance_owner;
-    static std::atomic<Tracker*> d_instance;
+    static std::unique_ptr<Tracker> s_instance_owner;
+    static std::atomic<Tracker*> s_instance;
 
     std::shared_ptr<RecordWriter> d_writer;
     FrameTree d_native_trace_tree;

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -232,6 +232,11 @@ class Tracker
     __attribute__((always_inline)) inline static void
     trackAllocation(void* ptr, size_t size, hooks::Allocator func)
     {
+        if (RecursionGuard::isActive || !Tracker::isActive()) {
+            return;
+        }
+        RecursionGuard guard;
+
         Tracker* tracker = getTracker();
         if (tracker) {
             tracker->trackAllocationImpl(ptr, size, func);
@@ -241,6 +246,11 @@ class Tracker
     __attribute__((always_inline)) inline static void
     trackDeallocation(void* ptr, size_t size, hooks::Allocator func)
     {
+        if (RecursionGuard::isActive || !Tracker::isActive()) {
+            return;
+        }
+        RecursionGuard guard;
+
         Tracker* tracker = getTracker();
         if (tracker) {
             tracker->trackDeallocationImpl(ptr, size, func);
@@ -249,6 +259,11 @@ class Tracker
 
     __attribute__((always_inline)) inline static void invalidate_module_cache()
     {
+        if (RecursionGuard::isActive || !Tracker::isActive()) {
+            return;
+        }
+        RecursionGuard guard;
+
         Tracker* tracker = getTracker();
         if (tracker) {
             tracker->invalidate_module_cache_impl();
@@ -257,6 +272,11 @@ class Tracker
 
     __attribute__((always_inline)) inline static void registerThreadName(const char* name)
     {
+        if (RecursionGuard::isActive || !Tracker::isActive()) {
+            return;
+        }
+        RecursionGuard guard;
+
         Tracker* tracker = getTracker();
         if (tracker) {
             tracker->registerThreadNameImpl(name);

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -93,27 +93,6 @@ PyTraceTrampoline(PyObject* obj, PyFrameObject* frame, int what, PyObject* arg);
 void
 install_trace_function();
 
-/**
- * Drop any references to frames on this thread's stack.
- *
- * This should be called when either the thread is dying or our profile
- * function is being uninstalled from it.
- */
-void
-forget_python_stack();
-
-/**
- * Sets a flag to enable integration with the `greenlet` module.
- */
-void
-begin_tracking_greenlets();
-
-/**
- * Handle a notification of control switching from one greenlet to another.
- */
-void
-handle_greenlet_switch(PyObject* from, PyObject* to);
-
 class NativeTrace
 {
   public:
@@ -291,6 +270,24 @@ class Tracker
     static bool isActive();
     static void activate();
     static void deactivate();
+
+    /**
+     * Drop any references to frames on this thread's stack.
+     *
+     * This should be called when either the thread is dying or our profile
+     * function is being uninstalled from it.
+     */
+    static void forgetPythonStack();
+
+    /**
+     * Sets a flag to enable integration with the `greenlet` module.
+     */
+    static void beginTrackingGreenlets();
+
+    /**
+     * Handle a notification of control switching from one greenlet to another.
+     */
+    static void handleGreenletSwitch(PyObject* from, PyObject* to);
 
   private:
     class BackgroundThread

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -288,7 +288,7 @@ class Tracker
     bool popFrames(uint32_t count);
 
     // Interface to activate/deactivate the tracking
-    static const std::atomic<bool>& isActive();
+    static bool isActive();
     static void activate();
     static void deactivate();
 
@@ -320,7 +320,6 @@ class Tracker
 
     // Data members
     FrameCollection<RawFrame> d_frames;
-    static std::atomic<bool> d_active;
     static std::unique_ptr<Tracker> d_instance_owner;
     static std::atomic<Tracker*> d_instance;
 

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -255,14 +255,6 @@ class Tracker
         }
     }
 
-    __attribute__((always_inline)) inline static void updateModuleCache()
-    {
-        Tracker* tracker = getTracker();
-        if (tracker) {
-            tracker->updateModuleCacheImpl();
-        }
-    }
-
     __attribute__((always_inline)) inline static void registerThreadName(const char* name)
     {
         Tracker* tracker = getTracker();

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -216,6 +216,7 @@ class Tracker
         }
         RecursionGuard guard;
 
+        std::unique_lock<std::mutex> lock(*s_mutex);
         Tracker* tracker = getTracker();
         if (tracker) {
             tracker->trackAllocationImpl(ptr, size, func);
@@ -230,6 +231,7 @@ class Tracker
         }
         RecursionGuard guard;
 
+        std::unique_lock<std::mutex> lock(*s_mutex);
         Tracker* tracker = getTracker();
         if (tracker) {
             tracker->trackDeallocationImpl(ptr, size, func);
@@ -243,6 +245,7 @@ class Tracker
         }
         RecursionGuard guard;
 
+        std::unique_lock<std::mutex> lock(*s_mutex);
         Tracker* tracker = getTracker();
         if (tracker) {
             tracker->invalidate_module_cache_impl();
@@ -256,6 +259,7 @@ class Tracker
         }
         RecursionGuard guard;
 
+        std::unique_lock<std::mutex> lock(*s_mutex);
         Tracker* tracker = getTracker();
         if (tracker) {
             tracker->registerThreadNameImpl(name);
@@ -305,7 +309,6 @@ class Tracker
         std::shared_ptr<RecordWriter> d_writer;
         bool d_stop{false};
         unsigned int d_memory_interval;
-        std::mutex d_mutex;
         std::condition_variable d_cv;
         std::thread d_thread;
         mutable std::ifstream d_procs_statm;
@@ -316,16 +319,17 @@ class Tracker
     };
 
     // Data members
-    FrameCollection<RawFrame> d_frames;
+    static std::unique_ptr<std::mutex> s_mutex;
     static std::unique_ptr<Tracker> s_instance_owner;
     static std::atomic<Tracker*> s_instance;
 
+    FrameCollection<RawFrame> d_frames;
     std::shared_ptr<RecordWriter> d_writer;
     FrameTree d_native_trace_tree;
-    bool d_unwind_native_frames;
-    unsigned int d_memory_interval;
-    bool d_follow_fork;
-    bool d_trace_python_allocators;
+    const bool d_unwind_native_frames;
+    const unsigned int d_memory_interval;
+    const bool d_follow_fork;
+    const bool d_trace_python_allocators;
     linker::SymbolPatcher d_patcher;
     std::unique_ptr<BackgroundThread> d_background_thread;
 

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -312,6 +312,7 @@ class Tracker
         std::shared_ptr<RecordWriter> d_writer;
         bool d_stop{false};
         unsigned int d_memory_interval;
+        std::mutex d_mutex;
         std::condition_variable d_cv;
         std::thread d_thread;
         mutable std::ifstream d_procs_statm;

--- a/src/memray/_memray/tracking_api.pxd
+++ b/src/memray/_memray/tracking_api.pxd
@@ -5,10 +5,7 @@ from libcpp.string cimport string
 
 
 cdef extern from "tracking_api.h" namespace "memray::tracking_api":
-    void forget_python_stack() except*
     void install_trace_function() except*
-    void begin_tracking_greenlets() except+
-    void handle_greenlet_switch(object, object) except+
 
     cdef cppclass Tracker:
         @staticmethod
@@ -25,3 +22,12 @@ cdef extern from "tracking_api.h" namespace "memray::tracking_api":
 
         @staticmethod
         Tracker* getTracker()
+
+        @staticmethod
+        void forgetPythonStack() except+
+
+        @staticmethod
+        void beginTrackingGreenlets() except+
+
+        @staticmethod
+        void handleGreenletSwitch(object, object) except+


### PR DESCRIPTION
In order to guarantee mutual exclusion between the tracker singleton being destroyed and allocation tracking that may be happening in other threads, switch from a fine grained locking model for the tracker to a coarse grained one where the same lock is used for all critical sections.

Closes: #288 