### PR TITLE
Add build requirements for ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you wish to build Memray from source you need the following binary dependenci
 - libunwind (for Linux)
 - liblz4
 
-Check your package manager on how to install these dependencies (for example `apt-get install libunwind-dev liblz4-dev` in Debian-based systems
+Check your package manager on how to install these dependencies (for example `apt-get install build-essential python3-dev libunwind-dev liblz4-dev` in Debian-based systems
 or `brew install lz4` in MacOS). Note that you may need to teach the compiler where to find the header and library files of the dependencies. For
 example, in MacOS with `brew` you may need to run:
 


### PR DESCRIPTION
I am building from source using a fairly fresh Ubuntu installation so I am taking this opportunity to document some of the build dependencies in the readme.

**Describe your changes**
Just a change in the readme.

**Testing performed**
I followed the build instructions from the readme iterating when I get a build error on 
```
python3 -m pip install -e . -r requirements-test.txt -r requirements-extra.txt
```

