### PR TITLE
Update `upload-artifact` and `download-artifact`: one artifact per OS + arch + platform tag series

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,12 +24,12 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: sdist
           path: dist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: tests
           path: tests
@@ -50,22 +50,20 @@ jobs:
 
   build_wheels:
     needs: [build_sdist, choose_architectures]
-    name: Wheel for Linux-${{ matrix.cibw_python }}-${{ matrix.cibw_arch }}
+    name: Wheel for Linux ${{ matrix.cibw_arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python:
-          ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*"]
         cibw_arch: ${{ fromJSON(needs.choose_architectures.outputs.cibw_arches) }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: dist
+          name: sdist
           path: dist
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tests
           path: tests
@@ -81,34 +79,33 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_BUILD: "cp3{7..12}-*"
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: python -m pytest {package}/tests
           CIBW_TEST_SKIP: "*aarch64*"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: linux-${{ matrix.cibw_arch }}-wheels
           path: ./wheelhouse/*.whl
 
   build_wheels_macos:
     needs: [build_sdist]
-    name: Wheel for MacOS-${{ matrix.cibw_python }}-${{ matrix.cibw_arch }}
+    name: Wheel for MacOS ${{ matrix.cibw_arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-11]
-        cibw_python: ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*"]
         cibw_arch: ["x86_64", "arm64"]
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: dist
+          name: sdist
           path: dist
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tests
           path: tests
@@ -123,7 +120,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_BUILD: "cp3{8..12}-*"
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test
@@ -131,24 +128,25 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           MACOSX_DEPLOYMENT_TARGET: "10.14"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: macos-${{ matrix.cibw_arch }}-wheels
           path: ./wheelhouse/*.whl
 
   upload_pypi:
     needs: [build_wheels, build_wheels_macos, build_sdist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: dist
+          # with no name set, it downloads all of the artifacts
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip_existing: true
-          password: ${{ secrets.PYPI_PASSWORD }}
+      - run: |
+          mv dist/sdist/*.tar.gz dist/
+          mv dist/*-wheels/*.whl dist/
+          rmdir dist/{sdist,*-wheels}
+          rm -r dist/tests
+      - run: ls -R dist
 
   publish_docs:
     name: Publish docs

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -133,9 +133,21 @@ jobs:
           name: macosx_${{ matrix.cibw_arch }}-wheels
           path: ./wheelhouse/*.whl
 
-  upload_pypi:
-    needs: [build_linux_wheels, build_macosx_wheels, build_sdist]
+  build_and_test_wheels:
+    name: Build and test wheels
+    needs: [build_linux_wheels, build_macosx_wheels]
     runs-on: ubuntu-latest
+    steps:
+      # We can't make a matrix job itself a required check in GitHub,
+      # so we instead add a job that depends on the two matrix jobs,
+      # and we mark this job as required instead. This job doesn't do
+      # any work, it just lets us better manage our required checks.
+      - run: echo "Done!"
+
+  upload_pypi:
+    needs: [build_and_test_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -146,7 +158,11 @@ jobs:
           mv dist/*-wheels/*.whl dist/
           rmdir dist/{sdist,*-wheels}
           rm -r dist/tests
-      - run: ls -R dist
+          ls -R dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip_existing: true
+          password: ${{ secrets.PYPI_PASSWORD }}
 
   publish_docs:
     name: Publish docs

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -34,29 +34,30 @@ jobs:
           name: tests
           path: tests
 
-  choose_architectures:
-    name: Decide which architectures to build wheels for
+  choose_linux_wheel_types:
+    name: Decide which wheel types to build
     runs-on: ubuntu-latest
     steps:
-      - id: x86_64
-        run: echo "cibw_arch=x86_64" >> $GITHUB_OUTPUT
-      - id: i686
-        run: echo "cibw_arch=i686" >> $GITHUB_OUTPUT
-      - id: aarch64
+      - id: manylinux_x86_64
+        run: echo "wheel_types=manylinux_x86_64" >> $GITHUB_OUTPUT
+      - id: musllinux_x86_64
+        run: echo "wheel_types=musllinux_x86_64" >> $GITHUB_OUTPUT
+      - id: manylinux_i686
+        run: echo "wheel_types=manylinux_i686" >> $GITHUB_OUTPUT
+      - id: manylinux_aarch64
         if: github.event_name == 'release' && github.event.action == 'published'
-        run: echo "cibw_arch=aarch64" >> $GITHUB_OUTPUT
+        run: echo "wheel_types=manylinux_aarch64" >> $GITHUB_OUTPUT
     outputs:
-      cibw_arches: ${{ toJSON(steps.*.outputs.cibw_arch) }}
+      wheel_types: ${{ toJSON(steps.*.outputs.wheel_types) }}
 
-  build_wheels:
-    needs: [build_sdist, choose_architectures]
-    name: Wheel for Linux ${{ matrix.cibw_arch }}
-    runs-on: ${{ matrix.os }}
+  build_linux_wheels:
+    needs: [build_sdist, choose_linux_wheel_types]
+    name: ${{ matrix.wheel_type }} wheels
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        cibw_arch: ${{ fromJSON(needs.choose_architectures.outputs.cibw_arches) }}
+        wheel_type: ${{ fromJSON(needs.choose_linux_wheel_types.outputs.wheel_types) }}
 
     steps:
       - uses: actions/download-artifact@v4
@@ -79,25 +80,24 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_BUILD: "cp3{7..12}-*"
-          CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
+          CIBW_BUILD: "cp3{7..12}-${{ matrix.wheel_type }}"
+          CIBW_ARCHS_LINUX: auto aarch64
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: python -m pytest {package}/tests
           CIBW_TEST_SKIP: "*aarch64*"
       - uses: actions/upload-artifact@v4
         with:
-          name: linux-${{ matrix.cibw_arch }}-wheels
+          name: ${{ matrix.wheel_type }}-wheels
           path: ./wheelhouse/*.whl
 
-  build_wheels_macos:
+  build_macosx_wheels:
     needs: [build_sdist]
-    name: Wheel for MacOS ${{ matrix.cibw_arch }}
-    runs-on: ${{ matrix.os }}
+    name: macosx_${{ matrix.cibw_arch }} wheels
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11]
         cibw_arch: ["x86_64", "arm64"]
 
     steps:
@@ -130,11 +130,11 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: macos-${{ matrix.cibw_arch }}-wheels
+          name: macosx_${{ matrix.cibw_arch }}-wheels
           path: ./wheelhouse/*.whl
 
   upload_pypi:
-    needs: [build_wheels, build_wheels_macos, build_sdist]
+    needs: [build_linux_wheels, build_macosx_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Another approach for #513 where we use one artifact per OS + architecture instead of one per wheel.
