### PR TITLE
Work around an IPython packaging bug

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,5 @@
 IPython
+IPython < 8.13; python_version < '3.9'
 sphinx
 sphinx-autobuild
 sphinx-argparse

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ greenlet; python_version < '3.11'
 pytest
 pytest-cov
 ipython
+ipython < 8.13; python_version < '3.9'

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ install_requires = [
 ]
 docs_requires = [
     "IPython",
+    "IPython < 8.13; python_version < '3.9'",
     "bump2version",
     "sphinx",
     "furo",
@@ -115,6 +116,7 @@ test_requires = [
     "pytest",
     "pytest-cov",
     "ipython",
+    "ipython < 8.13; python_version < '3.9'",
 ]
 
 benchmark_requires = [


### PR DESCRIPTION
This works around a packaging bug in IPython 8.13: it drops support for Python 3.8, but still declares support for 3.8 in its `python_requires`, so `pip` installs the new version even for Python versions that don't support it.

See https://github.com/ipython/ipython/issues/14053