### PR TITLE
Add a binding for Ctrl-Z to memray tree

### DIFF
--- a/news/581.feature.rst
+++ b/news/581.feature.rst
@@ -1,0 +1,1 @@
+Allow using Ctrl+Z to suspend ``memray tree`` and the live mode TUI.

--- a/src/memray/reporters/tree.py
+++ b/src/memray/reporters/tree.py
@@ -222,6 +222,7 @@ def node_is_not_import_system(node: Frame) -> bool:
 
 class TreeApp(App[None]):
     BINDINGS = [
+        Binding("ctrl+z", "suspend_process"),
         Binding(key="q", action="quit", description="Quit the app"),
         Binding(
             key="i", action="toggle_import_system", description="Hide import system"

--- a/src/memray/reporters/tui.py
+++ b/src/memray/reporters/tui.py
@@ -514,6 +514,7 @@ class TUI(Screen[None]):
     CSS_PATH = "tui.css"
 
     BINDINGS = [
+        Binding("ctrl+z", "suspend_process"),
         Binding("q,esc", "quit", "Quit"),
         Binding("<,left", "previous_thread", "Previous Thread"),
         Binding(">,right", "next_thread", "Next Thread"),


### PR DESCRIPTION
CTRL+z to suspend isn't enabled by default, but we can add it with a keybinding.

Closes: #559 