### PR TITLE
Drop pins to old IPython versions

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,4 @@
 IPython
-IPython < 8.13; python_version < '3.9'
 sphinx
 sphinx-autobuild
 sphinx-argparse

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,3 @@ greenlet; python_version < '3.11'
 pytest
 pytest-cov
 ipython
-ipython < 8.13; python_version < '3.9'

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ install_requires = [
 ]
 docs_requires = [
     "IPython",
-    "IPython < 8.13; python_version < '3.9'",
     "bump2version",
     "sphinx",
     "furo",
@@ -116,7 +115,6 @@ test_requires = [
     "pytest",
     "pytest-cov",
     "ipython",
-    "ipython < 8.13; python_version < '3.9'",
 ]
 
 benchmark_requires = [


### PR DESCRIPTION
This reverts commit 62fb9ad15a8456bc356cbc3ba42e33c6299eafa5. This is no longer necessary now that IPython upstream has yanked the release which incorrectly asserted it was compatible with 3.8.

Reverts #380 