### PR TITLE
Publish manylinux2010 wheels for Python 3.11/3.12

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -52,14 +52,40 @@ jobs:
 
   build_linux_wheels:
     needs: [build_sdist, choose_linux_wheel_types]
-    name: ${{ matrix.wheel_type }} wheels
+    name: ${{ matrix.wheel_type }}${{ matrix.manylinux2010_hack }} wheels
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         wheel_type: ${{ fromJSON(needs.choose_linux_wheel_types.outputs.wheel_types) }}
-
+        include:
+          - wheel_type: manylinux_x86_64
+            manylinux2010_hack: "_manylinux2010_hack"
     steps:
+      - name: Build manylinux2010 image containing Python 3.11 and 3.12
+        if: matrix.manylinux2010_hack
+        run: |
+          echo "CIBW_SKIP=*cp3{7,8,9,10}*" >> $GITHUB_ENV
+          echo "CIBW_MANYLINUX_X86_64_IMAGE=manylinux2010-with-modern-cpython" >> $GITHUB_ENV
+          docker build -t manylinux2010-with-modern-cpython - <<'EOF'
+          # syntax=docker/dockerfile:1
+          FROM quay.io/pypa/manylinux2010_x86_64:latest
+          RUN curl https://pyenv.run | bash && \
+           export PYENV_ROOT="$HOME/.pyenv" && \
+           export PATH="$PYENV_ROOT/bin:$PATH" && \
+           eval "$(pyenv init -)" && \
+           yum install -y make patch zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel perl-IPC-Cmd && \
+           curl -L https://www.openssl.org/source/openssl-3.0.12.tar.gz >openssl-3.0.12.tar.gz && \
+           tar xzf openssl-3.0.12.tar.gz && \
+           (cd openssl-3.0.12 && ./config no-shared --prefix=/usr/local/ssl --openssldir=/usr/local/ssl --libdir=lib && make && make install_sw) && \
+           rm -rf openssl-3.0.12.tar.gz && \
+           rm -rf openssl-3.0.12 && \
+           PYTHON_CONFIGURE_OPTS=--with-openssl=/usr/local/ssl pyenv install 3.11 && \
+           ln -s /root/.pyenv/versions/3.11* /opt/python/cp311-cp311 && \
+           PYTHON_CONFIGURE_OPTS=--with-openssl=/usr/local/ssl pyenv install 3.12 && \
+           ln -s /root/.pyenv/versions/3.12* /opt/python/cp312-cp312 && \
+           true
+          EOF
       - uses: actions/download-artifact@v4
         with:
           name: sdist
@@ -88,7 +114,7 @@ jobs:
           CIBW_TEST_SKIP: "*aarch64*"
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.wheel_type }}-wheels
+          name: ${{ matrix.wheel_type }}${{ matrix.manylinux2010_hack }}-wheels
           path: ./wheelhouse/*.whl
 
   build_macosx_wheels:


### PR DESCRIPTION
We can't get this for free from the manylinux2010 image, because support for it was dropped before Python 3.11 came out. We can spin up a container based on that image, install Python 3.11 and 3.12 in it, and then ask cibuildwheel to use it for building some wheels for us (and running `auditwheel repair` and tests).

We'll do it only for x86_64, not i686, since 64-bit is much more heavily used.