### PR TITLE
Declare our minimum supported Cython version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = [
      "setuptools",
      "wheel",
-     "Cython"
+     "Cython>=0.29.31"
 ]
 
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
Now that we use `noexcept` in some Cython functions signatures, we can no longer support Cython versions prior to 0.29.31.
