### PR TITLE
ci: Fix coverage reporting on Alpine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
         env:
           CYTHON_TEST_MACROS: 1
           PYTHON: /venv/bin/python
-          GENHTMLOPTS: "--ignore-errors category"
+          GENHTMLOPTS: "--ignore-errors inconsistent"
         run: |
           make dev-install pycoverage
 


### PR DESCRIPTION
Coverage.py sometimes reports events with the line number as 0. We need to ignore these.
