### PR TITLE
Depend on Textual >= 0.41

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ install_requires = [
     "jinja2 >= 2.9",
     "typing_extensions; python_version < '3.8.0'",
     "rich >= 11.2.0",
-    "textual >= 0.34.0",
+    "textual >= 0.41.0",
 ]
 docs_requires = [
     "IPython",


### PR DESCRIPTION
`memray tree` already uses features that require this version (`TextArea` was introduced in Textual 0.38, and `TextArea.text` gained a setter in Textual 0.41).

Correct our package metadata to accurately reflect our supported versions of the Textual dependency.

See #518 