### PR TITLE
Drop Cython tracing from tests

### DIFF
--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -1147,6 +1147,8 @@ PyTraceFunction(
     }
 
     if (frame != PyEval_GetFrame()) {
+        // This should only happen for the phony frames produced by Cython
+        // extension modules that were compiled with `profile=True`.
         return 0;
     }
 


### PR DESCRIPTION
A private Cython module used by our test suite still asks Cython to enable tracing and profiling support, even though we no longer need or make use of the artificial frames it supports (in fact, we deliberately detect and ignore these artificial frames).

Tell Cython to stop producing them. This lets Memray build on Python 3.12, for which Cython does not yet support profiling or tracing.