### PR TITLE
Expose the main thread ID in the reader

### DIFF
--- a/news/560.feature.rst
+++ b/news/560.feature.rst
@@ -1,0 +1,1 @@
+Expose the main thread id in the FileReader's metadata attribute.

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -754,6 +754,7 @@ cdef _create_metadata(header, peak_memory):
         peak_memory=peak_memory,
         command_line=header["command_line"],
         pid=header["pid"],
+        main_thread_id=header["main_tid"],
         python_allocator=allocator_id_to_name[header["python_allocator"]],
         has_native_traces=header["native_traces"],
         trace_python_allocators=header["trace_python_allocators"],

--- a/src/memray/_metadata.py
+++ b/src/memray/_metadata.py
@@ -13,6 +13,7 @@ class Metadata:
     peak_memory: int
     command_line: str
     pid: int
+    main_thread_id: int
     python_allocator: str
     has_native_traces: bool
     trace_python_allocators: bool

--- a/tests/unit/test_stats_reporter.py
+++ b/tests/unit/test_stats_reporter.py
@@ -99,6 +99,7 @@ def fake_stats():
             has_native_traces=False,
             trace_python_allocators=True,
             file_format=FileFormat.ALL_ALLOCATIONS,
+            main_thread_id=0x1,
         ),
         total_num_allocations=20,
         total_memory_allocated=sum(mem_allocation_list),
@@ -438,6 +439,7 @@ def test_stats_output_json(fake_stats, tmp_path):
             "has_native_traces": False,
             "trace_python_allocators": True,
             "file_format": 0,
+            "main_thread_id": 0x1,
         },
     }
     actual = json.loads(output_file.read_text())


### PR DESCRIPTION
To be able to filter allocations that happened only on the thread that
started the tracking, expose the main thread ID in the reader class.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
