### PR TITLE
Publish Cppcoverage report in CI to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,68 @@
+name: Coverage
+
+permissions:
+  pull-requests: write
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "docs/**"
+      - "CONTRIBUTING.md"
+  release:
+    types:
+      - published
+  schedule:
+    # At 12:00 on every day-of-month
+    - cron: "0 12 */1 * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qy \
+            libunwind-dev \
+            liblz4-dev \
+            gdb \
+            lcov \
+            libdw-dev \
+            libelf-dev \
+            python3.10-dev \
+            python3.10-dbg
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install --upgrade pip cython
+          make test-install
+      - name: Disable ptrace security restrictions
+        run: |
+          echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+      - name: Add ./node_modules/.bin to PATH
+        run: |
+          export PATH="./node_modules/.bin:$PATH"
+      - name: Compute C++ coverage
+        run: |
+          make ccoverage
+      - name: Upload C++ report to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: cppcoverage.lcov
+          flags: cpp

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ check-python:
 
 .PHONY: check-js  ## Run the Javascript tests
 check-js:
+	$(NPM) install jest --save-dev
 	$(NPM) run-script test
 
 .PHONY: pycoverage
@@ -102,9 +103,9 @@ ccoverage:  ## Run the test suite, with C++ code coverage
 	CFLAGS="$(CFLAGS) -O0 -pg --coverage" $(MAKE) build
 	$(MAKE) check
 	gcov -i build/*/src/memray/_memray -i -d
-	lcov --capture --directory .  --output-file memray.info
-	lcov --extract memray.info '*/src/memray/*' --output-file memray.info
-	genhtml memray.info --output-directory memray-coverage
+	lcov --capture --directory .  --output-file cppcoverage.lcov
+	lcov --extract cppcoverage.lcov '*/src/memray/_memray/*' --output-file cppcoverage.lcov
+	genhtml *coverage.lcov --branch-coverage --output-directory memray-coverage
 	find . | grep -E '(\.gcda|\.gcno|\.gcov\.json\.gz)' | xargs rm -rf
 
 .PHONY: format
@@ -149,9 +150,9 @@ clean:  ## Clean any built/generated artifacts
 	rm -f src/memray/_memray.*.so
 	rm -f src/memray/_inject.*.so
 	rm -f src/memray/_memray.cpp
-	rm -f memray.info
 	rm -rf memray-coverage
 	rm -rf node_modules
+	rm -f cppcoverage.lcov
 
 .PHONY: bump_version
 bump_version:


### PR DESCRIPTION
Issue number of the reported bug or feature request: #354 

**Describe your changes**
This change will calculate C++ coverage in CI and upload the result to CodeCov. 

**Testing performed**
I tested on a personal fork of the project using appropriate secrets for personal CodeCov. 

**Additional context**
Add any other context about your contribution here.
Example PR: https://github.com/apurvakhatri/memray/pull/3

