### PR TITLE
ci: Don't require `skip-news` if NEWS.rst changes

### DIFF
--- a/.github/workflows/news-check.yml
+++ b/.github/workflows/news-check.yml
@@ -18,6 +18,8 @@ jobs:
       - name: "Check for news entry"
         uses: brettcannon/check-for-changed-files@v1
         with:
-          file-pattern: "news/*.rst"
+          file-pattern: |
+            news/*.rst
+            NEWS.rst
           skip-label: "skip news"
           failure-message: "Missing a news file in ${file-pattern}; please add one or apply the ${skip-label} label to the pull request"


### PR DESCRIPTION
Until now we've been requiring every PR affect a file in the news/ directory or be labeled with `skip-news`. Also allow a PR to directly touch NEWS.rst instead.