### PR TITLE
Manage the Tracker's lifetime with `shared_ptr`

### DIFF
--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -564,9 +564,10 @@ Tracker::Tracker(
     if (!d_writer->writeHeader(false)) {
         throw IoError{"Failed to write output header"};
     }
-    updateModuleCache();
 
     RecursionGuard guard;
+    updateModuleCacheImpl();
+
     PythonStackTracker::s_native_tracking_enabled = native_traces;
     PythonStackTracker::installProfileHooks();
     if (d_trace_python_allocators) {
@@ -835,7 +836,7 @@ Tracker::invalidate_module_cache_impl()
 {
     RecursionGuard guard;
     d_patcher.overwrite_symbols();
-    updateModuleCache();
+    updateModuleCacheImpl();
 }
 
 #ifdef __linux__

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -255,14 +255,6 @@ class Tracker
         }
     }
 
-    __attribute__((always_inline)) inline static void updateModuleCache()
-    {
-        Tracker* tracker = getTracker();
-        if (tracker) {
-            tracker->updateModuleCacheImpl();
-        }
-    }
-
     __attribute__((always_inline)) inline static void registerThreadName(const char* name)
     {
         Tracker* tracker = getTracker();

--- a/src/memray/_memray/tracking_api.pxd
+++ b/src/memray/_memray/tracking_api.pxd
@@ -1,5 +1,6 @@
 from _memray.record_writer cimport RecordWriter
 from libcpp cimport bool
+from libcpp.memory cimport shared_ptr
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
 
@@ -24,4 +25,4 @@ cdef extern from "tracking_api.h" namespace "memray::tracking_api":
         object destroyTracker() except +
 
         @staticmethod
-        Tracker* getTracker()
+        shared_ptr[Tracker] getTracker()


### PR DESCRIPTION
Whenever any hook needs to make use of the Tracker singleton, have it atomically grab a reference to a `shared_ptr` singleton. When stopping tracking, unset that singleton, and then wait for all of the remaining references to it to be destroyed before really destroying the Tracker.