### PR TITLE
ci: Only check for news entries if src/ changed 

### DIFF
--- a/.github/workflows/news-check.yml
+++ b/.github/workflows/news-check.yml
@@ -1,0 +1,23 @@
+name: News entry check
+on:
+  pull_request:
+    paths:
+      - "src/memray/**"
+    types:
+      - "opened"
+      - "reopened"
+      - "synchronize"
+      - "labeled"
+      - "unlabeled"
+
+jobs:
+  news_entry_check:
+    runs-on: ubuntu-latest
+    name: Check for news entry
+    steps:
+      - name: "Check for news entry"
+        uses: brettcannon/check-for-changed-files@v1
+        with:
+          file-pattern: "news/*.rst"
+          skip-label: "skip news"
+          failure-message: "Missing a news file in ${file-pattern}; please add one or apply the ${skip-label} label to the pull request"

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -22,9 +22,3 @@ jobs:
         uses: tim-actions/dco@master
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
-      - name: "Check for news entry"
-        uses: brettcannon/check-for-changed-files@v1
-        with:
-          file-pattern: "news/*.rst"
-          skip-label: "skip news"
-          failure-message: "Missing a news file in ${file-pattern}; please add one or apply the ${skip-label} label to the pull request"


### PR DESCRIPTION
**Describe your changes**
- Separate the check for a news entry into its own action to apply only to `src/*` files
- Clean up `sanity-check.yml` workflow file

**Testing performed**
This PR will trigger the `sanity-check.yml` workflow file (which will now pass since there is no need for the `skip news` label), but not the `news-check.yml` workflow file since there are no changes to `src/memray/*`.
