### PR TITLE
Use consistently binary multiples in the reporters

### DIFF
--- a/src/memray/reporters/templates/base.html
+++ b/src/memray/reporters/templates/base.html
@@ -116,7 +116,7 @@
           End time: {{ metadata.end_time }}<br>
           Total number of allocations: {{ metadata.total_allocations }}<br>
           Total number of frames seen: {{ metadata.total_frames }}<br>
-          Peak memory usage: {{ metadata.peak_memory | filesizeformat }}<br>
+          Peak memory usage: {{ metadata.peak_memory | filesizeformat(true) }}<br>
           Python allocator: {{ metadata.python_allocator }}<br>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
We are inconsistently using decimal and binary multiples in different
places where we report sizes.