### PR TITLE
In unit test mocks, use generic path for python interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ export CFLAGS="-I$(brew --prefix lz4)/include" LDFLAGS="-L$(brew --prefix lz4)/l
 before installing `memray`. Check the documentation of your package manager to know the location of the header and library
 files for more detailed information.
 
+If you are building on MacOS, you will also need to set the deployment target.
+
+```shell
+export MACOSX_DEPLOYMENT_TARGET=10.14
+```
+
 Once you have the binary dependencies installed, you can clone the repository and follow with the normal building process:
 
 ```shell

--- a/tests/unit/test_flamegraph_reporter.py
+++ b/tests/unit/test_flamegraph_reporter.py
@@ -867,10 +867,10 @@ class TestFlameGraphReporter:
                 _stack=[
                     ("me", "fun.py", 12),
                     ("parent", "fun.py", 8),
-                    ("PyObject_Call", "/opt/bb/src/python/python3.8/Python/ceval.c", 4),
+                    ("PyObject_Call", "/src/python/python3.8/Python/ceval.c", 4),
                     (
                         "PyCFunction_Call",
-                        "/opt/bb/src/python/python3.8/Objects/call.c",
+                        "/src/python/python3.8/Objects/call.c",
                         1,
                     ),
                 ],

--- a/tests/unit/test_frame_tools.py
+++ b/tests/unit/test_frame_tools.py
@@ -12,21 +12,21 @@ class TestFrameFiltering:
             [
                 (
                     "_PyEval_EvalFrameDefault",
-                    "/opt/bb/src/python/python3.8/Python/ceval.c",
+                    "/src/python/python3.8/Python/ceval.c",
                     100,
                 ),
                 True,
             ],
             [
-                ("_PyEvalSomeFunc", "/opt/bb/src/python/python3.8/Python/ceval.c", 100),
+                ("_PyEvalSomeFunc", "/src/python/python3.8/Python/ceval.c", 100),
                 True,
             ],
-            [("VectorCall", "/opt/bb/src/python/python3.8/Python/ceval.c", 100), True],
-            [("proxy_call", "/opt/bb/src/python/python3.8/Python/ceval.c", 100), True],
+            [("VectorCall", "/src/python/python3.8/Python/ceval.c", 100), True],
+            [("proxy_call", "/src/python/python3.8/Python/ceval.c", 100), True],
             [
                 (
                     "function_code_fastcall",
-                    "/opt/bb/src/python/python3.8/Modules/gcmodule.c",
+                    "/src/python/python3.8/Modules/gcmodule.c",
                     100,
                 ),
                 True,
@@ -46,7 +46,7 @@ class TestFrameFiltering:
             [
                 (
                     "_PyEval_EvalFrameDefault",
-                    "/opt/bb/src/python/python3.8/Python/ceval.c",
+                    "/src/python/python3.8/Python/ceval.c",
                     100,
                 ),
                 False,
@@ -54,7 +54,7 @@ class TestFrameFiltering:
             [
                 (
                     "PyArg_ParseTuple",
-                    "/opt/bb/src/python/python3.8/Python/ceval.c",
+                    "/src/python/python3.8/Python/ceval.c",
                     100,
                 ),
                 True,
@@ -63,7 +63,7 @@ class TestFrameFiltering:
             [
                 (
                     "_PyEval_CompileCode",
-                    "/opt/bb/src/python/python3.8/Include/code.h",
+                    "/src/python/python3.8/Include/code.h",
                     100,
                 ),
                 False,
@@ -81,7 +81,7 @@ class TestFrameFiltering:
             [
                 (
                     "_PyEval_EvalFrameDefault",
-                    "/opt/bb/src/python/python3.8/Python/ceval.c",
+                    "/src/python/python3.8/Python/ceval.c",
                     100,
                 ),
                 False,

--- a/tests/unit/test_tree_reporter.py
+++ b/tests/unit/test_tree_reporter.py
@@ -977,10 +977,10 @@ class TestTreeReporter:
                 _stack=[
                     ("me", "fun.py", 12),
                     ("parent", "fun.py", 8),
-                    ("PyObject_Call", "/opt/bb/src/python/python3.8/Python/ceval.c", 4),
+                    ("PyObject_Call", "/src/python/python3.8/Python/ceval.c", 4),
                     (
                         "PyCFunction_Call",
-                        "/opt/bb/src/python/python3.8/Objects/call.c",
+                        "/src/python/python3.8/Objects/call.c",
                         1,
                     ),
                 ],


### PR DESCRIPTION
*Issue number of the reported bug or feature request:  no issue*

**Describe your changes**
- Use the generic path prefix /src for python in the unit tests that are mocking stack frames
- Add note in the README about MacOS deployment target

**Testing performed**
- pre-commit hooks
- make dev-install pycoverage

**Additional context**
None