### PR TITLE
Miscellaneous improvements to our documentation and help messages

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -3,9 +3,6 @@ name: Wheels
 on:
   push:
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "CONTRIBUTING.md"
   release:
     types:
       - published

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,13 +64,13 @@ jobs:
         run: |
           make pycoverage
       - name: Upload C++ report to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: cppcoverage.lcov
           flags: cpp
       - name: Upload {P,C}ython report to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: pycoverage.lcov

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,7 @@
 """Sphinx configuration file for memray's documentation."""
 
+import os
+
 # -- General configuration ------------------------------------------------------------
 
 # The name of a reST role (builtin or Sphinx extension) to use as the default role,
@@ -57,3 +59,10 @@ intersphinx_mapping = {
         (None,),
     ),
 }
+
+# -- Options for sphinx-argparse ------------------------------------------------------
+
+# Limit the width of usage messages. argparse defaults to the terminal width,
+# but we don't want different output depending on the terminal width where the
+# docs were built.
+os.environ["COLUMNS"] = "88"

--- a/src/memray/_ipython/flamegraph.py
+++ b/src/memray/_ipython/flamegraph.py
@@ -47,7 +47,7 @@ def argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--trace-python-allocators",
         action="store_true",
-        help="Record allocations made by the Pymalloc allocator",
+        help="Record allocations made by the pymalloc allocator",
         default=False,
     )
     alloc_type_group = parser.add_mutually_exclusive_group()

--- a/src/memray/commands/__init__.py
+++ b/src/memray/commands/__init__.py
@@ -106,7 +106,7 @@ def get_argument_parser() -> argparse.ArgumentParser:
 
         # Add the subcommand
         command_parser = subparsers.add_parser(
-            name, help=command.__doc__, epilog=_EPILOG
+            name, help=command.__doc__, description=command.__doc__, epilog=_EPILOG
         )
         command_parser.set_defaults(entrypoint=command.run)
         command.prepare_parser(command_parser)

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -264,7 +264,7 @@ class AttachCommand:
         parser.add_argument(
             "--trace-python-allocators",
             action="store_true",
-            help="Record allocations made by the Pymalloc allocator",
+            help="Record allocations made by the pymalloc allocator",
             default=False,
         )
         compression = parser.add_mutually_exclusive_group()

--- a/src/memray/commands/run.py
+++ b/src/memray/commands/run.py
@@ -236,7 +236,7 @@ class RunCommand:
         parser.add_argument(
             "--trace-python-allocators",
             action="store_true",
-            help="Record allocations made by the Pymalloc allocator",
+            help="Record allocations made by the pymalloc allocator",
             default=False,
         )
         parser.add_argument(


### PR DESCRIPTION
Before adding a `description=` to our `ArgumentParser`'s:
```text
$ memray parse --help
usage: memray parse [-h] results

positional arguments:
  results     Results of the tracker run

options:
  -h, --help  show this help message and exit

Please submit feedback, ideas, and bug reports by filing a new issue at https://github.com/bloomberg/memray/issues
```

After:
```text
$ memray parse --help
usage: memray parse [-h] results

Debug a results file by parsing and printing each record in it

positional arguments:
  results     Results of the tracker run

options:
  -h, --help  show this help message and exit

Please submit feedback, ideas, and bug reports by filing a new issue at https://github.com/bloomberg/memray/issues
```

Before setting `COLUMNS` in our `docs/conf.py`:
![image](https://github.com/bloomberg/memray/assets/29423/03f440d2-299a-492f-8ef9-223dc03eb1d6)

After:
![image](https://github.com/bloomberg/memray/assets/29423/c74b9a30-8536-41de-adc2-a842d51b6bee)

