### PR TITLE
Add Python 3.7 Trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -314,6 +314,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
**Describe your changes**

Memray still supports Python 3.7, add the missing classifier for PyPI.


**Testing performed**

None.
