### PR TITLE
Refactor `HighWatermarkCommand`

### DIFF
--- a/src/memray/commands/common.py
+++ b/src/memray/commands/common.py
@@ -4,7 +4,6 @@ import pathlib
 import sys
 from pathlib import Path
 from textwrap import dedent
-from typing import Any
 from typing import Iterable
 from typing import Optional
 from typing import Tuple
@@ -123,7 +122,6 @@ class HighWatermarkCommand:
         temporary_allocation_threshold: int,
         merge_threads: Optional[bool] = None,
         temporal_leaks: bool = False,
-        **kwargs: Any,
     ) -> None:
         try:
             reader = FileReader(os.fspath(result_path), report_progress=True)
@@ -141,7 +139,6 @@ class HighWatermarkCommand:
                     temporal_snapshot,
                     memory_records=tuple(reader.get_memory_snapshots()),
                     native_traces=reader.metadata.has_native_traces,
-                    **kwargs,
                 )
                 show_memory_leaks = True
             else:
@@ -162,7 +159,6 @@ class HighWatermarkCommand:
                     snapshot,
                     memory_records=tuple(reader.get_memory_snapshots()),
                     native_traces=reader.metadata.has_native_traces,
-                    **kwargs,
                 )
         except OSError as e:
             raise MemrayCommandError(
@@ -237,15 +233,14 @@ class HighWatermarkCommand:
         )
         parser.add_argument("results", help="Results of the tracker run")
 
-    def run(
-        self, args: argparse.Namespace, parser: argparse.ArgumentParser, **kwargs: Any
-    ) -> None:
+    def run(self, args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
         result_path, output_file = self.validate_filenames(
             output=args.output,
             results=args.results,
             overwrite=args.force,
         )
         self.output_file = output_file
+        kwargs = {}
         if hasattr(args, "split_threads"):
             kwargs["merge_threads"] = not args.split_threads
 

--- a/src/memray/commands/common.py
+++ b/src/memray/commands/common.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import sys
 from pathlib import Path
+from textwrap import dedent
 from typing import Any
 from typing import Iterable
 from typing import Optional
@@ -176,6 +177,65 @@ class HighWatermarkCommand:
                 show_memory_leaks=show_memory_leaks,
                 merge_threads=merge_threads,
             )
+
+    def prepare_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "-o",
+            "--output",
+            help="Output file name",
+            default=None,
+        )
+        parser.add_argument(
+            "-f",
+            "--force",
+            help="If the output file already exists, overwrite it",
+            action="store_true",
+            default=False,
+        )
+        alloc_type_group = parser.add_mutually_exclusive_group()
+        alloc_type_group.add_argument(
+            "--leaks",
+            help="Show memory leaks, instead of peak memory usage",
+            action="store_true",
+            dest="show_memory_leaks",
+            default=False,
+        )
+        if self.temporal_reporter_factory:
+            alloc_type_group.add_argument(
+                "--temporal-leaks",
+                help=(
+                    "Generate a dynamic flame graph showing allocations performed"
+                    " in a user-selected time range and not freed before the end"
+                    " of that time range."
+                ),
+                action="store_true",
+                default=False,
+            )
+        alloc_type_group.add_argument(
+            "--temporary-allocation-threshold",
+            metavar="N",
+            help=dedent(
+                """
+                Report temporary allocations, as opposed to leaked allocations
+                or high watermark allocations.  An allocation is considered
+                temporary if at most N other allocations occur before it is
+                deallocated.  With N=0, an allocation is temporary only if it
+                is immediately deallocated before any other allocation occurs.
+                """
+            ),
+            action="store",
+            dest="temporary_allocation_threshold",
+            type=int,
+            default=-1,
+        )
+        alloc_type_group.add_argument(
+            "--temporary-allocations",
+            help="Equivalent to --temporary-allocation-threshold=1",
+            action="store_const",
+            dest="temporary_allocation_threshold",
+            const=1,
+        )
+        parser.add_argument("results", help="Results of the tracker run")
 
     def run(
         self, args: argparse.Namespace, parser: argparse.ArgumentParser, **kwargs: Any

--- a/src/memray/commands/common.py
+++ b/src/memray/commands/common.py
@@ -112,28 +112,28 @@ class HighWatermarkCommand:
     ) -> None:
         try:
             reader = FileReader(os.fspath(result_path), report_progress=True)
-            default_merge_threads = True if merge_threads is None else merge_threads
+            merge_threads = True if merge_threads is None else merge_threads
 
             if reader.metadata.has_native_traces:
                 warn_if_not_enough_symbols()
 
             if show_memory_leaks:
                 snapshot = reader.get_leaked_allocation_records(
-                    merge_threads=default_merge_threads
+                    merge_threads=merge_threads
                 )
             elif temporary_allocation_threshold >= 0:
                 snapshot = reader.get_temporary_allocation_records(
                     threshold=temporary_allocation_threshold,
-                    merge_threads=default_merge_threads,
+                    merge_threads=merge_threads,
                 )
             elif temporal_leaks:
                 snapshot = reader.get_temporal_allocation_records(
-                    merge_threads=default_merge_threads
+                    merge_threads=merge_threads
                 )  # type: ignore
                 show_memory_leaks = True
             else:
                 snapshot = reader.get_high_watermark_allocation_records(
-                    merge_threads=default_merge_threads
+                    merge_threads=merge_threads
                 )
             memory_records = tuple(reader.get_memory_snapshots())
             reporter = self.reporter_factory(
@@ -149,14 +149,11 @@ class HighWatermarkCommand:
             )
 
         with open(os.fspath(output_file.expanduser()), "w") as f:
-            kwargs = {}
-            if merge_threads is not None:
-                kwargs["merge_threads"] = merge_threads
             reporter.render(
                 outfile=f,
                 metadata=reader.metadata,
                 show_memory_leaks=show_memory_leaks,
-                **kwargs,
+                merge_threads=merge_threads,
             )
 
     def run(

--- a/src/memray/commands/common.py
+++ b/src/memray/commands/common.py
@@ -1,16 +1,17 @@
 import argparse
 import os
 import pathlib
+import sys
 from pathlib import Path
 from typing import Any
 from typing import Iterable
 from typing import Optional
 from typing import Tuple
 
-try:
+if sys.version_info >= (3, 8):
     from typing import Protocol
-except ImportError:
-    from typing_extensions import Protocol  # type: ignore
+else:
+    from typing_extensions import Protocol
 
 from rich import print as pprint
 

--- a/src/memray/commands/flamegraph.py
+++ b/src/memray/commands/flamegraph.py
@@ -1,5 +1,4 @@
 import argparse
-from textwrap import dedent
 
 from ..reporters.flamegraph import FlameGraphReporter
 from .common import HighWatermarkCommand
@@ -16,66 +15,10 @@ class FlamegraphCommand(HighWatermarkCommand):
         )
 
     def prepare_parser(self, parser: argparse.ArgumentParser) -> None:
-        parser.add_argument(
-            "-o",
-            "--output",
-            help="Output file name",
-            default=None,
-        )
-        parser.add_argument(
-            "-f",
-            "--force",
-            help="If the output file already exists, overwrite it",
-            action="store_true",
-            default=False,
-        )
-        alloc_type_group = parser.add_mutually_exclusive_group()
-        alloc_type_group.add_argument(
-            "--leaks",
-            help="Show memory leaks, instead of peak memory usage",
-            action="store_true",
-            dest="show_memory_leaks",
-            default=False,
-        )
-        alloc_type_group.add_argument(
-            "--temporal-leaks",
-            help=(
-                "Generate a dynamic flame graph showing allocations performed"
-                " in a user-selected time range and not freed before the end"
-                " of that time range."
-            ),
-            action="store_true",
-            default=False,
-        )
-        alloc_type_group.add_argument(
-            "--temporary-allocation-threshold",
-            metavar="N",
-            help=dedent(
-                """
-                Report temporary allocations, as opposed to leaked allocations
-                or high watermark allocations.  An allocation is considered
-                temporary if at most N other allocations occur before it is
-                deallocated.  With N=0, an allocation is temporary only if it
-                is immediately deallocated before any other allocation occurs.
-                """
-            ),
-            action="store",
-            dest="temporary_allocation_threshold",
-            type=int,
-            default=-1,
-        )
-        alloc_type_group.add_argument(
-            "--temporary-allocations",
-            help="Equivalent to --temporary-allocation-threshold=1",
-            action="store_const",
-            dest="temporary_allocation_threshold",
-            const=1,
-        )
-
+        super().prepare_parser(parser)
         parser.add_argument(
             "--split-threads",
             help="Do not merge allocations across threads",
             action="store_true",
             default=False,
         )
-        parser.add_argument("results", help="Results of the tracker run")

--- a/src/memray/commands/flamegraph.py
+++ b/src/memray/commands/flamegraph.py
@@ -1,10 +1,8 @@
 import argparse
 from textwrap import dedent
-from typing import cast
 
 from ..reporters.flamegraph import FlameGraphReporter
 from .common import HighWatermarkCommand
-from .common import ReporterFactory
 
 
 class FlamegraphCommand(HighWatermarkCommand):
@@ -12,7 +10,7 @@ class FlamegraphCommand(HighWatermarkCommand):
 
     def __init__(self) -> None:
         super().__init__(
-            reporter_factory=cast(ReporterFactory, FlameGraphReporter.from_snapshot),
+            reporter_factory=FlameGraphReporter.from_snapshot,
             reporter_name="flamegraph",
         )
 

--- a/src/memray/commands/flamegraph.py
+++ b/src/memray/commands/flamegraph.py
@@ -11,6 +11,7 @@ class FlamegraphCommand(HighWatermarkCommand):
     def __init__(self) -> None:
         super().__init__(
             reporter_factory=FlameGraphReporter.from_snapshot,
+            temporal_reporter_factory=FlameGraphReporter.from_temporal_snapshot,
             reporter_name="flamegraph",
         )
 

--- a/src/memray/commands/table.py
+++ b/src/memray/commands/table.py
@@ -1,6 +1,3 @@
-import argparse
-from textwrap import dedent
-
 from ..reporters.table import TableReporter
 from .common import HighWatermarkCommand
 
@@ -13,52 +10,3 @@ class TableCommand(HighWatermarkCommand):
             reporter_factory=TableReporter.from_snapshot,
             reporter_name="table",
         )
-
-    def prepare_parser(self, parser: argparse.ArgumentParser) -> None:
-        parser.add_argument(
-            "-o",
-            "--output",
-            help="Output file name",
-            default=None,
-        )
-        parser.add_argument(
-            "-f",
-            "--force",
-            help="If the output file already exists, overwrite it",
-            action="store_true",
-            default=False,
-        )
-        alloc_type_group = parser.add_mutually_exclusive_group()
-        alloc_type_group.add_argument(
-            "--leaks",
-            help="Show memory leaks, instead of peak memory usage",
-            action="store_true",
-            dest="show_memory_leaks",
-            default=False,
-        )
-        alloc_type_group.add_argument(
-            "--temporary-allocation-threshold",
-            metavar="N",
-            help=dedent(
-                """
-                Report temporary allocations, as opposed to leaked allocations
-                or high watermark allocations.  An allocation is considered
-                temporary if at most N other allocations occur before it is
-                deallocated.  With N=0, an allocation is temporary only if it
-                is immediately deallocated before any other allocation occurs.
-                """
-            ),
-            action="store",
-            dest="temporary_allocation_threshold",
-            type=int,
-            default=-1,
-        )
-        alloc_type_group.add_argument(
-            "--temporary-allocations",
-            help="Equivalent to --temporary-allocation-threshold=1",
-            action="store_const",
-            dest="temporary_allocation_threshold",
-            const=1,
-        )
-
-        parser.add_argument("results", help="Results of the tracker run")

--- a/src/memray/commands/table.py
+++ b/src/memray/commands/table.py
@@ -1,10 +1,8 @@
 import argparse
 from textwrap import dedent
-from typing import cast
 
 from ..reporters.table import TableReporter
 from .common import HighWatermarkCommand
-from .common import ReporterFactory
 
 
 class TableCommand(HighWatermarkCommand):
@@ -12,7 +10,7 @@ class TableCommand(HighWatermarkCommand):
 
     def __init__(self) -> None:
         super().__init__(
-            reporter_factory=cast(ReporterFactory, TableReporter.from_snapshot),
+            reporter_factory=TableReporter.from_snapshot,
             reporter_name="table",
         )
 

--- a/src/memray/commands/transform.py
+++ b/src/memray/commands/transform.py
@@ -4,7 +4,6 @@ import shutil
 import sys
 from textwrap import dedent
 from typing import Any
-from typing import cast
 
 from rich import print as pprint
 
@@ -12,7 +11,6 @@ from memray._errors import MemrayCommandError
 
 from ..reporters.transform import TransformReporter
 from .common import HighWatermarkCommand
-from .common import ReporterFactory
 
 
 class TransformCommand(HighWatermarkCommand):
@@ -20,7 +18,7 @@ class TransformCommand(HighWatermarkCommand):
 
     def __init__(self) -> None:
         super().__init__(
-            reporter_factory=cast(ReporterFactory, TransformReporter),
+            reporter_factory=TransformReporter,
             reporter_name="transform",
         )
 

--- a/src/memray/commands/transform.py
+++ b/src/memray/commands/transform.py
@@ -2,7 +2,6 @@ import argparse
 import importlib.util
 import shutil
 import sys
-from textwrap import dedent
 from typing import Any
 
 from rich import print as pprint
@@ -28,52 +27,7 @@ class TransformCommand(HighWatermarkCommand):
             "format",
             help=f"Format to use for the report. Available formats: {formats}",
         )
-        parser.add_argument(
-            "-o",
-            "--output",
-            help="Output file name",
-            default=None,
-        )
-        parser.add_argument(
-            "-f",
-            "--force",
-            help="If the output file already exists, overwrite it",
-            action="store_true",
-            default=False,
-        )
-        alloc_type_group = parser.add_mutually_exclusive_group()
-        alloc_type_group.add_argument(
-            "--leaks",
-            help="Show memory leaks, instead of peak memory usage",
-            action="store_true",
-            dest="show_memory_leaks",
-            default=False,
-        )
-        alloc_type_group.add_argument(
-            "--temporary-allocation-threshold",
-            metavar="N",
-            help=dedent(
-                """
-                Report temporary allocations, as opposed to leaked allocations
-                or high watermark allocations.  An allocation is considered
-                temporary if at most N other allocations occur before it is
-                deallocated.  With N=0, an allocation is temporary only if it
-                is immediately deallocated before any other allocation occurs.
-                """
-            ),
-            action="store",
-            dest="temporary_allocation_threshold",
-            type=int,
-            default=-1,
-        )
-        alloc_type_group.add_argument(
-            "--temporary-allocations",
-            help="Equivalent to --temporary-allocation-threshold=1",
-            action="store_const",
-            dest="temporary_allocation_threshold",
-            const=1,
-        )
-        parser.add_argument("results", help="Results of the tracker run")
+        super().prepare_parser(parser)
 
     def run(
         self, args: argparse.Namespace, parser: argparse.ArgumentParser, **kwargs: Any

--- a/src/memray/commands/transform.py
+++ b/src/memray/commands/transform.py
@@ -2,7 +2,6 @@ import argparse
 import importlib.util
 import shutil
 import sys
-from typing import Any
 
 from rich import print as pprint
 
@@ -17,7 +16,9 @@ class TransformCommand(HighWatermarkCommand):
 
     def __init__(self) -> None:
         super().__init__(
-            reporter_factory=TransformReporter,
+            reporter_factory=lambda *args, **kwargs: TransformReporter(
+                *args, **kwargs, format=self.reporter_name
+            ),
             reporter_name="transform",
         )
 
@@ -29,9 +30,7 @@ class TransformCommand(HighWatermarkCommand):
         )
         super().prepare_parser(parser)
 
-    def run(
-        self, args: argparse.Namespace, parser: argparse.ArgumentParser, **kwargs: Any
-    ) -> None:
+    def run(self, args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
         the_format = args.format.lower()
         suffix = TransformReporter.SUFFIX_MAP.get(the_format)
         if not suffix:
@@ -41,7 +40,7 @@ class TransformCommand(HighWatermarkCommand):
 
         self.suffix = suffix
         self.reporter_name = the_format
-        super().run(args, parser, format=the_format)
+        super().run(args, parser)
 
         post_run_callable = getattr(self, f"post_run_{the_format}", None)
         if post_run_callable:

--- a/src/memray/reporters/__init__.py
+++ b/src/memray/reporters/__init__.py
@@ -1,11 +1,12 @@
+import sys
 from typing import TextIO
 
 from memray import Metadata
 
-try:
+if sys.version_info >= (3, 8):
     from typing import Protocol
-except ImportError:
-    from typing_extensions import Protocol  # type: ignore
+else:
+    from typing_extensions import Protocol
 
 
 class BaseReporter(Protocol):

--- a/src/memray/reporters/flamegraph.py
+++ b/src/memray/reporters/flamegraph.py
@@ -87,7 +87,7 @@ class FlameGraphReporter:
     @classmethod
     def from_snapshot(
         cls,
-        allocations: Iterator[Union[AllocationRecord, TemporalAllocationRecord]],
+        allocations: Iterable[Union[AllocationRecord, TemporalAllocationRecord]],
         *,
         memory_records: Iterable[MemorySnapshot],
         native_traces: bool,

--- a/src/memray/reporters/table.py
+++ b/src/memray/reporters/table.py
@@ -2,7 +2,6 @@ import html
 from typing import Any
 from typing import Dict
 from typing import Iterable
-from typing import Iterator
 from typing import List
 from typing import TextIO
 
@@ -27,7 +26,7 @@ class TableReporter:
     @classmethod
     def from_snapshot(
         cls,
-        allocations: Iterator[AllocationRecord],
+        allocations: Iterable[AllocationRecord],
         *,
         memory_records: Iterable[MemorySnapshot],
         native_traces: bool,
@@ -62,13 +61,16 @@ class TableReporter:
         outfile: TextIO,
         metadata: Metadata,
         show_memory_leaks: bool,
+        merge_threads: bool,
     ) -> None:
+        if not merge_threads:
+            raise NotImplementedError("TableReporter only supports merged threads.")
         html_code = render_report(
             kind="table",
             data=self.data,
             metadata=metadata,
             memory_records=self.memory_records,
             show_memory_leaks=show_memory_leaks,
-            merge_threads=True,
+            merge_threads=merge_threads,
         )
         print(html_code, file=outfile)

--- a/src/memray/reporters/transform.py
+++ b/src/memray/reporters/transform.py
@@ -3,7 +3,6 @@ import json
 from typing import Any
 from typing import Dict
 from typing import Iterable
-from typing import Iterator
 from typing import List
 from typing import TextIO
 from typing import Tuple
@@ -24,7 +23,7 @@ class TransformReporter:
 
     def __init__(
         self,
-        allocations: Iterator[AllocationRecord],
+        allocations: Iterable[AllocationRecord],
         *,
         format: str,
         native_traces: bool,
@@ -77,7 +76,10 @@ class TransformReporter:
         outfile: TextIO,
         metadata: Metadata,
         show_memory_leaks: bool,
+        merge_threads: bool,
     ) -> None:
+        if not merge_threads:
+            raise NotImplementedError("TransformReporter only supports merged threads.")
         renderer = getattr(self, f"render_as_{self.format}")
         renderer(outfile, metadata=metadata, show_memory_leaks=show_memory_leaks)
 


### PR DESCRIPTION
This PR implements the cleanup of the `HighWatermarkCommand` interface that I promised when we were discussing ways to clean up #317 to pass the `TemporalAllocationRecord`'s through the layers more cleanly.

I think this is a huge improvement over what we've got. This is in a reviewable state, I'm only marking it as draft to remind us not to land it until we've landed #317 and rebased this on it.