### PR TITLE
Improve text readability in jupyterlab dark theme

### DIFF
--- a/news/344.bugfix.rst
+++ b/news/344.bugfix.rst
@@ -1,0 +1,1 @@
+Change the font color used by the ``%%memray_flamegraph`` Jupyter magic's progress updates for better contrast on the JupyterLab dark theme.

--- a/src/memray/_ipython/flamegraph.py
+++ b/src/memray/_ipython/flamegraph.py
@@ -159,7 +159,7 @@ class FlamegraphMagics(Magics):
                 merge_threads=merge_threads,
             )
         dump_file.unlink()
-        pprint(f"Results saved to [bold blue]{flamegraph_path}[/bold blue]")
+        pprint(f"Results saved to [bold cyan]{flamegraph_path}")
         display(IFrame(flamegraph_path, width="100%", height="600"))  # type: ignore
 
 

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -798,7 +798,7 @@ cdef class ProgressIndicator:
             return self
         self._context_manager = self._indicator.__enter__()
         self._task = self._context_manager.add_task(
-            f"[blue]{self._task_description}...",
+            f"[cyan]{self._task_description}...",
             total=self._total
         )
         return self


### PR DESCRIPTION
This applies to:
- progress bar text status
- jupyter magic %%memray_flamegraph output filename

*Issue number of the reported bug or feature request: #343*

**Describe your changes**
I changed the color blue to cyan for a few text outputs to improve readability in dark themes.
![color_change](https://user-images.githubusercontent.com/16963011/233504369-0f41b858-d60d-4c06-bec0-ac07b45f9b08.png)

**Testing performed**
The screenshot above shows good readability of the cyan text in both light and dark themes, and uses a color number below 16, so it displays properly in terminals with 16 colors.

**Additional context**
Closes: #343