### PR TITLE
Always run required CI checks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "docs/**"
-      - "CONTRIBUTING.md"
   release:
     types:
       - published


### PR DESCRIPTION
As Matt [said for python-comdb2](https://github.com/bloomberg/python-comdb2/pull/45#discussion_r1367462028): let's not do this.
