### PR TITLE
Abbreviate Memray's path displayed in the TUI

### DIFF
--- a/src/memray/reporters/tui.py
+++ b/src/memray/reporters/tui.py
@@ -751,6 +751,13 @@ class TUIApp(App[None]):
             if self._cmdline_override is not None
             else self._reader.command_line
         )
+
+        if cmd_line is not None and "/memray" in cmd_line:
+            cmd_args = cmd_line.split()
+            if any(cmd_args[0].endswith(p) for p in ("/memray", "/memray/__main__.py")):
+                cmd_args[0] = "memray"
+                cmd_line = " ".join(cmd_args)
+
         self.tui = TUI(
             pid=self._reader.pid,
             cmd_line=cmd_line,

--- a/tests/unit/test_tui_reporter.py
+++ b/tests/unit/test_tui_reporter.py
@@ -496,6 +496,21 @@ def test_pid_display(pid, display_val):
     "command_line, display_val",
     [
         pytest.param("foo bar baz", "CMD: foo bar baz", id="Known command"),
+        pytest.param(
+            "/path/to/foo bar baz",
+            "CMD: /path/to/foo bar baz",
+            id="Known command with path",
+        ),
+        pytest.param(
+            "/path/to/memray bar baz",
+            "CMD: memray bar baz",
+            id="Memray script with path",
+        ),
+        pytest.param(
+            "/path/to/memray/__main__.py bar baz",
+            "CMD: memray bar baz",
+            id="Memray module with path",
+        ),
         pytest.param(None, "CMD: ???", id="Unknown command"),
     ],
 )


### PR DESCRIPTION
When the TUI shows a command line that indicates that Memray is running (either a command named `memray` or a file named `memray/__main__.py` as the first argument), shorten this to just "memray" to save room for more valuable information.
