### PR TITLE
Lock around Tracker creation and destruction

### DIFF
--- a/news/667.bugfix.rst
+++ b/news/667.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a race condition that was able to cause strange exception messages if two different threads tried to initialize Memray tracking at once.


### PR DESCRIPTION
The `Tracker.__enter__` and `Tracker.__exit` methods may wind up releasing the GIL, which allows another thread to see an intermediate state where the tracker is not fully installed. Add a lock, shared across all trackers, to serialize access to the global state that tracker installation and uninstallation writes to.

Closes #665 