### PR TITLE
Leverage pkg-config in setup.py

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -qy \
+            pkg-config \
             libunwind-dev \
             liblz4-dev \
             gdb \
@@ -46,7 +47,7 @@ jobs:
             python3.10-dbg
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --upgrade pip cython
+          python3 -m pip install --upgrade pip cython pkgconfig
           make test-install
       - name: Disable ptrace security restrictions
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@
 requires = [
      "setuptools",
      "wheel",
+     "pkgconfig",
      "Cython>=0.29.31"
 ]
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,4 +5,5 @@ pytest
 pytest-cov
 ipython
 setuptools; python_version >= '3.12'
+pkgconfig
 pytest-textual-snapshot


### PR DESCRIPTION
Using pkg-config we can get automatically the build flags in MacOS
and Linux and this doesn't require the user to manually modify CFLAGS
just to build the extension.

Signed-off-by: Pablo Galindo <pablogsal@gmail.com>
