### PR TITLE
Build musl x86-64 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -40,7 +40,7 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test
-          CIBW_TEST_COMMAND: pytest {package}/tests
+          CIBW_TEST_COMMAND: python -m pytest {package}/tests
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/news/379.feature.rst
+++ b/news/379.feature.rst
@@ -1,0 +1,1 @@
+We now publish x86-64 musllinux_1_1 wheels, compatible with Alpine Linux.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ exclude="tests/integration/(native_extension|multithreaded_extension)/"
 
 [tool.cibuildwheel]
 build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
-skip = "*musllinux*"
+skip = "*musllinux*i686*"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 
@@ -102,3 +102,11 @@ omit = [
 [tool.coverage.report]
 skip_covered = true
 show_missing = true
+
+
+# Override the default linux before-all for musl linux
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux*"
+before-all = [
+  "apk add --update libunwind-dev lz4-dev gdb lldb",
+]

--- a/src/memray/_memray/hooks.cpp
+++ b/src/memray/_memray/hooks.cpp
@@ -280,8 +280,11 @@ void*
 dlopen(const char* filename, int flag) noexcept
 {
     assert(hooks::dlopen);
-
-    void* ret = hooks::dlopen(filename, flag);
+    void* ret;
+    {
+        tracking_api::RecursionGuard guard;
+        ret = hooks::dlopen(filename, flag);
+    }
     if (ret) {
         tracking_api::Tracker::invalidate_module_cache();
         if (filename && nullptr != strstr(filename, "/_greenlet.")) {

--- a/src/memray/_memray/hooks.cpp
+++ b/src/memray/_memray/hooks.cpp
@@ -190,7 +190,11 @@ realloc(void* ptr, size_t size) noexcept
 {
     assert(hooks::realloc);
 
-    void* ret = hooks::realloc(ptr, size);
+    void* ret;
+    {
+        tracking_api::RecursionGuard guard;
+        ret = hooks::realloc(ptr, size);
+    }
     if (ret) {
         if (ptr != nullptr) {
             tracking_api::Tracker::trackDeallocation(ptr, 0, hooks::Allocator::FREE);
@@ -310,7 +314,11 @@ aligned_alloc(size_t alignment, size_t size) noexcept
 {
     assert(hooks::aligned_alloc);
 
-    void* ret = hooks::aligned_alloc(alignment, size);
+    void* ret;
+    {
+        tracking_api::RecursionGuard guard;
+        ret = hooks::aligned_alloc(alignment, size);
+    }
     if (ret) {
         tracking_api::Tracker::trackAllocation(ret, size, hooks::Allocator::ALIGNED_ALLOC);
     }


### PR DESCRIPTION
#352 Set up CI to build and test musl libc wheels

**Describe your changes**
Enable musl builds in the pyproject file. Dependencies for memray are supplied using comparable libraries from the Alpine main repository.

**Testing performed**
Running against GitHub actions is producing long build times. Further changes may be necessary.