### PR TITLE
Add missing include

### DIFF
--- a/src/memray/_memray/snapshot.h
+++ b/src/memray/_memray/snapshot.h
@@ -3,6 +3,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+#include <algorithm>
 #include <deque>
 #include <functional>
 #include <optional>


### PR DESCRIPTION
Without this the build fails on the upcoming Fedora Linux 40 release with:

```
  gcc -fno-strict-overflow -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -fexceptions -fexceptions -fexceptions -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -mbranch-protection=standard -fasynchronous-unwind-tables -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fPIC -D_FILE_OFFSET_BITS=64 -DUSE_MEMRAY_TLS_MODEL=1 -Isrc/memray/_memray -Isrc -I/builddir/build/BUILD/memray-1.11.0/src/vendor/libbacktrace/install/include -I/usr/include/python3.12 -c src/memray/_memray/record_writer.cpp -o build/temp.linux-aarch64-cpython-312/src/memray/_memray/record_writer.o -std=c++17 -Wall -flto -fvisibility=hidden
  In file included from src/memray/_memray/record_writer.cpp:12:
  src/memray/_memray/snapshot.h: In member function ‘size_t memray::api::IntervalTree<T>::size()’:
  src/memray/_memray/snapshot.h:137:14: error: ‘for_each’ is not a member of ‘std’
    137 |         std::for_each(d_intervals.begin(), d_intervals.end(), [&](const auto& pair) {
        |              ^~~~~~~~
  src/memray/_memray/snapshot.h: In member function ‘std::vector<std::pair<typename std::tuple_element<field, std::pair<long unsigned int, long unsigned int> >::type, std::optional<long unsigned int> > > memray::api::AllocationStatsAggregator::topLocationsBySizeAndCountField(size_t)’:
  src/memray/_memray/snapshot.h:525:14: error: ‘make_heap’ is not a member of ‘std’
    525 |         std::make_heap(heap.begin(), heap.end());
        |              ^~~~~~~~~
  src/memray/_memray/snapshot.h:527:18: error: ‘pop_heap’ is not a member of ‘std’
    527 |             std::pop_heap(heap.begin(), heap.end() - i);
        |                  ^~~~~~~~
  error: command '/usr/bin/gcc' failed with exit code 1
  error: subprocess-exited-with-error
  
  × Building wheel for memray (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /usr/bin/python3 /usr/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py build_wheel /builddir/build/BUILD/memray-1.11.0/.pyproject-builddir/tmpaqpzqfbr
  cwd: /builddir/build/BUILD/memray-1.11.0
  Building wheel for memray (pyproject.toml): finished with status 'error'
  ERROR: Failed building wheel for memray
Failed to build memray
```