### PR TITLE
attach: Wake up the process after lldb detaches

### DIFF
--- a/news/311.bugfix.rst
+++ b/news/311.bugfix.rst
@@ -1,0 +1,1 @@
+Work around `a bug in LLDB on Linux <https://github.com/llvm/llvm-project/issues/60408>`_ that could cause ``memray attach`` to hang.

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -107,6 +107,15 @@ def inject(debugger: str, pid: int, port: int, verbose: bool) -> str | None:
         output = exc.output
         returncode = exc.returncode
 
+    if cmd is lldb_cmd:
+        # A bug in lldb sometimes means processes stay stopped after it exits.
+        # Send a signal to wake the process up. Ignore any errors: the process
+        # may have died, or may have never existed, or may be owned by another
+        # user, etc. Processes that aren't stopped will ignore this signal, so
+        # this should be harmless, though it is a huge hack.
+        with contextlib.suppress(OSError):
+            os.kill(pid, signal.SIGCONT)
+
     if verbose:
         print(f"debugger return code: {returncode}")
         print(f"debugger output:\n{output}")


### PR DESCRIPTION
lldb on Linux appears to have a bug causing it to sometimes leave a process stopped at a breakpoint even after the debugger has detached. Defend against this by sending a `SIGCONT` signal to the process after the debugger attaches. If the process was already resumed then it will just ignore this spurious signal, but if lldb had left it stopped this will rescue it.

Relates-to: https://github.com/llvm/llvm-project/issues/60408.
Relates-to: #309 