### PR TITLE
Disable leaks warning if tracing Python allocators

### DIFF
--- a/news/492.feature.rst
+++ b/news/492.feature.rst
@@ -1,0 +1,1 @@
+When generating a ``--leaks`` flamegraph, don't show a warning that the ``pymalloc`` allocator is in use if ``--trace-python-allocators`` was used when generating the capture file.

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -673,6 +673,7 @@ cdef class Tracker:
                 command_line,
                 native_traces,
                 file_format,
+                trace_python_allocators,
             )
         )
 
@@ -753,6 +754,7 @@ cdef _create_metadata(header, peak_memory):
         pid=header["pid"],
         python_allocator=allocator_id_to_name[header["python_allocator"]],
         has_native_traces=header["native_traces"],
+        trace_python_allocators=header["trace_python_allocators"],
     )
 
 

--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -87,7 +87,10 @@ RecordReader::readHeader(HeaderRecord& header)
                 sizeof(header.skipped_frames_on_main_tid))
         || !d_input->read(
                 reinterpret_cast<char*>(&header.python_allocator),
-                sizeof(header.python_allocator)))
+                sizeof(header.python_allocator))
+        || !d_input->read(
+                reinterpret_cast<char*>(&header.trace_python_allocators),
+                sizeof(header.trace_python_allocators)))
     {
         throw std::ios_base::failure("Failed to read input file header.");
     }
@@ -936,7 +939,7 @@ RecordReader::dumpAllRecords()
     printf("HEADER magic=%.*s version=%d native_traces=%s file_format=%s"
            " n_allocations=%zd n_frames=%zd start_time=%lld end_time=%lld"
            " pid=%d main_tid=%lu skipped_frames_on_main_tid=%zd"
-           " command_line=%s python_allocator=%s\n",
+           " command_line=%s python_allocator=%s trace_python_allocators=%s\n",
            (int)sizeof(d_header.magic),
            d_header.magic,
            d_header.version,
@@ -950,7 +953,8 @@ RecordReader::dumpAllRecords()
            d_header.main_tid,
            d_header.skipped_frames_on_main_tid,
            d_header.command_line.c_str(),
-           python_allocator.c_str());
+           python_allocator.c_str(),
+           d_header.trace_python_allocators ? "true" : "false");
 
     switch (d_header.file_format) {
         case FileFormat::ALL_ALLOCATIONS:

--- a/src/memray/_memray/record_writer.h
+++ b/src/memray/_memray/record_writer.h
@@ -62,7 +62,8 @@ createRecordWriter(
         std::unique_ptr<memray::io::Sink> sink,
         const std::string& command_line,
         bool native_traces,
-        FileFormat file_format);
+        FileFormat file_format,
+        bool trace_python_allocators);
 
 template<typename T>
 bool inline RecordWriter::writeSimpleType(const T& item)

--- a/src/memray/_memray/record_writer.pxd
+++ b/src/memray/_memray/record_writer.pxd
@@ -13,4 +13,5 @@ cdef extern from "record_writer.h" namespace "memray::api":
         string command_line,
         bool native_trace,
         FileFormat file_format,
+        bool trace_python_allocators,
     ) except+

--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -18,7 +18,7 @@
 namespace memray::tracking_api {
 
 extern const char MAGIC[7];  // Value assigned in records.cpp
-const int CURRENT_HEADER_VERSION = 10;
+const int CURRENT_HEADER_VERSION = 11;
 
 using frame_id_t = size_t;
 using thread_id_t = unsigned long;
@@ -118,6 +118,7 @@ struct HeaderRecord
     thread_id_t main_tid{};
     size_t skipped_frames_on_main_tid{};
     PythonAllocatorType python_allocator{};
+    bool trace_python_allocators{};
 };
 
 struct MemoryRecord

--- a/src/memray/_memray/records.pxd
+++ b/src/memray/_memray/records.pxd
@@ -34,6 +34,7 @@ cdef extern from "records.h" namespace "memray::tracking_api":
        size_t main_tid
        size_t skipped_frames_on_main_tid
        int python_allocator
+       bool trace_python_allocators
 
    cdef cppclass Allocation:
        thread_id_t tid

--- a/src/memray/_metadata.py
+++ b/src/memray/_metadata.py
@@ -13,3 +13,4 @@ class Metadata:
     pid: int
     python_allocator: str
     has_native_traces: bool
+    trace_python_allocators: bool

--- a/src/memray/reporters/templates/base.html
+++ b/src/memray/reporters/templates/base.html
@@ -55,16 +55,21 @@
   <main class="container-fluid">
     <div class="row">
       <div class="col bg-light py-3">
-        {% if show_memory_leaks and metadata.python_allocator == "pymalloc" %}
+        {% if show_memory_leaks and metadata.python_allocator == "pymalloc" and not metadata.trace_python_allocators %}
         <div class="alert alert-warning alert-dismissible fade show" role="alert">
-          <p><strong>Report generated using "--leaks" using pymalloc
-              allocator</strong></p>
-          <p>This report for memory leaks was generated with the
-            pymalloc allocator active. This can show confusing results because
-            the Python allocator doesn't necessarily release memory to
-            the system when Python objects are deallocated and these can still
-            appear as "leaks". If you want to exclude these, you can run your
-            application with the `PYTHONMALLOC=malloc` environment variable set.
+          <p><strong>Report generated using "--leaks" using pymalloc allocator</strong></p>
+          <p>
+            This report for memory leaks was generated with the pymalloc
+            allocator active, but without tracking enabled for calls to the
+            pymalloc allocator. This will show confusing results because the
+            pymalloc allocator will retain memory in memory pools even after
+            the objects that requested that memory are deallocated, and Memray
+            won't be able to distinguish memory set aside for reuse from leaked
+            memory. You should rerun your application with the
+            `PYTHONMALLOC=malloc` environment variable set or pass the
+            `--trace-python-allocators` flag when profiling your application.
+            <a href="https://bloomberg.github.io/memray/python_allocators.html">
+            Click here</a> for more information.
           </p>
           <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>

--- a/tests/unit/test_stats_reporter.py
+++ b/tests/unit/test_stats_reporter.py
@@ -99,6 +99,7 @@ def fake_stats():
             pid=123456,
             python_allocator="pymalloc",
             has_native_traces=False,
+            trace_python_allocators=True,
         ),
         total_num_allocations=20,
         total_memory_allocated=sum(mem_allocation_list),
@@ -436,6 +437,7 @@ def test_stats_output_json(fake_stats, tmp_path):
             "pid": 123456,
             "python_allocator": "pymalloc",
             "has_native_traces": False,
+            "trace_python_allocators": True,
         },
     }
     actual = json.loads(output_file.read_text())


### PR DESCRIPTION
We warn when generating a leaks report when pymalloc is in use, because
the memory held by pymalloc would appear to us as a leak when it has
actually just been set aside for future use.

But, when `--trace-python-allocators` is used, we do have visibility
into whether the memory has set aside for future use, and so we don't
need to show this warning in that case.