### PR TITLE
Avoid patching symbols in the extension module

### DIFF
--- a/news/685.bugfix.rst
+++ b/news/685.bugfix.rst
@@ -1,0 +1,1 @@
+Fix some crashes caused by interposing symbols in memray itself

--- a/src/memray/_memray/linker_shenanigans.h
+++ b/src/memray/_memray/linker_shenanigans.h
@@ -3,14 +3,27 @@
 #include <set>
 #include <string>
 
+#include <dlfcn.h>
+
 namespace memray::linker {
+
+static void
+_dummy(void){};
 
 class SymbolPatcher
 {
   private:
     std::set<std::string> symbols;
+    std::string self_so_name = "_memray.cpython-";
 
   public:
+    SymbolPatcher()
+    {
+        Dl_info info;
+        if (dladdr((void*)&_dummy, &info)) {
+            self_so_name = info.dli_fname;
+        }
+    }
     void overwrite_symbols() noexcept;
     void restore_symbols() noexcept;
 };


### PR DESCRIPTION
The fact that patching ourselves had not raised problems so far its
really an outstanding fact in this universe. Unfortunately seems that
with the latest toolchain + GCC there is something that causes memray to
point the d_original entry of the hooks pointing to itself, which should
never happen.

To fix this resiliently, avoid patching ourselves by getting our own
name in the extension module and then avoiding that shared object.

Closes: #662
