### PR TITLE
Fix a segfault on macOS when _dyld_shared_cache_contains_path is not available

### DIFF
--- a/news/615.bugfix.rst
+++ b/news/615.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a crash in old macOS versions (<11.0) due to the inavailability of some linker cache APIs.


### PR DESCRIPTION
The _dyld_shared_cache_contains_path is only available in macOS 11.0
or later. As we are compiling in a new system that's newer than 11.0 but
setting the deployment target to an older version, it's possible that
the _dyld_shared_cache_contains_path is not available in the target
platform and in that case we will segfault when calling it. It's also
possible that when compiling memray in an old system
_dyld_shared_cache_contains_path is not even prototyped in the headers.

To handle this, we change to fetch the function via a dlopen/dlsym approach
that will be generic in all macOS versions at the cost of an extra call
to dlopen the first time we interpose symbols.