### PR TITLE
Fix debugger output parsing in attach command

### DIFF
--- a/news/490.bugfix.rst
+++ b/news/490.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug that was caussing attaching to fail in macOS Sonoma.

--- a/src/memray/commands/_attach.lldb
+++ b/src/memray/commands/_attach.lldb
@@ -21,7 +21,7 @@ expr auto $dlerror = $dlsym($rtld_default, "dlerror")
 expr auto $dll = ((void*(*)(const char*, int))$dlopen)($libpath, $rtld_now)
 p ((char*(*)(void))$dlerror)()
 expr auto $spawn = $dlsym($dll, "memray_spawn_client")
-p ((int(*)(int))$spawn)($port) ? "FAILURE" : "SUCCESS"
+p ((int(*)(int))$spawn)($port)?"FAILURE":"SUCCESS"
 DONE
 
 continue

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -192,7 +192,10 @@ def inject(debugger: str, pid: int, port: int, verbose: bool) -> str | None:
         print(f"debugger return code: {returncode}")
         print(f"debugger output:\n{output}")
 
-    if returncode == 0 and ' = "SUCCESS"' in output:
+    command_output_lines = (
+        line for line in output.splitlines() if not line.startswith(f"({debugger})")
+    )
+    if returncode == 0 and any(' "SUCCESS"' in line for line in command_output_lines):
         return None
 
     # An error occurred. Give the best message we can. This is hacky; we don't


### PR DESCRIPTION
When using lldb in macOS, the output of lldb is slighly different and we
are not properly matching that is what we expect. To avoid having to
rely on weird hacks to not detect the actual command we issue, filter
the output to not contain the lines that have the debugger promt to only
check against the actual debugger output. This simplifies the check and
provides an easier way to do assert that we are in the situation we
expect.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
