### PR TITLE
Add a warning to promote --aggregated if files are too big

### DIFF
--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -757,6 +757,7 @@ cdef _create_metadata(header, peak_memory):
         python_allocator=allocator_id_to_name[header["python_allocator"]],
         has_native_traces=header["native_traces"],
         trace_python_allocators=header["trace_python_allocators"],
+        file_format=FileFormat(header["file_format"]),
     )
 
 

--- a/src/memray/_metadata.py
+++ b/src/memray/_metadata.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from datetime import datetime
 
+from ._memray import FileFormat
+
 
 @dataclass
 class Metadata:
@@ -14,3 +16,4 @@ class Metadata:
     python_allocator: str
     has_native_traces: bool
     trace_python_allocators: bool
+    file_format: FileFormat

--- a/src/memray/commands/summary.py
+++ b/src/memray/commands/summary.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 
 from memray import FileReader
 from memray._errors import MemrayCommandError
+from memray.commands.common import warn_if_file_is_not_aggregated_and_is_too_big
 from memray.commands.common import warn_if_not_enough_symbols
 from memray.reporters.summary import SummaryReporter
 
@@ -67,6 +68,9 @@ class SummaryCommand:
             reader = FileReader(os.fspath(args.results), report_progress=True)
             if reader.metadata.has_native_traces:
                 warn_if_not_enough_symbols()
+
+            if not args.temporary_allocation_threshold >= 0:
+                warn_if_file_is_not_aggregated_and_is_too_big(reader, result_path)
 
             if args.temporary_allocation_threshold >= 0:
                 snapshot = iter(

--- a/src/memray/commands/tree.py
+++ b/src/memray/commands/tree.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 
 from memray import FileReader
 from memray._errors import MemrayCommandError
+from memray.commands.common import warn_if_file_is_not_aggregated_and_is_too_big
 from memray.commands.common import warn_if_not_enough_symbols
 from memray.reporters.tree import TreeReporter
 
@@ -56,6 +57,10 @@ class TreeCommand:
             reader = FileReader(os.fspath(args.results), report_progress=True)
             if reader.metadata.has_native_traces:
                 warn_if_not_enough_symbols()
+
+            if not args.temporary_allocation_threshold >= 0:
+                warn_if_file_is_not_aggregated_and_is_too_big(reader, result_path)
+
             if args.temporary_allocation_threshold >= 0:
                 snapshot = iter(
                     reader.get_temporary_allocation_records(

--- a/tests/unit/test_highwatermark_command.py
+++ b/tests/unit/test_highwatermark_command.py
@@ -1,5 +1,7 @@
 import os
+import sys
 from pathlib import Path
+from unittest.mock import ANY
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import call
@@ -8,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from memray._errors import MemrayCommandError
+from memray._memray import FileFormat
 from memray.commands.common import HighWatermarkCommand
 
 
@@ -165,6 +168,9 @@ class TestReportGeneration:
         calls = [
             call(os.fspath(result_path), report_progress=True),
             call().metadata.has_native_traces.__bool__(),
+            call().metadata.file_format.__eq__(FileFormat.ALL_ALLOCATIONS)
+            if sys.version_info >= (3, 8, 0)
+            else ANY,
             call().get_high_watermark_allocation_records(merge_threads=merge_threads),
             call().get_memory_snapshots(),
         ]
@@ -195,6 +201,9 @@ class TestReportGeneration:
         calls = [
             call(os.fspath(result_path), report_progress=True),
             call().metadata.has_native_traces.__bool__(),
+            call().metadata.file_format.__eq__(FileFormat.ALL_ALLOCATIONS)
+            if sys.version_info >= (3, 8, 0)
+            else ANY,
             call().get_leaked_allocation_records(merge_threads=merge_threads),
             call().get_memory_snapshots(),
         ]

--- a/tests/unit/test_stats_reporter.py
+++ b/tests/unit/test_stats_reporter.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from memray import AllocatorType as AT
+from memray._memray import FileFormat
 from memray._metadata import Metadata
 from memray._stats import Stats
 from memray.reporters.stats import StatsReporter
@@ -97,6 +98,7 @@ def fake_stats():
             python_allocator="pymalloc",
             has_native_traces=False,
             trace_python_allocators=True,
+            file_format=FileFormat.ALL_ALLOCATIONS,
         ),
         total_num_allocations=20,
         total_memory_allocated=sum(mem_allocation_list),
@@ -435,6 +437,7 @@ def test_stats_output_json(fake_stats, tmp_path):
             "python_allocator": "pymalloc",
             "has_native_traces": False,
             "trace_python_allocators": True,
+            "file_format": 0,
         },
     }
     actual = json.loads(output_file.read_text())


### PR DESCRIPTION
Users tend to run memray over long running programs but they don't tend
to know about the --aggregated option, while most of the cases they
don't need the extra features that runnin with the default mode has.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
