### PR TITLE
Allow spinning a Memray environment up in codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "Memray Dockerfile",
+  "build": {
+    "context": "..",
+    "dockerfile": "../Dockerfile"
+  },
+  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+  "onCreateCommand": "pip install -e ."
+}

--- a/.gitignore
+++ b/.gitignore
@@ -169,7 +169,6 @@ cython_debug/
 memray-*
 
 # VSCode
-.devcontainer
 .vscode
 
 # NodeJS

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN $PYTHON -m pip install -U \
     -r /tmp/requirements-test.txt \
     -r /tmp/requirements-docs.txt \
     cython \
+    pkgconfig \
     setuptools \
     wheel
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ ENV VIRTUAL_ENV=/venv \
 RUN python3.9 -m venv "$VIRTUAL_ENV"
 
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}" \
-    PYTHON="${VIRTUAL_ENV}/bin/python"
+    PYTHON="${VIRTUAL_ENV}/bin/python" \
+    MEMRAY_MINIMIZE_INLINING="1"
 
 COPY requirements-test.txt requirements-extra.txt requirements-docs.txt /tmp/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,9 +32,9 @@ ENV VIRTUAL_ENV=/venv \
     CC=gcc \
     CXX=g++
 
-RUN python3.9 -m venv "$VIRTUAL_ENV"
+RUN python3 -m venv "$VIRTUAL_ENV"
 
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}" \
+ENV PATH="${VIRTUAL_ENV}/bin:/usr/lib/ccache:${PATH}" \
     PYTHON="${VIRTUAL_ENV}/bin/python" \
     MEMRAY_MINIMIZE_INLINING="1"
 
@@ -50,8 +50,5 @@ RUN $PYTHON -m pip install -U \
     wheel
 
 RUN npm install -g prettier
-
-RUN ln -s /usr/bin/ccache /bin/g++ \
-    && ln -s /usr/bin/ccache /bin/gcc
 
 WORKDIR /src


### PR DESCRIPTION
Update our Dockerfile to the latest Debian stable, and add a devcontainer.json based on it, with our build and test dependencies installed.