### PR TITLE
Streamline linting processes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -qy clang-format npm libunwind-dev liblz4-dev pkg-config
-          npm install -g prettier
       - name: Install Python dependencies
         run: |
           python3 -m pip install -r requirements-extra.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,7 @@ jobs:
       - name: Lint sources
         run: |
           make lint
+          python3 -m pre_commit run --all-files --hook-stage pre-push
       - name: Build docs
         run: |
           make docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,38 +1,51 @@
+default_install_hook_types: [pre-commit, pre-push]
 exclude: "^(src/memray/reporters/templates/assets|src/vendor|benchmarks|docs/_static/flamegraphs)/"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
       - id: check-added-large-files
+        stages: [pre-commit]
       - id: check-json
         exclude: "^asv\\.conf\\.json$"
+        stages: [pre-commit]
       - id: check-merge-conflict
+        stages: [pre-commit]
       - id: check-toml
+        stages: [pre-commit]
       - id: check-yaml
+        stages: [pre-commit]
       - id: end-of-file-fixer
+        stages: [pre-commit]
       - id: trailing-whitespace
+        stages: [pre-commit]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
       - id: rst-directive-colons
+        stages: [pre-commit]
       - id: rst-inline-touching-normal
+        stages: [pre-commit]
 
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
+        stages: [pre-commit]
 
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
       - id: flake8
         types: [file, python]
+        stages: [pre-commit]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
+        stages: [pre-commit]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
@@ -41,6 +54,7 @@ repos:
         args: [--no-editorconfig]
         exclude: "^asv\\.conf\\.json$"
         exclude_types: [html]
+        stages: [pre-commit]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v16.0.2
@@ -48,6 +62,7 @@ repos:
       - id: clang-format
         args: [--Werror, -i]
         types_or: [c++, c, cuda]
+        stages: [pre-commit]
 
   - repo: https://github.com/mgedmin/check-manifest
     rev: "0.49"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,8 +61,9 @@ repos:
     hooks:
       - id: clang-format
         args: [--Werror, -i]
-        types_or: [c++, c, cuda]
+        exclude: "^tests/integration/"
         stages: [pre-commit]
+        types_or: [c++, c, cuda]
 
   - repo: https://github.com/mgedmin/check-manifest
     rev: "0.49"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-json
-        exclude: "^asv.conf.json$"
+        exclude: "^asv\\.conf\\.json$"
       - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml
@@ -38,5 +38,19 @@ repos:
     rev: v2.7.1
     hooks:
       - id: prettier
+        args: [--no-editorconfig]
         exclude: "^asv\\.conf\\.json$"
         exclude_types: [html]
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v16.0.2
+    hooks:
+      - id: clang-format
+        args: [--Werror, -i]
+        types_or: [c++, c, cuda]
+
+  - repo: https://github.com/mgedmin/check-manifest
+    rev: "0.49"
+    hooks:
+      - id: check-manifest
+        stages: [pre-push]

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,9 +1,5 @@
-black
-flake8
-isort
 mypy
 bump2version
 towncrier
-check-manifest
 pre-commit
 -r requirements-docs.txt

--- a/src/memray/_memray/alloc.h
+++ b/src/memray/_memray/alloc.h
@@ -8,7 +8,8 @@
 
 extern "C" {
 #ifndef __GLIBC__
-static void* pvalloc [[maybe_unused]] (size_t size)
+static void*
+pvalloc [[maybe_unused]] (size_t size)
 {
     return NULL;
 }
@@ -24,7 +25,8 @@ aligned_alloc(size_t alignment, size_t size)
 
 #ifdef __APPLE__
 
-static void* memalign [[maybe_unused]] (size_t alignment, size_t size)
+static void*
+memalign [[maybe_unused]] (size_t alignment, size_t size)
 {
     return NULL;
 }

--- a/src/memray/_memray/elf_utils.h
+++ b/src/memray/_memray/elf_utils.h
@@ -241,7 +241,8 @@ struct SymbolTable
             const auto* sym_name = string_table.table + sym->st_name;
             const uint32_t hash = chain[symbol_index - symbol_offset];
             if ((namehash | 1) == (hash | 1) && isDefinedGlobalSymbol(sym)
-                && strcmp(sym_name, name) == 0) {
+                && strcmp(sym_name, name) == 0)
+            {
                 return base + sym->st_value;
             }
 

--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -514,7 +514,8 @@ RecordReader::nextRecordFromAllAllocationsFile()
         RecordTypeAndFlags record_type_and_flags;
         if (!d_input->read(
                     reinterpret_cast<char*>(&record_type_and_flags),
-                    sizeof(record_type_and_flags))) {
+                    sizeof(record_type_and_flags)))
+        {
             return RecordResult::END_OF_FILE;
         }
 
@@ -533,7 +534,8 @@ RecordReader::nextRecordFromAllAllocationsFile()
             case RecordType::ALLOCATION: {
                 AllocationRecord record;
                 if (!parseAllocationRecord(&record, record_type_and_flags.flags)
-                    || !processAllocationRecord(record)) {
+                    || !processAllocationRecord(record))
+                {
                     if (d_input->is_open()) LOG(ERROR) << "Failed to process allocation record";
                     return RecordResult::ERROR;
                 }
@@ -649,7 +651,8 @@ RecordReader::nextRecordFromAggregatedAllocationsFile()
             case AggregatedRecordType::AGGREGATED_ALLOCATION: {
                 AggregatedAllocation record;
                 if (!parseAggregatedAllocationRecord(&record)
-                    || !processAggregatedAllocationRecord(record)) {
+                    || !processAggregatedAllocationRecord(record))
+                {
                     if (d_input->is_open()) {
                         LOG(ERROR) << "Failed to process aggregated allocation record";
                     }
@@ -971,7 +974,8 @@ RecordReader::dumpAllRecordsFromAllAllocationsFile()
         RecordTypeAndFlags record_type_and_flags;
         if (!d_input->read(
                     reinterpret_cast<char*>(&record_type_and_flags),
-                    sizeof(record_type_and_flags))) {
+                    sizeof(record_type_and_flags)))
+        {
             Py_RETURN_NONE;
         }
 

--- a/src/memray/_memray/record_writer.cpp
+++ b/src/memray/_memray/record_writer.cpp
@@ -235,7 +235,8 @@ RecordWriter::writeMappingsCommon(const std::vector<ImageSegments>& mappings)
 
         for (const auto& segment : image.segments) {
             if (!writeSimpleType(segment_token) || !writeSimpleType(segment.vaddr)
-                || !writeVarint(segment.memsz)) {
+                || !writeVarint(segment.memsz))
+            {
                 return false;
             }
         }


### PR DESCRIPTION
*Issue number of the reported bug or feature request: closes https://github.com/bloomberg/memray/issues/360*

**Describe your changes**
- Add `check-manifest` and `clang-format` to pre-commit setup (removing from `make`)
- Remove intermediary `make` commands
- Clean up `Makefile` and C files found during linting
- Configure pre-push hook to run in CI
- Remove extra requirements absorbed into pre-commit

**Testing performed**
Reinstalled the hooks to allow for pre-commit and pre-push hooks. Running `pre-commit run --all-files` runs in the pre-commit stage so all but `check-manifest`. Running `pre-commit run --all-files --hook-stage pre-push` only runs `check-manifest`.
