### PR TITLE
ci: Avoid testing with buggy Textual versions

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,4 +7,4 @@ ipython
 setuptools; python_version >= '3.12'
 pkgconfig
 pytest-textual-snapshot
-textual >= '0.43'
+textual >= 0.43, != 0.65.2, != 0.66

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ test_requires = [
     "ipython",
     "setuptools; python_version >= '3.12'",
     "pytest-textual-snapshot",
+    "textual >= 0.43, != 0.65.2, != 0.66",
 ]
 
 benchmark_requires = [


### PR DESCRIPTION
These two versions lead to a test suite deadlock. The problem has been reported upstream, so hopefully the next release contains a fix.

See https://github.com/Textualize/textual/issues/4634