### PR TITLE
Allow to create non-minimized javascript files

### DIFF
--- a/src/memray/reporters/assets/flamegraph_common.js
+++ b/src/memray/reporters/assets/flamegraph_common.js
@@ -11,6 +11,28 @@ const FILTER_UNINTERESTING = "filter_uninteresting";
 const FILTER_IMPORT_SYSTEM = "filter_import_system";
 const FILTER_THREAD = "filter_thread";
 
+class FilteredChart {
+  constructor() {
+    this.filters = {};
+  }
+  registerFilter(name, func) {
+    this.filters[name] = func;
+  }
+  unRegisterFilter(name) {
+    delete this.filters[name];
+  }
+
+  drawChart(data) {
+    let filtered = data;
+    _.forOwn(this.filters, (func) => {
+      filtered = func(filtered);
+    });
+    drawChart(filtered);
+    // Merge 0 additional elements, triggering a redraw
+    chart.merge([]);
+  }
+}
+
 var chart = null;
 let filteredChart = new FilteredChart();
 
@@ -65,28 +87,6 @@ export function onResetZoom() {
 function getChartWidth() {
   // Return the display width of the div we're drawing into
   return document.getElementById("chart").clientWidth;
-}
-
-class FilteredChart {
-  constructor() {
-    this.filters = {};
-  }
-  registerFilter(name, func) {
-    this.filters[name] = func;
-  }
-  unRegisterFilter(name) {
-    delete this.filters[name];
-  }
-
-  drawChart(data) {
-    let filtered = data;
-    _.forOwn(this.filters, (func) => {
-      filtered = func(filtered);
-    });
-    drawChart(filtered);
-    // Merge 0 additional elements, triggering a redraw
-    chart.merge([]);
-  }
 }
 
 export function onResize() {

--- a/src/memray/reporters/templates/flamegraph.html
+++ b/src/memray/reporters/templates/flamegraph.html
@@ -77,7 +77,7 @@
 
 {% block flamegraph_script %}
 <script type="text/javascript">
-  {%- include "assets/flamegraph.js" -%}
+  {{ include_file("assets/flamegraph.js") }}
 </script>
 {% endblock %}
 

--- a/src/memray/reporters/templates/table.html
+++ b/src/memray/reporters/templates/table.html
@@ -41,6 +41,6 @@
 <script src="https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js"></script>
 <script src="https://cdn.datatables.net/1.10.23/js/dataTables.bootstrap4.min.js"></script>
 <script type="text/javascript">
-  {%- include "assets/table.js" -%}
+  {{ include_file("assets/table.js") }}
 </script>
 {% endblock %}

--- a/src/memray/reporters/templates/temporal_flamegraph.html
+++ b/src/memray/reporters/templates/temporal_flamegraph.html
@@ -38,6 +38,6 @@
 
 {% block flamegraph_script %}
 <script type="text/javascript">
-  {%- include "assets/temporal_flamegraph.js" -%}
+  {{ include_file("assets/temporal_flamegraph.js") }}
 </script>
 {% endblock %}


### PR DESCRIPTION
To make debugging of the generated javascript possible, we need to allow
to set `minimize: false` in the webpack.config.js file. Unfortunately
this has some problems:

* The non-minimized javascript templates includes some stuff that causes
  jinja2 to freak out because it tries to interpolate the contents.
* The order of declaration of some classes is wrong and it fails to
  create some objects at import time.

To help with this, add a new globally available function in the jinja
templates that allows us to include files without interpolating them and
fix the order-of-definition problems.