### PR TITLE
ci: Build macOS x86_64 wheels on macOS 13

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -125,7 +125,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-11
+          - os: macos-13
             arch: x86_64
           - os: macos-14
             arch: arm64


### PR DESCRIPTION
Previously these were being built on macOS 11, but GitHub is dropping its macOS 11 runners. Upgrade to build these on macOS 13 instead (the latest version with free public Intel Mac runners). Because we leave `MACOSX_DEPLOYMENT_TARGET` set to 10.14, this should have no effect on the ABI of the built wheels.
