### PR TITLE
Set our recursion guard in all hooks

### DIFF
--- a/news/433.bugfix.rst
+++ b/news/433.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug leading to a deadlock when Memray is used to profile an application that uses the jemalloc implementation of ``malloc``.


### PR DESCRIPTION
This prevents reentrancy if one hooked function calls into another. For instance, the jemalloc implementation of `malloc` calls into `mmap` while holding a lock, and our `mmap` hook calls `malloc`, so we must prevent our `mmap` hook from running beneath our `malloc` hook.

Closes #336 