### PR TITLE
attach: Work around a bug in old gdb versions

### DIFF
--- a/benchmarks/benchmarking/plot.py
+++ b/benchmarks/benchmarking/plot.py
@@ -32,7 +32,6 @@ def remove_outliers(values, m=2):
 
 
 def plot_diff_pair(ax, ref, head, names, outlier_rejection=True):
-
     master_data = []
     all_data = []
     means = []

--- a/news/310.bugfix.1.rst
+++ b/news/310.bugfix.1.rst
@@ -1,0 +1,1 @@
+Work around `a bug in GDB versions before 10.1 <https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=da1df1db9ae43050c8de62e4842428ddda7eb509>`_ that could cause ``memray attach`` to fail.

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ class BuildMemray(build_ext_orig):
         subprocess.run(command, check=True, **kwargs)
 
     def build_libbacktrace(self):
-
         archive_location = LIBBACKTRACE_LIBDIR / "libbacktrace.a"
 
         if archive_location.exists():

--- a/src/memray/commands/_attach.gdb
+++ b/src/memray/commands/_attach.gdb
@@ -27,7 +27,7 @@ b PyMem_Calloc
 b PyMem_Realloc
 b PyMem_Free
 # Apply commands to all 8 breakpoints above
-commands 1 2 3 4 5 6 7 8
+commands 1-8
     disable breakpoints
     call (void*)dlopen($libpath, $rtld_now)
     p (char*)dlerror()

--- a/src/memray/reporters/summary.py
+++ b/src/memray/reporters/summary.py
@@ -9,7 +9,6 @@ from memray.reporters.tui import TUI
 
 
 class SummaryReporter:
-
     N_COLUMNS = len(TUI.KEY_TO_COLUMN_NAME)
 
     def __init__(self, data: Iterable[AllocationRecord], native: bool):

--- a/src/memray/reporters/table.py
+++ b/src/memray/reporters/table.py
@@ -32,7 +32,6 @@ class TableReporter:
         memory_records: Iterable[MemorySnapshot],
         native_traces: bool,
     ) -> "TableReporter":
-
         result = []
         for record in allocations:
             stack_trace = (

--- a/src/memray/reporters/transform.py
+++ b/src/memray/reporters/transform.py
@@ -41,7 +41,6 @@ class TransformReporter:
         outfile: TextIO,
         **kwargs: Any,
     ) -> None:
-
         location_to_index: Dict[Location, int] = {}
         all_locations: List[Dict[str, str]] = []
         events = []
@@ -87,7 +86,6 @@ class TransformReporter:
         outfile: TextIO,
         **kwargs: Any,
     ) -> None:
-
         writer = csv.writer(outfile)
         writer.writerow(
             [

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -957,7 +957,6 @@ class TestReporterSubCommands:
 
 class TestLiveRemoteSubcommand:
     def test_live_tracking(self, tmp_path, simple_test_file, free_port):
-
         # GIVEN
         server = subprocess.Popen(
             [
@@ -1165,7 +1164,6 @@ class TestLiveRemoteSubcommand:
         assert b"Interrupted system call" not in stderr
 
     def test_live_client_exits_properly_on_sigint_before_connecting(self, free_port):
-
         # GIVEN
         client = subprocess.Popen(
             [

--- a/tests/integration/test_tracking.py
+++ b/tests/integration/test_tracking.py
@@ -1115,7 +1115,6 @@ class TestLeaks:
     def test_leaks_that_happen_in_the_same_function_are_aggregated(
         self, tmp_path, file_format
     ):
-
         # GIVEN
         allocators = []
         output = tmp_path / "test.bin"
@@ -1172,7 +1171,6 @@ class TestLeaks:
         )
 
     def test_thread_allocations_multiple_threads(self, tmpdir, file_format):
-
         # GIVEN
         def allocating_function(allocator, amount, stop_flag):
             allocator.posix_memalign(amount)
@@ -1352,7 +1350,6 @@ class TestTemporaryAllocations:
     def test_temporary_allocations_that_happen_in_the_same_function_are_aggregated(
         self, tmp_path
     ):
-
         # GIVEN
         output = tmp_path / "test.bin"
 
@@ -1400,7 +1397,6 @@ class TestTemporaryAllocations:
         )
 
     def test_thread_allocations_multiple_threads(self, tmpdir):
-
         # GIVEN
         def allocating_function(allocator, amount, stop_flag):
             allocator.posix_memalign(amount)

--- a/tests/unit/test_tui_reporter.py
+++ b/tests/unit/test_tui_reporter.py
@@ -34,7 +34,6 @@ class TestTUIHeader:
         ],
     )
     def test_pid(self, pid, out_str):
-
         # GIVEN
         snapshot = []
         output = StringIO()
@@ -107,7 +106,6 @@ class TestTUIHeader:
         assert actual == expected
 
     def test_with_no_allocations(self):
-
         # GIVEN
         snapshot = []
         output = StringIO()


### PR DESCRIPTION
There's [a bug (fixed in gdb 10.1)](https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=da1df1db9ae43050c8de62e4842428ddda7eb509) with how gdb parses the "commands" command when reading from a script, which causes the commands to get associated only with the first breakpoint rather than all of the breakpoints we wanted them associated with.

Through sheer good luck, this bug doesn't affect the case when a range of breakpoint numbers is given, rather than a space separated list of breakpoint numbers, so we can switch to using a range to avoid the bug.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>

Closes #309 