### PR TITLE
Support added for memray --version & -V

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ positional arguments:
 optional arguments:
   -h, --help            Show this help message and exit
   -v, --verbose         Increase verbosity. Option is additive and can be specified up to 3 times
+  -V, --version         Displays memray version
 
 Please submit feedback, ideas, and bug reports by filing a new issue at https://github.com/bloomberg/memray/issues
 ```

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ positional arguments:
 optional arguments:
   -h, --help            Show this help message and exit
   -v, --verbose         Increase verbosity. Option is additive and can be specified up to 3 times
-  -V, --version         Displays memray version
+  -V, --version         Displays the current version of Memray
 
 Please submit feedback, ideas, and bug reports by filing a new issue at https://github.com/bloomberg/memray/issues
 ```

--- a/news/420.feature.rst
+++ b/news/420.feature.rst
@@ -1,0 +1,1 @@
+Allow to report the current version of Memray via a ``--version/-V`` command line parameter

--- a/src/memray/commands/__init__.py
+++ b/src/memray/commands/__init__.py
@@ -5,6 +5,8 @@ import textwrap
 from typing import List
 from typing import Optional
 
+from memray._version import __version__
+
 try:
     from typing import Protocol
 except ImportError:
@@ -82,6 +84,13 @@ def get_argument_parser() -> argparse.ArgumentParser:
         action="count",
         default=0,
         help="Increase verbosity. Option is additive and can be specified up to 3 times",
+    )
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=__version__,
+        help="Displays memray version",
     )
 
     subparsers = parser.add_subparsers(

--- a/src/memray/commands/__init__.py
+++ b/src/memray/commands/__init__.py
@@ -90,7 +90,7 @@ def get_argument_parser() -> argparse.ArgumentParser:
         "--version",
         action="version",
         version=__version__,
-        help="Displays memray version",
+        help="Displays the current version of Memray",
     )
 
     subparsers = parser.add_subparsers(


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #417 *

**Describe your changes**
In order for memray to display its own version, I have added an argument to basic parser. Since it is added as an option rather than positional argument, only the init file was modified. Further, README has been updated on how to use the option. 

**Testing performed**
The command "memray --version" or "memray -V" successfully ran on my system (MacOS).

**Additional context**
-
