### PR TITLE
Add pre-commit hook for rstcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,14 @@ repos:
         stages: [pre-commit]
         types_or: [c++, c, cuda]
 
+  - repo: https://github.com/rstcheck/rstcheck
+    rev: v6.1.2
+    hooks:
+      - id: rstcheck
+        files: ^news/
+        stages: [pre-commit]
+        types: [rst]
+
   - repo: https://github.com/mgedmin/check-manifest
     rev: "0.49"
     hooks:


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #349*

**Describe your changes**
* Added rstcheck pre-commit hook to validate reStructuredText for news fragments.

**Testing performed**
1. Created rST files in the news directory, both valid and invalid. Some good examples for invalid rST are found in the [rstcheck README](https://github.com/rstcheck/rstcheck/blob/main/README.rst).
2. Staged the files and ran pre-commit. Errors should pop up for the invalid files. Unstaging the invalid files should allow everything to pass.

**Additional context**
Closes #349 
