### PR TITLE
Use the vanilla Alpine image instead of the python-based one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,19 +64,20 @@ jobs:
     name: 'Test in Alpine Linux'
     runs-on: ubuntu-latest
     container:
-      image: python:3.10-alpine
+      image: alpine
       options: --cap-add=SYS_PTRACE
     steps:
     - uses: actions/checkout@v3
     - name: Set up dependencies
       run: |
-        apk add --update build-base libunwind-dev lz4-dev musl-dev python3-dev gdb lldb
+        apk add --update build-base libunwind-dev lz4-dev musl-dev python3-dev python3-dbg gdb lldb
     - name: Install Python dependencies
       run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install tox
+        python3 -m venv /venv
+        /venv/bin/python -m pip install --upgrade pip
+        /venv/bin/python -m pip install tox
     - name: Run tox
-      run: python3 -m tox -e py310 -vvv
+      run: /venv/bin/python -m tox -e py310 -vvv
 
   lint_and_docs:
     name: 'Lint and Docs'


### PR DESCRIPTION
The Python-based alpine image downloads and builds a Python executable
without symbols. This causes several tests to fail because we cannot
leverage the `python3-dbg`package that contains symbols for the
interpreter.

To fix this, use the vanilla Alpine docker image and also install the
`python3-dbg` package so we always have symbols available.