### PR TITLE
Only delete the *.so files that we create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,8 +179,12 @@ gh-pages:  ## Publish documentation on BBGitHub Pages
 
 .PHONY: clean
 clean:  ## Clean any built/generated artifacts
-	find . | grep -E '(\.o|\.so|\.gcda|\.gcno|\.gcov\.json\.gz)' | xargs rm -rf
+	find . | grep -E '(\.o|\.gcda|\.gcno|\.gcov\.json\.gz)' | xargs rm -rf
 	find . | grep -E '(__pycache__|\.pyc|\.pyo)' | xargs rm -rf
+	rm -rf build
+	rm -f src/memray/_test_utils.*.so
+	rm -f src/memray/_memray.*.so
+	rm -f src/memray/_inject.*.so
 	rm -f src/memray/_memray.cpp
 	rm -f memray.info
 	rm -rf memray-coverage


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #353 *

**Describe your changes**
Delete only the following:
- `_test_utils`
- `_memray`
- `_inject`
- `build/` dir

**Testing performed**
To make sure that the virtualenv is working after running `make clean`, I did the following,
- Installed some packages in the virtualenv
- Start the interpreter and import a few modules

**Additional context**
Closes #353 
