### PR TITLE
Add a GitHub action to check for changelog files

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -1,5 +1,12 @@
 name: Sanity check
-on: [pull_request]
+on: 
+  pull_request:
+    types:
+    - "opened"
+    - "reopened"
+    - "synchronize"
+    - "labeled"
+    - "unlabeled"
 
 jobs:
   commits_check_job:
@@ -15,3 +22,9 @@ jobs:
       uses: tim-actions/dco@master
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
+    - name: "Check for news entry"
+      uses: brettcannon/check-for-changed-files@v1
+      with:
+        file-pattern: "news/*.rst"
+        skip-label: "skip news"
+        failure-message: "Missing a news file in ${file-pattern}; please add one or apply the ${skip-label} label to the pull request"


### PR DESCRIPTION
We constantly forget to add news entries in Pull Requests and we need to
fix this after the Pull Requests are landed. With this action we can
easily automate the check so we can consciously decide to ignore if
needed.

Signed-off-by: Pablo Galindo <pablogsal@gmail.com>
