### PR TITLE
Fix Dockerfile - python3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM debian:latest
+FROM debian:bullseye-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get install -y --force-yes --no-install-recommends \


### PR DESCRIPTION
Image debian:latest contains python3.11 so "docker build" returns error:

 > [3/8] RUN python3.9 -m venv "/venv":
0.349 /bin/sh: 1: python3.9: not found

python3.9 is installed in Debian Bullseye release.