### PR TITLE
Fix cibuildwheel `before-all` configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ manylinux-i686-image = "manylinux2010"
 [tool.cibuildwheel.linux]
 before-all = [
   "yum install -y libunwind-devel lz4-devel gdb",
-  "yum install -y lldb || echo 'lldb is not available'",
+  "if ! yum install -y lldb; then echo lldb is not available; fi",
 ]
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
If you provide multiple commands, `cibuildwheel` naively stitches them together into one shell command by concatenating them with `&&` in between. That changes the meaning of a shell `||` (it winds up running if a completely unrelated command fails).

Fix this by switching from `||` to an `if` statement.
