### PR TITLE
Vendor libdebuginfod into our wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -qy libunwind-dev liblz4-dev pkg-config npm gdb lldb lcov
+          sudo apt-get install -qy libdebuginfod-dev libunwind-dev liblz4-dev pkg-config npm gdb lldb lcov
       - name: Create virtual environment
         run: |
           python3 -m venv venv
@@ -79,6 +79,15 @@ jobs:
           apk add --update build-base libunwind-dev lz4-dev musl-dev python3-dev python3-dbg gdb lldb git bash perl perl-datetime build-base perl-app-cpanminus
           cpanm Date::Parse
           cpanm Capture::Tiny
+          # Build elfutils
+          cd /
+          apk add --update argp-standalone bison bsd-compat-headers bzip2-dev curl curl-dev flex-dev libtool linux-headers musl-fts-dev musl-libintl musl-obstack-dev xz-dev zlib-dev zstd-dev
+          VERS=0.191
+          curl https://sourceware.org/elfutils/ftp/$VERS/elfutils-$VERS.tar.bz2 > ./elfutils.tar.bz2
+          tar -xf elfutils.tar.bz2
+          cd elfutils-$VERS
+          CFLAGS='-Wno-error -DFNM_EXTMATCH=0 -g -O3' CXXFLAGS='-Wno-error -DFNM_EXTMATCH=0 -g -O3' ./configure --enable-libdebuginfod --disable-debuginfod --disable-nls --with-zstd
+          make install
       - name: Clone lcov repository
         run: |
           git clone https://github.com/linux-test-project/lcov.git
@@ -119,7 +128,7 @@ jobs:
       - name: Set up dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -qy clang-format npm libunwind-dev liblz4-dev pkg-config
+          sudo apt-get install -qy clang-format npm libdebuginfod-dev libunwind-dev liblz4-dev pkg-config
       - name: Install Python dependencies
         run: |
           python3 -m pip install -r requirements-extra.txt
@@ -146,7 +155,7 @@ jobs:
       - name: Set up dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -qy libunwind-dev liblz4-dev pkg-config npm valgrind
+          sudo apt-get install -qy libdebuginfod-dev libunwind-dev liblz4-dev pkg-config npm valgrind
       - name: Install Python dependencies and package
         run: |
           python3 -m pip install --upgrade pip

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,6 +37,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -qy \
             pkg-config \
+            libdebuginfod-dev \
             libunwind-dev \
             liblz4-dev \
             gdb \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,38 @@ manylinux-i686-image = "manylinux2010"
 
 [tool.cibuildwheel.linux]
 before-all = [
-  "yum install -y libunwind-devel lz4-devel gdb",
-  "if ! yum install -y lldb; then echo lldb is not available; fi",
+  # Build the latest curl from source.
+  "yum install -y openssl-devel",
+  "cd /",
+  "CURL_VERS=8.7.1",
+  "curl -LO https://curl.se/download/curl-$CURL_VERS.tar.bz2",
+  "tar xf ./curl-$CURL_VERS.tar.bz2",
+  "cd curl-$CURL_VERS",
+  "./configure --with-openssl",
+  "make install",
+
+  # Build the latest zstd from source
+  "yum install -y lz4-devel xz-devel",
+  "cd /",
+  "ZSTD_VERS=1.5.6",
+  "/usr/bin/curl -LO https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-$ZSTD_VERS.tar.gz",
+  "tar xf ./zstd-$ZSTD_VERS.tar.gz",
+  "cd zstd-$ZSTD_VERS",
+  "V=1 LDLIBS=-lrt make install",
+
+  # Build the latest elfutils from source.
+  "yum install -y lz4-devel",
+  "cd /",
+  "VERS=0.191",
+  "/usr/bin/curl https://sourceware.org/elfutils/ftp/$VERS/elfutils-$VERS.tar.bz2 > ./elfutils.tar.bz2",
+  "tar -xf elfutils.tar.bz2",
+  "cd elfutils-$VERS",
+  "CFLAGS='-Wno-error -g -O3' CXXFLAGS='-Wno-error -g -O3' LDFLAGS=-lrt ./configure --enable-libdebuginfod --disable-debuginfod --disable-nls --with-zstd",
+  "make install",
+
+  # Install Memray's other build and test dependencies
+  "yum install -y libunwind-devel gdb",
+  "if ! yum install -y lldb; then echo lldb is not available; fi"
 ]
 
 [tool.cibuildwheel.macos]
@@ -114,5 +144,38 @@ show_missing = true
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
 before-all = [
-  "apk add --update libunwind-dev lz4-dev gdb lldb",
+  # Remove gettext-dev, which conficts with the musl-libintl, which is a build
+  # dependency of elfutils.
+  "apk del gettext-dev glib-dev",
+
+  # Build musl-fts from source. This is a build dependency of elfutils, but
+  # isn't in the Alpine repos of the musllinux_1_1 image. The build steps come
+  # from https://git.alpinelinux.org/aports/tree/main/musl-fts/APKBUILD
+  # Setting PATH before calling boostrap.sh fixes an automake failure. I think
+  # the failure may be caused by a different pkg-config in /usr/local/bin.
+  "cd /",
+  "apk add --update automake autoconf libtool",
+  "VERS=1.2.7",
+  "curl -L https://github.com/void-linux/musl-fts/archive/refs/tags/v$VERS.tar.gz > ./musl-fts.tar.gz",
+  "tar -xf musl-fts.tar.gz",
+  "cd musl-fts-$VERS",
+  "PATH=/usr/bin:/bin ./bootstrap.sh",
+  "CFLAGS=-fPIC ./configure",
+  "make install",
+
+  # Build the latest elfutils from source. The build steps come from
+  # https://git.alpinelinux.org/aports/tree/main/elfutils, and the need to
+  # set the FNM_EXTMATCH macro to get the build to succeed is seen here:
+  # https://git.alpinelinux.org/aports/tree/main/elfutils/musl-macros.patch
+  "cd /",
+  "apk add --update argp-standalone bison bsd-compat-headers bzip2-dev curl-dev flex-dev libtool linux-headers musl-libintl musl-obstack-dev xz-dev zlib-dev zstd-dev",
+  "VERS=0.191",
+  "curl https://sourceware.org/elfutils/ftp/$VERS/elfutils-$VERS.tar.bz2 > ./elfutils.tar.bz2",
+  "tar -xf elfutils.tar.bz2",
+  "cd elfutils-$VERS",
+  "CFLAGS='-Wno-error -DFNM_EXTMATCH=0 -g -O3' CXXFLAGS='-Wno-error -g -O3' ./configure --enable-libdebuginfod --disable-debuginfod --disable-nls --with-zstd",
+  "make install",
+
+  # Install Memray's other build and test dependencies
+  "apk add --update libunwind-dev lz4-dev gdb lldb"
 ]

--- a/src/vendor/libbacktrace/debuginfod_support.h
+++ b/src/vendor/libbacktrace/debuginfod_support.h
@@ -40,9 +40,6 @@
 #define DEBUGINFOD_MAXTIME_ENV_VAR "DEBUGINFOD_MAXTIME"
 #define DEBUGINFOD_HEADERS_FILE_ENV_VAR "DEBUGINFOD_HEADERS_FILE"
 
-/* The libdebuginfod soname.  */
-#define DEBUGINFOD_SONAME "libdebuginfod.so.1"
-
 /* Handle for debuginfod-client connection.  */
 typedef struct debuginfod_client debuginfod_client;
 

--- a/src/vendor/libbacktrace/macho.c
+++ b/src/vendor/libbacktrace/macho.c
@@ -491,7 +491,7 @@ macho_defined_symbol (uint8_t type)
 {
   if ((type & MACH_O_N_STAB) != 0)
   {
-    switch (type) 
+    switch (type)
      {
      case MACH_O_N_FNAME:
       return 1;

--- a/src/vendor/libbacktrace_2446c66076480ce07a6bd868badcbceb3eeecc2e_debuginfod_patch.diff
+++ b/src/vendor/libbacktrace_2446c66076480ce07a6bd868badcbceb3eeecc2e_debuginfod_patch.diff
@@ -60,10 +60,10 @@ index dc1e692..5dde684 100644
  mmap.lo: config.h backtrace.h internal.h
 diff --git a/debuginfod_support.h b/debuginfod_support.h
 new file mode 100644
-index 0000000..8c3674a
+index 0000000..78f4d8d
 --- /dev/null
 +++ b/debuginfod_support.h
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,115 @@
 +/* External declarations for the libdebuginfod client library.
 +   Copyright (C) 2019-2020 Red Hat, Inc.
 +   This file is part of elfutils.
@@ -105,9 +105,6 @@ index 0000000..8c3674a
 +#define DEBUGINFOD_MAXSIZE_ENV_VAR "DEBUGINFOD_MAXSIZE"
 +#define DEBUGINFOD_MAXTIME_ENV_VAR "DEBUGINFOD_MAXTIME"
 +#define DEBUGINFOD_HEADERS_FILE_ENV_VAR "DEBUGINFOD_HEADERS_FILE"
-+
-+/* The libdebuginfod soname.  */
-+#define DEBUGINFOD_SONAME "libdebuginfod.so.1"
 +
 +/* Handle for debuginfod-client connection.  */
 +typedef struct debuginfod_client debuginfod_client;
@@ -183,7 +180,7 @@ index 0000000..8c3674a
 +
 +#endif /* _DEBUGINFOD_CLIENT_H */
 diff --git a/elf.c b/elf.c
-index fb54165..1bc4de0 100644
+index fb54165..0fcce38 100644
 --- a/elf.c
 +++ b/elf.c
 @@ -38,6 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.  */
@@ -202,72 +199,27 @@ index fb54165..1bc4de0 100644
  
  #ifndef S_ISLNK
   #ifndef S_IFLNK
-@@ -851,6 +853,82 @@ elf_readlink (struct backtrace_state *state, const char *filename,
+@@ -851,6 +853,37 @@ elf_readlink (struct backtrace_state *state, const char *filename,
  
  #define SYSTEM_BUILD_ID_DIR "/usr/lib/debug/.build-id/"
  
-+typedef debuginfod_client*(*debuginfod_begin_t)(void);
-+
-+typedef int(*debuginfod_find_debuginfo_t)(debuginfod_client *client,
-+                                            const unsigned char *build_id,
-+                                            int build_id_len,
-+                                            char **path);
-+typedef void(*debuginfod_end_t)(debuginfod_client *client);
-+
-+
-+static debuginfod_find_debuginfo_t the_debuginfod_find_debuginfo = NULL;
-+static debuginfod_begin_t the_debuginfod_begin = NULL;
-+static debuginfod_end_t the_debuginfod_end = NULL;
-+static int debuginfod_guard = 0;
-+static int debuginfod_dlopen_failed = 0;
-+
 +static int
 +elf_open_debugfile_by_debuginfod (const char *buildid_data,
 +			       size_t buildid_size,
 +			       backtrace_error_callback error_callback,
 +			       void *data)
 +{
-+  if (debuginfod_dlopen_failed) {
-+      return -1;
-+  }
-+
-+  if (the_debuginfod_find_debuginfo == NULL) {
-+    void *handle = dlopen(DEBUGINFOD_SONAME, RTLD_LAZY);
-+    if (!handle) {
-+      debuginfod_dlopen_failed = 1;
-+      return -1;
-+    }
-+
-+    the_debuginfod_find_debuginfo = (debuginfod_find_debuginfo_t)dlsym(handle, "debuginfod_find_debuginfo");
-+    if (!the_debuginfod_find_debuginfo) {
-+      return -1;
-+    }
-+
-+    the_debuginfod_begin = (debuginfod_begin_t)dlsym(handle, "debuginfod_begin");
-+    if (!the_debuginfod_begin) {
-+      the_debuginfod_find_debuginfo = NULL;
-+      return -1;
-+    }
-+
-+    the_debuginfod_end = (debuginfod_end_t)dlsym(handle, "debuginfod_end");
-+    if (!the_debuginfod_end) {
-+      the_debuginfod_find_debuginfo = NULL;
-+      the_debuginfod_begin = NULL;
-+      return -1;
-+    }
-+  }
-+
 +  char* path = NULL;
 +  const unsigned char* bi = (const unsigned char*)buildid_data;
 +
-+  debuginfod_client* client = the_debuginfod_begin();
++  debuginfod_client* client = debuginfod_begin();
 +  if (!client) {
 +    return -1;
 +  }
 +
-+  const int fd = the_debuginfod_find_debuginfo(client, bi, buildid_size, &path);
++  const int fd = debuginfod_find_debuginfo(client, bi, buildid_size, &path);
 +
-+  the_debuginfod_end(client);
++  debuginfod_end(client);
 +
 +  if (!path || fd <= 0) {
 +    return -1;
@@ -285,11 +237,11 @@ index fb54165..1bc4de0 100644
  /* Open a separate debug info file, using the build ID to find it.
     Returns an open file descriptor, or -1.
  
-@@ -4422,6 +4500,14 @@ elf_add (struct backtrace_state *state, const char *filename, int descriptor,
+@@ -4422,6 +4455,14 @@ elf_add (struct backtrace_state *state, const char *filename, int descriptor,
  
        d = elf_open_debugfile_by_buildid (state, buildid_data, buildid_size,
  					 error_callback, data);
-+      if (d < 0 && !debuginfod_guard) {
++      if (d < 0) {
 +          char* env = getenv(DEBUGINFOD_PROGRESS_ENV_VAR);
 +          if (env) {
 +            fprintf(stderr, "Trying to download debuginfo for %s\n", filename);
@@ -300,33 +252,3 @@ index fb54165..1bc4de0 100644
        if (d >= 0)
  	{
  	  int ret;
-@@ -4889,7 +4975,29 @@ backtrace_initialize (struct backtrace_state *state, const char *filename,
-   pd.exe_filename = filename;
-   pd.exe_descriptor = ret < 0 ? descriptor : -1;
- 
-+
-+  /* Here, There Be Dragons: we are about to call dl_iterate_phdr,
-+     which is a glibc-internal function that holds a libc internal
-+     lock. As this function needs to iterate over all the loaded
-+     modules, this lock is shared by dlopen so no new modules can be
-+     loaded while is iterating. This is a problem for us, as the
-+     debuginfod client will use libcurl to spawn threads to download
-+     debuginfo files, and libcurl uses dlopen to load a bunch of stuff
-+     for its backend in some versions. This can cause a deadlock because
-+     the debuginfod client will wait until the libcurl threads finish but
-+     they will never finish because they are waiting for the dlopen lock
-+     to be released, which will not happen until the call to dl_iterate_phdr
-+     finishes.
-+
-+     To avoid this, we use a global variable to detect if we are already
-+     iterating over the modules, and if so, we skip the query to debuginfod
-+     and just try with the other default methods.
-+
-+     Note this ONLY affects the symbol resolution when retrieving a backtrace,
-+     and it doesn't affect offline symbolication.  */
-+  debuginfod_guard++;
-   dl_iterate_phdr (phdr_callback, (void *) &pd);
-+  debuginfod_guard--;
- 
-   if (!state->threaded)
-     {

--- a/src/vendor/libbacktrace_2446c66076480ce07a6bd868badcbceb3eeecc2e_patch.diff
+++ b/src/vendor/libbacktrace_2446c66076480ce07a6bd868badcbceb3eeecc2e_patch.diff
@@ -184,7 +184,7 @@ index 66e101e..9422a90 100644
    if ((type & MACH_O_N_STAB) != 0)
 -    return 0;
 +  {
-+    switch (type) 
++    switch (type)
 +     {
 +     case MACH_O_N_FNAME:
 +      return 1;


### PR DESCRIPTION
This allows us to guarantee that `libdebuginfod` is always available for every Memray install. Previously we were dependent upon using `dlopen` to find a copy of it already installed in the runtime environment.