### PR TITLE
Fix publication of x86_64 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -58,6 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         wheel_type: ${{ fromJSON(needs.choose_linux_wheel_types.outputs.wheel_types) }}
+        manylinux2010_hack: [""]
         include:
           - wheel_type: manylinux_x86_64
             manylinux2010_hack: "_manylinux2010_hack"


### PR DESCRIPTION
This was broken when we added support for building manylinux2010 wheels for modern Python interpreters due to a misuse of the `include` configuration of the GitHub Actions matrix job.
