### PR TITLE
Added new commands to memray attach

### DIFF
--- a/docs/attach.rst
+++ b/docs/attach.rst
@@ -103,12 +103,26 @@ or ``thread backtrace all`` in lldb.
 
 .. _file a bug report: https://github.com/bloomberg/memray/issues/new?assignees=&labels=bug&template=---bug-report.yaml
 
-.. _memray attach cli reference:
-
 CLI Reference
 -------------
+
+.. _memray attach cli reference:
+
+memray attach
+^^^^^^^^^^^^^
 
 .. argparse::
     :ref: memray.commands.get_argument_parser
     :path: attach
     :prog: memray
+    :nodefaultconst:
+    :noepilog:
+
+memray detach
+^^^^^^^^^^^^^
+
+.. argparse::
+    :ref: memray.commands.get_argument_parser
+    :path: detach
+    :prog: memray
+    :nodefaultconst:

--- a/news/458.feature.1.rst
+++ b/news/458.feature.1.rst
@@ -1,0 +1,2 @@
+A new ``memray detach`` command allows you to manually deactivate tracking that
+was started by a previous call to ``memray attach``.

--- a/news/458.feature.rst
+++ b/news/458.feature.rst
@@ -1,2 +1,2 @@
 ``memray attach`` has been enhanced to allow tracking for only a set period of
-time, or until a set heap size is reached.
+time.

--- a/news/458.feature.rst
+++ b/news/458.feature.rst
@@ -1,3 +1,2 @@
 ``memray attach`` has been enhanced to allow tracking for only a set period of
-time, or until a set heap size is reached. You can also manually deactivate
-tracking that was started by a previous call to ``memray attach``.
+time, or until a set heap size is reached.

--- a/news/458.feature.rst
+++ b/news/458.feature.rst
@@ -1,0 +1,3 @@
+``memray attach`` has been enhanced to allow tracking for only a set period of
+time, or until a set heap size is reached. You can also manually deactivate
+tracking that was started by a previous call to ``memray attach``.

--- a/src/memray/commands/__init__.py
+++ b/src/memray/commands/__init__.py
@@ -68,6 +68,7 @@ _COMMANDS: List[Command] = [
     stats.StatsCommand(),
     transform.TransformCommand(),
     attach.AttachCommand(),
+    attach.DetachCommand(),
 ]
 
 

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -48,6 +48,11 @@ def _get_current_heap_size() -> int:
     return rss_bytes
 
 
+class BareExceptionMessage(Exception):
+    def __repr__(self):
+        return self.args[0]
+
+
 class RepeatingTimer(threading.Thread):
     def __init__(self, interval, function):
         self._interval = interval
@@ -143,6 +148,8 @@ if not hasattr(memray, "_last_tracker"):
 if {mode!r} == "ACTIVATE":
     activate_tracker()
 elif {mode!r} == "DEACTIVATE":
+    if not getattr(memray, "_last_tracker", None):
+        raise BareExceptionMessage("no previous `memray attach` call detected")
     deactivate_last_tracker()
 elif {mode!r} == "UNTIL_HEAP_SIZE":
     track_until_heap_size({heap_size})

--- a/tests/integration/test_attach.py
+++ b/tests/integration/test_attach.py
@@ -121,7 +121,7 @@ def run_process(cmd, wait_for_stderr=False):
             print(exc.output)
             raise
     finally:
-        tracked_process.stdin.write("1\n")
+        print("1", file=tracked_process.stdin, flush=True)
         if wait_for_stderr:
             process_stderr = tracked_process.stderr.readline()
             while "WARNING" in process_stderr:

--- a/tests/integration/test_attach.py
+++ b/tests/integration/test_attach.py
@@ -190,24 +190,6 @@ def test_aggregated_attach(tmp_path, method):
 
 
 @pytest.mark.parametrize("method", ["lldb", "gdb"])
-def test_attach_heap(tmp_path, method):
-    if not debugger_available(method):
-        pytest.skip(f"a supported {method} debugger isn't installed")
-
-    # GIVEN
-    limit = 50 * 1024 * 1024
-    output = tmp_path / "test.bin"
-    attach_cmd = generate_attach_command(method, output, "--heap-limit", str(limit))
-
-    # WHEN
-    process_stderr = run_process(attach_cmd, wait_for_stderr=True)
-
-    # THEN
-    assert "memray: Deactivating tracking: heap size has reached" in process_stderr
-    assert f" the limit was {limit}" in process_stderr
-
-
-@pytest.mark.parametrize("method", ["lldb", "gdb"])
 def test_attach_time(tmp_path, method):
     if not debugger_available(method):
         pytest.skip(f"a supported {method} debugger isn't installed")

--- a/tests/unit/test_attach.py
+++ b/tests/unit/test_attach.py
@@ -20,26 +20,3 @@ class TestAttachSubCommand:
         captured = capsys.readouterr()
         print("Error", captured.err)
         assert "Can't use aggregated mode without an output file." in captured.err
-
-
-class TestAttachSubCommandOptions:
-    @pytest.mark.parametrize(
-        "arg1,arg2",
-        [
-            ("--heap-limit=10", "--duration=10"),
-        ],
-    )
-    def test_memray_attach_stop_tracking_option_with_other_mode_options(
-        self, arg1, arg2, capsys
-    ):
-        # WHEN
-        with pytest.raises(SystemExit):
-            main(["attach", "1234", arg1, arg2])
-
-        captured = capsys.readouterr()
-        arg1_name = arg1.split("=")[0]
-        arg2_name = arg2.split("=")[0]
-        assert (
-            f"argument {arg2_name}: not allowed with argument {arg1_name}"
-            in captured.err
-        )

--- a/tests/unit/test_attach.py
+++ b/tests/unit/test_attach.py
@@ -24,35 +24,8 @@ class TestAttachSubCommand:
 
 class TestAttachSubCommandOptions:
     @pytest.mark.parametrize(
-        "option",
-        [
-            ["--output", "foo"],
-            ["-o", "foo"],
-            ["--native"],
-            ["--force"],
-            ["-f"],
-            ["--aggregate"],
-            ["--follow-fork"],
-            ["--trace-python-allocators"],
-            ["--no-compress"],
-        ],
-    )
-    def test_memray_attach_stop_tracking_option_with_other_options(
-        self, option, capsys
-    ):
-        # WHEN
-        with pytest.raises(SystemExit):
-            main(["attach", "1234", "--stop-tracking", *option])
-
-        captured = capsys.readouterr()
-        assert "Can't use --stop-tracking with" in captured.err
-        assert option[0] in captured.err.split()
-
-    @pytest.mark.parametrize(
         "arg1,arg2",
         [
-            ("--stop-tracking", "--heap-limit=10"),
-            ("--stop-tracking", "--duration=10"),
             ("--heap-limit=10", "--duration=10"),
         ],
     )

--- a/tests/unit/test_attach.py
+++ b/tests/unit/test_attach.py
@@ -18,4 +18,55 @@ class TestAttachSubCommand:
             main(["attach", "--aggregate", "1234"])
 
         captured = capsys.readouterr()
+        print("Error", captured.err)
         assert "Can't use aggregated mode without an output file." in captured.err
+
+
+class TestAttachSubCommandOptions:
+    @pytest.mark.parametrize(
+        "option",
+        [
+            ["--output", "foo"],
+            ["-o", "foo"],
+            ["--native"],
+            ["--force"],
+            ["-f"],
+            ["--aggregate"],
+            ["--follow-fork"],
+            ["--trace-python-allocators"],
+            ["--no-compress"],
+        ],
+    )
+    def test_memray_attach_stop_tracking_option_with_other_options(
+        self, option, capsys
+    ):
+        # WHEN
+        with pytest.raises(SystemExit):
+            main(["attach", "1234", "--stop-tracking", *option])
+
+        captured = capsys.readouterr()
+        assert "Can't use --stop-tracking with" in captured.err
+        assert option[0] in captured.err.split()
+
+    @pytest.mark.parametrize(
+        "arg1,arg2",
+        [
+            ("--stop-tracking", "--heap-limit=10"),
+            ("--stop-tracking", "--duration=10"),
+            ("--heap-limit=10", "--duration=10"),
+        ],
+    )
+    def test_memray_attach_stop_tracking_option_with_other_mode_options(
+        self, arg1, arg2, capsys
+    ):
+        # WHEN
+        with pytest.raises(SystemExit):
+            main(["attach", "1234", arg1, arg2])
+
+        captured = capsys.readouterr()
+        arg1_name = arg1.split("=")[0]
+        arg2_name = arg2.split("=")[0]
+        assert (
+            f"argument {arg2_name}: not allowed with argument {arg1_name}"
+            in captured.err
+        )


### PR DESCRIPTION
Letting memray attach supports deactivating an attached tracker manually, or after a specified heap size is reached, or after a specified time limit has elapsed.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
