### PR TITLE
Move the `memray attach` callback into a module

### DIFF
--- a/src/memray/_attach_callback.py
+++ b/src/memray/_attach_callback.py
@@ -1,0 +1,34 @@
+import atexit
+
+import memray
+
+
+def deactivate_last_tracker() -> None:
+    global _last_tracker
+    tracker = _last_tracker
+
+    if tracker:
+        _last_tracker = None
+        tracker.__exit__(None, None, None)
+
+
+def activate_tracking(**tracker_kwargs) -> None:
+    global _last_tracker
+    deactivate_last_tracker()
+
+    tracker = memray.Tracker(**tracker_kwargs)
+    try:
+        tracker.__enter__()
+        _last_tracker = tracker
+    finally:
+        # Prevent any exception from keeping the tracker alive.
+        # This way resources are cleaned up ASAP.
+        del tracker
+
+
+def callback(**tracker_kwargs) -> None:
+    activate_tracking(**tracker_kwargs)
+
+
+_last_tracker = None
+atexit.register(deactivate_last_tracker)

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -14,7 +14,6 @@ import sys
 import threading
 
 import memray
-from memray import FileFormat
 from memray._errors import MemrayCommandError
 
 from .live import LiveCommand
@@ -340,11 +339,13 @@ class AttachCommand:
             live_port = _get_free_port()
             destination = memray.SocketDestination(server_port=live_port)
 
-        if args.aggregate and not hasattr(args, "output"):
+        if args.aggregate and not args.output:
             parser.error("Can't use aggregated mode without an output file.")
 
         file_format = (
-            f"file_format={FileFormat.AGGREGATED_ALLOCATIONS}" if args.aggregate else ""
+            "file_format=memray.FileFormat.AGGREGATED_ALLOCATIONS"
+            if args.aggregate
+            else ""
         )
 
         tracker_call = (

--- a/tests/integration/test_attach.py
+++ b/tests/integration/test_attach.py
@@ -34,7 +34,7 @@ def bar():
 
 def baz():
     allocator = MemoryAllocator()
-    allocator.valloc(1024)
+    allocator.valloc(50 * 1024 * 1024)
     allocator.free()
 
 
@@ -52,13 +52,43 @@ for line in sys.stdin:
 """
 
 
-@pytest.mark.parametrize("method", ["lldb", "gdb"])
-def test_basic_attach(tmp_path, method):
-    if not debugger_available(method):
-        pytest.skip(f"a supported {method} debugger isn't installed")
+def compare_allocations(allocations1, allocations2):
+    assert len(allocations1) == len(allocations2)
+    for i in range(0, len(allocations1)):
+        assert allocations1[i].allocator == allocations2[i].allocator
+        assert allocations1[i].n_allocations == allocations2[i].n_allocations
+        assert allocations1[i].size == allocations2[i].size
+        assert allocations1[i].stack_id == allocations2[i].stack_id
+        assert allocations1[i].tid == allocations2[i].tid
+        assert allocations1[i].native_stack_id == allocations2[i].native_stack_id
+        assert (
+            allocations1[i].native_segment_generation
+            == allocations2[i].native_segment_generation
+        )
+        assert allocations1[i].thread_name == allocations2[i].thread_name
 
-    # GIVEN
-    output = tmp_path / "test.bin"
+
+def generate_command(method, output, aggregate):
+    cmd = [
+        sys.executable,
+        "-m",
+        "memray",
+        "attach",
+        "--verbose",
+        "--force",
+        "--method",
+        method,
+        "-o",
+        str(output),
+    ]
+
+    if aggregate:
+        cmd.append("--aggregate")
+
+    return cmd
+
+
+def run_process(cmd):
     tracked_process = subprocess.Popen(
         [sys.executable, "-uc", PROGRAM],
         stdin=subprocess.PIPE,
@@ -71,22 +101,12 @@ def test_basic_attach(tmp_path, method):
     assert tracked_process.stdout is not None
 
     assert tracked_process.stdout.readline() == "ready\n"
-    attach_cmd = [
-        sys.executable,
-        "-m",
-        "memray",
-        "attach",
-        "--verbose",
-        "--method",
-        method,
-        "-o",
-        str(output),
-        str(tracked_process.pid),
-    ]
+
+    cmd.append(str(tracked_process.pid))
 
     # WHEN
     try:
-        subprocess.check_output(attach_cmd, stderr=subprocess.STDOUT, text=True)
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True)
     except subprocess.CalledProcessError as exc:
         if "Couldn't write extended state status" in exc.output:
             # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=898048
@@ -103,14 +123,65 @@ def test_basic_attach(tmp_path, method):
     assert "" == tracked_process.stdout.read()
     assert tracked_process.returncode == 0
 
-    reader = FileReader(output)
-    records = list(reader.get_allocation_records())
-    vallocs = [
+
+def get_functions(allocations):
+    (valloc,) = allocations
+    return [f[0] for f in valloc.stack_trace()]
+
+
+def get_relevant_allocations(records):
+    return [
         record
         for record in filter_relevant_allocations(records)
         if record.allocator == AllocatorType.VALLOC
     ]
 
-    (valloc,) = vallocs
-    functions = [f[0] for f in valloc.stack_trace()]
-    assert functions == ["valloc", "baz", "bar", "foo", "<module>"]
+
+@pytest.mark.parametrize("method", ["lldb", "gdb"])
+@pytest.mark.parametrize("aggregate", [True, False])
+def test_basic_attach(tmp_path, method, aggregate):
+    if not debugger_available(method):
+        pytest.skip(f"a supported {method} debugger isn't installed")
+
+    # GIVEN
+    output = tmp_path / "test.bin"
+
+    attach_cmd = generate_command(method, output, aggregate)
+
+    run_process(attach_cmd)
+
+    reader = FileReader(output)
+
+    # WHEN
+    try:
+        hwa_allocation_records = list(reader.get_high_watermark_allocation_records())
+        assert hwa_allocation_records is not None
+        allocation_records = list(reader.get_allocation_records())
+    except NotImplementedError as exc:
+        if aggregate:
+            assert (
+                "Can't get all allocations from a pre-aggregated capture file."
+                in str(exc)
+            )
+
+    hwa_relevant_allocations_records = get_relevant_allocations(hwa_allocation_records)
+    relevant_allocations_records = (
+        get_relevant_allocations(allocation_records) if not aggregate else []
+    )
+
+    if not aggregate:
+        assert get_functions(hwa_relevant_allocations_records) == get_functions(
+            relevant_allocations_records
+        )
+    else:
+        output_no_aggregate = tmp_path / "test.bin"
+        attach_cmd = generate_command(method, output_no_aggregate, False)
+        run_process(attach_cmd)
+
+        reader = FileReader(output_no_aggregate)
+        allocation_records = list(reader.get_high_watermark_allocation_records())
+        relevant_allocations_records = get_relevant_allocations(allocation_records)
+
+        compare_allocations(
+            relevant_allocations_records, hwa_relevant_allocations_records
+        )

--- a/tests/integration/test_attach.py
+++ b/tests/integration/test_attach.py
@@ -52,22 +52,6 @@ for line in sys.stdin:
 """
 
 
-def compare_allocations(allocations1, allocations2):
-    assert len(allocations1) == len(allocations2)
-    for i in range(0, len(allocations1)):
-        assert allocations1[i].allocator == allocations2[i].allocator
-        assert allocations1[i].n_allocations == allocations2[i].n_allocations
-        assert allocations1[i].size == allocations2[i].size
-        assert allocations1[i].stack_id == allocations2[i].stack_id
-        assert allocations1[i].tid == allocations2[i].tid
-        assert allocations1[i].native_stack_id == allocations2[i].native_stack_id
-        assert (
-            allocations1[i].native_segment_generation
-            == allocations2[i].native_segment_generation
-        )
-        assert allocations1[i].thread_name == allocations2[i].thread_name
-
-
 def generate_command(method, output, aggregate):
     cmd = [
         sys.executable,
@@ -124,12 +108,11 @@ def run_process(cmd):
     assert tracked_process.returncode == 0
 
 
-def get_functions(allocations):
-    (valloc,) = allocations
-    return [f[0] for f in valloc.stack_trace()]
+def get_call_stack(allocation):
+    return [f[0] for f in allocation.stack_trace()]
 
 
-def get_relevant_allocations(records):
+def get_relevant_vallocs(records):
     return [
         record
         for record in filter_relevant_allocations(records)
@@ -138,50 +121,42 @@ def get_relevant_allocations(records):
 
 
 @pytest.mark.parametrize("method", ["lldb", "gdb"])
-@pytest.mark.parametrize("aggregate", [True, False])
-def test_basic_attach(tmp_path, method, aggregate):
+def test_basic_attach(tmp_path, method):
     if not debugger_available(method):
         pytest.skip(f"a supported {method} debugger isn't installed")
 
     # GIVEN
     output = tmp_path / "test.bin"
-
-    attach_cmd = generate_command(method, output, aggregate)
-
-    run_process(attach_cmd)
-
-    reader = FileReader(output)
+    attach_cmd = generate_command(method, output, aggregate=False)
 
     # WHEN
-    try:
-        hwa_allocation_records = list(reader.get_high_watermark_allocation_records())
-        assert hwa_allocation_records is not None
-        allocation_records = list(reader.get_allocation_records())
-    except NotImplementedError as exc:
-        if aggregate:
-            assert (
-                "Can't get all allocations from a pre-aggregated capture file."
-                in str(exc)
-            )
+    run_process(attach_cmd)
 
-    hwa_relevant_allocations_records = get_relevant_allocations(hwa_allocation_records)
-    relevant_allocations_records = (
-        get_relevant_allocations(allocation_records) if not aggregate else []
-    )
+    # THEN
+    reader = FileReader(output)
+    (valloc,) = get_relevant_vallocs(reader.get_allocation_records())
+    assert get_call_stack(valloc) == ["valloc", "baz", "bar", "foo", "<module>"]
 
-    if not aggregate:
-        assert get_functions(hwa_relevant_allocations_records) == get_functions(
-            relevant_allocations_records
-        )
-    else:
-        output_no_aggregate = tmp_path / "test.bin"
-        attach_cmd = generate_command(method, output_no_aggregate, False)
-        run_process(attach_cmd)
 
-        reader = FileReader(output_no_aggregate)
-        allocation_records = list(reader.get_high_watermark_allocation_records())
-        relevant_allocations_records = get_relevant_allocations(allocation_records)
+@pytest.mark.parametrize("method", ["lldb", "gdb"])
+def test_aggregated_attach(tmp_path, method):
+    if not debugger_available(method):
+        pytest.skip(f"a supported {method} debugger isn't installed")
 
-        compare_allocations(
-            relevant_allocations_records, hwa_relevant_allocations_records
-        )
+    # GIVEN
+    output = tmp_path / "test.bin"
+    attach_cmd = generate_command(method, output, aggregate=True)
+
+    # WHEN
+    run_process(attach_cmd)
+
+    # THEN
+    reader = FileReader(output)
+    with pytest.raises(
+        NotImplementedError,
+        match="Can't get all allocations from a pre-aggregated capture file.",
+    ):
+        list(reader.get_allocation_records())
+
+    (valloc,) = get_relevant_vallocs(reader.get_high_watermark_allocation_records())
+    assert get_call_stack(valloc) == ["valloc", "baz", "bar", "foo", "<module>"]

--- a/tests/unit/test_attach.py
+++ b/tests/unit/test_attach.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+
+import pytest
+
+from memray.commands import main
+
+
+@patch("memray.commands.attach.debugger_available")
+class TestAttachSubCommand:
+    def test_memray_attach_aggregated_without_output_file(
+        self, is_debugger_available_mock, capsys
+    ):
+        # GIVEN
+        is_debugger_available_mock.return_value = True
+
+        # WHEN
+        with pytest.raises(SystemExit):
+            main(["attach", "--aggregate", "1234"])
+
+        captured = capsys.readouterr()
+        assert "Can't use aggregated mode without an output file." in captured.err


### PR DESCRIPTION
Previously we were maintaining this as a string literal inside the
client-side `attach` code, but it's growing more complex, and we're
reaching the point where it would be advantageous to have it in a normal
module that linters and type checkers can analyze.

This commit is based on the code in #455, and will need to be rebased once we land that, but it's ready for review other than that. Marking it draft until #455 is landed.