### PR TITLE
Publish wheels for Python 3.13

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/---bug-report.yaml
@@ -53,6 +53,7 @@ body:
         - "3.10"
         - "3.11"
         - "3.12"
+        - "3.13"
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -196,10 +196,6 @@ jobs:
           rmdir dist/{sdist,*-wheels}
           rm -r dist/tests
           ls -R dist
-      - name: Avoid publishing Python 3.13 wheels
-        run: |
-          rm -f dist/*cp313*
-          ls -l dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip_existing: true

--- a/docs/supported_environments.rst
+++ b/docs/supported_environments.rst
@@ -11,7 +11,7 @@ Supported Python versions
 
 Every Python version that hasn't reached end of life is supported.
 
-Currently that's Python 3.7 through 3.12.
+Currently that's Python 3.8 through 3.13.
 
 Supported operating systems
 ---------------------------

--- a/news/658.feature.rst
+++ b/news/658.feature.rst
@@ -1,0 +1,1 @@
+Wheels are now published for Python 3.13, though we don't yet support free-threaded (no GIL) builds.


### PR DESCRIPTION
Now that Python 3.13 is ABI stable, document that it is supported and begin to publish wheels for it.