### PR TITLE
Disable attach tests in cibuildwheel

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -174,12 +174,15 @@ jobs:
     name: Build and test wheels
     needs: [build_linux_wheels, build_macosx_wheels]
     runs-on: ubuntu-latest
+    if: always() # Don't skip this step if a predecessor failed!
     steps:
       # We can't make a matrix job itself a required check in GitHub,
       # so we instead add a job that depends on the two matrix jobs,
       # and we mark this job as required instead. This job doesn't do
       # any work, it just lets us better manage our required checks.
-      - run: echo "Done!"
+      - if: "!success()"
+        run: echo "Some builds failed" && exit 1
+      - run: echo "All builds succeeded!"
 
   upload_pypi:
     needs: [build_and_test_wheels, build_sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,7 @@ before-all = [
   "make install",
 
   # Install Memray's other build and test dependencies
-  "yum install -y libunwind-devel gdb",
-  "if ! yum install -y lldb; then echo lldb is not available; fi"
+  "yum install -y libunwind-devel",
 ]
 
 [tool.cibuildwheel.macos]
@@ -177,5 +176,5 @@ before-all = [
   "make install",
 
   # Install Memray's other build and test dependencies
-  "apk add --update libunwind-dev lz4-dev gdb lldb"
+  "apk add --update libunwind-dev lz4-dev"
 ]


### PR DESCRIPTION
Disable the `memray attach` tests in cibuildwheel. These tests have broken because of changes to the GitHub runners. The old debuggers being installed in the containers are not compatible with the new Linux kernel being used by the runners. Rather than spend a bunch of effort to get this working, we'll just disable these tests in those environments.

Note that we still exercising attaching with both debuggers in other workflows: the `test_with_coverage` workflow tests both gdb and lldb on glibc, and the `test_on_alpine` workflow tests both gdb and lldb on musl libc.

Additionally, ensure "Build and test wheels" can fail. We added the "Build and test wheels" job as a required check to our CI in order to avoid needing to list every possible matrix job as required, but this didn't actually work as intended: the job never failed, it always either passed or was skipped, and GitHub doesn't count a skipped job as a failing check.

Work around this with a different approach: ensure that this job always runs, and succeeds if and only if all of its dependencies succeeded.