### PR TITLE
Fix live updates to footers on Textual TUIs

### DIFF
--- a/news/597.bugfix.rst
+++ b/news/597.bugfix.rst
@@ -1,0 +1,1 @@
+Fix dynamic toggling between descriptions like "Pause" vs "Unpause" or "Show" vs "Hide" in the footer of the live-mode TUI and tree reporter. This was broken by changes introduced in Textual 0.61.

--- a/src/memray/reporters/_textual_hacks.py
+++ b/src/memray/reporters/_textual_hacks.py
@@ -1,0 +1,26 @@
+import dataclasses
+from typing import Dict
+from typing import Tuple
+from typing import Union
+
+from textual import binding
+from textual.binding import Binding
+from textual.dom import DOMNode
+
+# In Textual 0.61, `App.namespace_bindings` was removed in favor of
+# `Screen.active_bindings`. The two have a slightly different interface:
+# a 2 item `tuple` was updated to a 3 item `namedtuple`.
+# The `Bindings` type alias shows the two possible structures.
+# The `update_key_description` implementation works for both,
+# since we still support Textual versions below 0.61.
+
+Bindings = Union[Dict[str, "binding.ActiveBinding"], Dict[str, Tuple[DOMNode, Binding]]]
+
+
+def update_key_description(bindings: Bindings, key: str, description: str) -> None:
+    val = bindings[key]
+    binding = dataclasses.replace(val[1], description=description)
+    if type(val) is tuple:
+        bindings[key] = val[:1] + (binding,) + val[2:]  # type: ignore
+    else:
+        bindings[key] = val._replace(binding=binding)  # type: ignore

--- a/src/memray/reporters/tree.py
+++ b/src/memray/reporters/tree.py
@@ -27,6 +27,7 @@ from textual.containers import Horizontal
 from textual.containers import Vertical
 from textual.dom import DOMNode
 from textual.reactive import reactive
+from textual.screen import Screen
 from textual.widget import Widget
 from textual.widgets import Footer
 from textual.widgets import Label
@@ -220,10 +221,10 @@ def node_is_not_import_system(node: Frame) -> bool:
     return not node.import_system
 
 
-class TreeApp(App[None]):
+class TreeScreen(Screen[None]):
     BINDINGS = [
-        Binding("ctrl+z", "suspend_process"),
-        Binding(key="q", action="quit", description="Quit the app"),
+        Binding("ctrl+z", "app.suspend_process"),
+        Binding(key="q", action="app.quit", description="Quit the app"),
         Binding(
             key="i", action="toggle_import_system", description="Hide import system"
         ),
@@ -380,6 +381,19 @@ class TreeApp(App[None]):
         # Hack: trick the Footer into redrawing itself
         self.app.query_one(Footer).highlight_key = "q"
         self.app.query_one(Footer).highlight_key = None
+
+
+class TreeApp(App[None]):
+    def __init__(
+        self,
+        data: Frame,
+        elided_locations: ElidedLocations,
+    ):
+        super().__init__()
+        self.tree_screen = TreeScreen(data, elided_locations)
+
+    def on_mount(self) -> None:
+        self.push_screen(self.tree_screen)
 
     @property
     def namespace_bindings(self) -> Dict[str, Tuple[DOMNode, Binding]]:

--- a/src/memray/reporters/tui.py
+++ b/src/memray/reporters/tui.py
@@ -514,8 +514,8 @@ class TUI(Screen[None]):
     CSS_PATH = "tui.css"
 
     BINDINGS = [
-        Binding("ctrl+z", "suspend_process"),
-        Binding("q,esc", "quit", "Quit"),
+        Binding("ctrl+z", "app.suspend_process"),
+        Binding("q,esc", "app.quit", "Quit"),
         Binding("<,left", "previous_thread", "Previous Thread"),
         Binding(">,right", "next_thread", "Next Thread"),
         Binding("t", "sort(1)", "Sort by Total"),

--- a/src/memray/reporters/tui.py
+++ b/src/memray/reporters/tui.py
@@ -565,8 +565,7 @@ class TUI(Screen[None]):
         """Toggle pause on keypress"""
         if self.paused or not self.disconnected:
             self.paused = not self.paused
-            self.app.query_one(Footer).highlight_key = "space"
-            self.app.query_one(Footer).highlight_key = None
+            self.redraw_footer()
             if not self.paused:
                 self.display_snapshot()
 
@@ -592,8 +591,7 @@ class TUI(Screen[None]):
 
     def watch_disconnected(self) -> None:
         self.update_label()
-        self.app.query_one(Footer).highlight_key = "space"
-        self.app.query_one(Footer).highlight_key = None
+        self.redraw_footer()
 
     def watch_paused(self) -> None:
         self.update_label()
@@ -664,6 +662,11 @@ class TUI(Screen[None]):
         """Method called to update the table sort key attribute."""
         body = self.query_one(AllocationTable)
         body.sort_column_id = col_number
+
+    def redraw_footer(self) -> None:
+        # Hack: trick the Footer into redrawing itself
+        self.app.query_one(Footer).highlight_key = "q"
+        self.app.query_one(Footer).highlight_key = None
 
 
 class UpdateThread(threading.Thread):


### PR DESCRIPTION
In Textual 0.61, `App.namespace_bindings` was removed in favor of `Screen.active_bindings`. Update our implementation of dynamically updating footer descriptions to work for both, since we still support Textual versions below 0.61.