### PR TITLE
Handle missing eval symbols in the hybrid stack with non entry frames

### DIFF
--- a/news/334.bugfix.rst
+++ b/news/334.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug that was hitting an assert when constructing hybrid stack frames in Python 3.11 when no eval symbols are available.

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -236,13 +236,13 @@ cdef hybrid_stack_trace(
             hybrid_stack[hidx] = native_frame
             hidx -= 1
 
-    assert hidx == -1
     if pidx >= 0:
         # We ran out of native frames without using up all of our Python
         # frames. We've seen this happen on stripped interpreters on Alpine
         # Linux in CI. Presumably this indicates that unwinding failed to
         # symbolify some of the calls to _PyEval_EvalFrameDefault.
-        return [("<unknown stack>", "<unknown>", 0)]
+        return python_stack
+    assert hidx == -1
 
     return hybrid_stack[:max_stacks]
 


### PR DESCRIPTION
In Python 3.11, due to the presence of non-entry frames we are hitting an assertion when constructing the hybrid stack.

for Python 3.10 and earlier, `len(hybrid_stack) == len(native_stack)`, which is why we've never seen this `assert hidx == -1` fail before. In 3.11 there are now non-entry frames, and `hybrid_stack` is longer than `native_stack` by the number of non-entry frames in the Python stack. If we fail to recognize a `_PyEval_EvalFrameDefault` call in Python 3.10 and earlier it only causes us to fill a native frame into `hybrid_stack` instead of a Python frame, but from 3.11 on it _also_ causes us to totally fail to insert any non-entry Python frames that were evaluated by that call to `_PyEval_EvalFrameDefault`, meaning we write fewer total entries into `hybrid_stack` than we meant to.

After some discussion we have decided that the correct thing to do here is return the Python stack if we cannot construct the hybrid stack. This is because report files that include native information will always try to construct the hybrid stack and returning something that doesn't include the Python stack somehow will result in a very bad user experience as they won't see any Python code whatsoever in the reports.

Closes: #332
