### PR TITLE
news: Fix a misspelled news entry

### DIFF
--- a/news/490.bugfix.rst
+++ b/news/490.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed a bug that was caussing attaching to fail in macOS Sonoma.
+Fixed a bug that caused ``memray attach`` to fail with newer LLDB versions, including on macOS Sonoma.


### PR DESCRIPTION
And add a little bit more detail, since we now know this issue isn't specific to macOS.