### PR TITLE
Override dlsym instead of dlopen to correctly honour RPATH/RUNPATHS

### DIFF
--- a/news/525.bugfix.rst
+++ b/news/525.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that was causing ``dlopen`` to not load shared libraries that have an RPATH/RUNPATH set.

--- a/src/memray/_memray/elf_shenanigans.cpp
+++ b/src/memray/_memray/elf_shenanigans.cpp
@@ -171,7 +171,9 @@ phdrs_callback(dl_phdr_info* info, [[maybe_unused]] size_t size, void* data) noe
         patched.insert(info->dlpi_name);
     }
 
-    if (strstr(info->dlpi_name, "/ld-linux") || strstr(info->dlpi_name, "linux-vdso.so.1")) {
+    if (strstr(info->dlpi_name, "/ld-linux") || strstr(info->dlpi_name, "/ld-musl")
+        || strstr(info->dlpi_name, "linux-vdso.so.1"))
+    {
         // Avoid chaos by not overwriting the symbols in the linker.
         // TODO: Don't override the symbols in our shared library!
         return 0;

--- a/src/memray/_memray/elf_shenanigans.cpp
+++ b/src/memray/_memray/elf_shenanigans.cpp
@@ -83,8 +83,13 @@ overwrite_elf_table(
         const char* symname = symbols.getSymbolNameByIndex(index);
         auto symbol_addr = relocation.r_offset + base_addr;
 #define FOR_EACH_HOOKED_FUNCTION(hookname)                                                              \
-    if (strcmp(hooks::hookname.d_symbol, symname) == 0) {                                               \
-        patch_symbol(hooks::hookname, &intercept::hookname, symname, symbol_addr, restore_original);    \
+    if (strcmp(MEMRAY_ORIG(hookname).d_symbol, symname) == 0) {                                         \
+        patch_symbol(                                                                                   \
+                MEMRAY_ORIG(hookname),                                                                  \
+                &intercept::hookname,                                                                   \
+                symname,                                                                                \
+                symbol_addr,                                                                            \
+                restore_original);                                                                      \
         continue;                                                                                       \
     }
         MEMRAY_HOOKED_FUNCTIONS

--- a/src/memray/_memray/hooks.h
+++ b/src/memray/_memray/hooks.h
@@ -43,7 +43,7 @@
     FOR_EACH_HOOKED_FUNCTION(aligned_alloc)                                                             \
     FOR_EACH_HOOKED_FUNCTION(mmap)                                                                      \
     FOR_EACH_HOOKED_FUNCTION(munmap)                                                                    \
-    FOR_EACH_HOOKED_FUNCTION(dlopen)                                                                    \
+    FOR_EACH_HOOKED_FUNCTION(dlsym)                                                                     \
     FOR_EACH_HOOKED_FUNCTION(dlclose)                                                                   \
     FOR_EACH_HOOKED_FUNCTION(PyGILState_Ensure)                                                         \
     MEMRAY_PLATFORM_HOOKED_FUNCTIONS
@@ -175,7 +175,7 @@ void*
 pvalloc(size_t size) noexcept;
 
 void*
-dlopen(const char* filename, int flag) noexcept;
+dlsym(void* handle, const char* symbol) noexcept;
 
 int
 dlclose(void* handle) noexcept;

--- a/src/memray/_memray/hooks.h
+++ b/src/memray/_memray/hooks.h
@@ -140,7 +140,11 @@ allocatorKind(const Allocator& allocator);
 bool
 isDeallocator(const Allocator& allocator);
 
-#define FOR_EACH_HOOKED_FUNCTION(f) extern SymbolHook<decltype(&::f)> f;
+#define MEMRAY_ORIG_concat_helper(x, y) x##y
+#define MEMRAY_ORIG_NO_NS(f) MEMRAY_ORIG_concat_helper(memray_, f)
+#define MEMRAY_ORIG(f) memray::hooks::MEMRAY_ORIG_NO_NS(f)
+
+#define FOR_EACH_HOOKED_FUNCTION(f) extern SymbolHook<decltype(&::f)> MEMRAY_ORIG_NO_NS(f);
 MEMRAY_HOOKED_FUNCTIONS
 #undef FOR_EACH_HOOKED_FUNCTION
 

--- a/src/memray/_memray/macho_shenanigans.cpp
+++ b/src/memray/_memray/macho_shenanigans.cpp
@@ -50,11 +50,11 @@ patch_symbols_in_section(
             continue;
         }
 #define FOR_EACH_HOOKED_FUNCTION(hookname)                                                              \
-    if (strcmp(hooks::hookname.d_symbol, symbol_name + 1) == 0) {                                       \
+    if (strcmp(MEMRAY_ORIG(hookname).d_symbol, symbol_name + 1) == 0) {                                 \
         LOG(DEBUG) << "Patching " << symbol_name << " symbol pointer at " << std::hex << std::showbase  \
                    << *(symbol_addr_table + i) << " for relocation entry " << (symbol_addr_table + i);  \
         patch_symbol(                                                                                   \
-                hooks::hookname,                                                                        \
+                MEMRAY_ORIG(hookname),                                                                  \
                 &intercept::hookname,                                                                   \
                 symbol_name,                                                                            \
                 symbol_addr_table + i,                                                                  \
@@ -227,7 +227,7 @@ patch_stubs(
         }
         auto stub_addr = reinterpret_cast<uint64_t>(symbol_addr_table + i * element_size);
 #define FOR_EACH_HOOKED_FUNCTION(hookname)                                                              \
-    if (strcmp(hooks::hookname.d_symbol, symbol_name + 1) == 0) {                                       \
+    if (strcmp(MEMRAY_ORIG(hookname).d_symbol, symbol_name + 1) == 0) {                                 \
         LOG(DEBUG) << "Extracting symbol address for " << symbol_name << " from stub function at "      \
                    << std::hex << std::showbase << stub_addr;                                           \
         void* symbol_addr = reinterpret_cast<void*>(lazy_pointer_from_stub(stub_addr));                 \
@@ -238,7 +238,7 @@ patch_stubs(
         LOG(DEBUG) << "Patching " << symbol_name << " pointer at address " << std::hex << std::showbase \
                    << symbol_addr;                                                                      \
         patch_symbol(                                                                                   \
-                hooks::hookname,                                                                        \
+                MEMRAY_ORIG(hookname),                                                                  \
                 &intercept::hookname,                                                                   \
                 symbol_name,                                                                            \
                 symbol_addr,                                                                            \

--- a/src/memray/commands/_attach.lldb
+++ b/src/memray/commands/_attach.lldb
@@ -15,7 +15,7 @@ breakpoint set -b malloc -b calloc -b realloc -b free -b PyMem_Malloc -b PyMem_C
 # Set commands to execute when breakpoint is reached
 breakpoint command add -e true
 breakpoint disable
-expr auto $dlsym = (void* (*)(void*, const char*))&dlsym
+expr auto $dlsym = (void* (*)(void*, const char*))&::dlsym
 expr auto $dlopen = $dlsym($rtld_default, "dlopen")
 expr auto $dlerror = $dlsym($rtld_default, "dlerror")
 expr auto $dll = ((void*(*)(const char*, int))$dlopen)($libpath, $rtld_now)

--- a/tests/integration/rpath_extension/ext.c
+++ b/tests/integration/rpath_extension/ext.c
@@ -1,0 +1,46 @@
+#include <Python.h>
+#include <dlfcn.h>
+
+
+static PyObject *hello_world(PyObject *self, PyObject *args) {
+    // Load the shared library
+    void *lib_handle = dlopen("sharedlib.so", RTLD_LAZY);
+
+    if (!lib_handle) {
+        PyErr_SetString(PyExc_RuntimeError, dlerror());
+        return NULL;
+    }
+
+    // Get the function pointer
+    void (*my_shared_function)() = dlsym(lib_handle, "my_shared_function");
+    if (!my_shared_function) {
+        PyErr_SetString(PyExc_RuntimeError, dlerror());
+        dlclose(lib_handle);
+        return NULL;
+    }
+
+    // Call the function
+    my_shared_function();
+
+    // Close the shared library
+    dlclose(lib_handle);
+
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef methods[] = {
+    {"hello_world", hello_world, METH_NOARGS, "Print Hello, World!"},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    "ext",
+    NULL,
+    -1,
+    methods
+};
+
+PyMODINIT_FUNC PyInit_ext(void) {
+    return PyModule_Create(&module);
+}

--- a/tests/integration/rpath_extension/setup.py
+++ b/tests/integration/rpath_extension/setup.py
@@ -1,0 +1,22 @@
+import subprocess
+
+from setuptools import Extension
+from setuptools import setup
+
+# Compile the shared library before building the extension
+subprocess.run(
+    ["gcc", "-shared", "-o", "sharedlibs/sharedlib.so", "sharedlibs/sharedlib.c"]
+)
+
+
+setup(
+    name="ext",
+    version="1.0",
+    ext_modules=[
+        Extension(
+            "ext",
+            sources=["ext.c"],
+            extra_link_args=["-Wl,-rpath,$ORIGIN/sharedlibs"],
+        )
+    ],
+)

--- a/tests/integration/rpath_extension/sharedlibs/sharedlib.c
+++ b/tests/integration/rpath_extension/sharedlibs/sharedlib.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+void my_shared_function() {
+    printf("This is a function from your_shared_lib!\n");
+}


### PR DESCRIPTION
We need to override dlopen/dlclose to account for new shared libraries
being loaded in the process memory space. This is needed so we can
correctly track allocations in those libraries by overriding their PLT
entries and also so we can properly map the addresses of the symbols in
those libraries when we resolve later native traces. Unfortunately, we
can't just override dlopen directly because of the following edge case:
when a shared library dlopen's another by name (e.g.
dlopen("libfoo.so")), the dlopen call will honor the RPATH/RUNPATH of
the calling library if it's set. Some libraries set an RPATH/RUNPATH
based on $ORIGIN (the path of the calling library) to load dependencies
from a relative directory based on the location of the calling library.
This means that if we override dlopen, we'll end up loading the library
from the wrong path or more likely, not loading it at all because the
dynamic loader will think the memray extenion it's the calling library
and the RPATH of the real calling library will not be honoured.

To work around this, we override dlsym instead and override the symbols
in the loaded libraries only the first time we have seen a handle passed
to dlsym. This works because for a symbol from a given dlopen-ed library
to appear in a call stack, *something* from that library has to be
dlsym-ed first. The only exception to this are static initializers, but
we cannot track those anyway by overriding dlopen as they run within the
dlopen call itself.

Closes: #212
