### PR TITLE
Fix symbol resolution for malloc_type functions on macOS Sequoia

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,9 @@ jobs:
     container:
       image: alpine
       options: --cap-add=SYS_PTRACE
+    env:
+      # Coverage is kind of broken in Alpine
+      SKIP_COVERAGE_HTML: 1
     steps:
       - uses: actions/checkout@v4
       - name: Set up dependencies

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,9 @@ pycoverage:  ## Run the test suite, with Python code coverage
 		--cov-append $(PYTEST_ARGS) \
 		tests
 	$(PYTHON) -m coverage lcov -i -o pycoverage.lcov
-	genhtml *coverage.lcov  --branch-coverage --output-directory memray-coverage $(GENHTMLOPTS)
+	if [ -z "$$SKIP_COVERAGE_HTML" ]; then \
+		genhtml *coverage.lcov  --branch-coverage --output-directory memray-coverage $(GENHTMLOPTS); \
+	fi
 
 .PHONY: valgrind
 valgrind:  ## Run valgrind, with the correct configuration

--- a/news/693.bugfix.rst
+++ b/news/693.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug that was causing tracking of runtime libraries that are part of the linker cache not work in macOS 15.


### PR DESCRIPTION
This commit addresses an issue with symbol resolution for malloc_type
functions on the latest macOS Sequoia. The problem arises due to changes
in how these functions are named in the dynamic symbol table of the
system libraries that are part of the linker cache like the ones that
contain the C++ runtime.

This fix ensures that Memray correctly intercepts and tracks allocations
made by malloc_type functions, fixing tracking allocations in the C++
runtime and other system libraries on macOS Sequoia.
