### PR TITLE
Fix docs building in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -qy libunwind-dev liblz4-dev pkg-config
+          sudo apt-get install --no-install-recommends -qy libdebuginfod-dev libunwind-dev liblz4-dev pkg-config
       - name: Install Python dependencies
         run: |
           python3 -m pip install -r requirements-extra.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --force-yes --no-install-recommends \
     build-essential \
+    libdebuginfod-dev \
     libunwind-dev \
     liblz4-dev \
     pkg-config \

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ system where you are doing the installation.
 
 If you wish to build Memray from source you need the following binary dependencies in your system:
 
+- libdebuginfod-dev (for Linux)
 - libunwind (for Linux)
 - liblz4
 
-Check your package manager on how to install these dependencies (for example `apt-get install build-essential python3-dev libunwind-dev liblz4-dev` in Debian-based systems
+Check your package manager on how to install these dependencies (for example `apt-get install build-essential python3-dev libdebuginfod-dev libunwind-dev liblz4-dev` in Debian-based systems
 or `brew install lz4` in MacOS). Note that you may need to teach the compiler where to find the header and library files of the dependencies. For
 example, in MacOS with `brew` you may need to run:
 


### PR DESCRIPTION
Fix docs building in CI. This was broken by #592, but wasn't noticed until the PR landed because the workflow only runs on main, not PRs.