### PR TITLE
Protect against deregistered profile functions in greenlet switches

### DIFF
--- a/news/700.bugfix.rst
+++ b/news/700.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a crash when a greenlet switch happens after Memray's profile function has been deactivated or replaced.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 Cython
 coverage[toml]
-greenlet; python_version < '3.13'
+greenlet; python_version < '3.14'
 pytest
 pytest-cov
 ipython

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ lint_requires = [
 
 test_requires = [
     "Cython",
-    "greenlet; python_version < '3.13'",
+    "greenlet; python_version < '3.14'",
     "pytest",
     "pytest-cov",
     "ipython",


### PR DESCRIPTION
When greenlet tracking is enabled is possible that we run into a
situation where the function that recreates the Python stack in our TLS
variable after a greenlet switch is called **after** the profile
function has been deactivated. In this case, recreating the Python stack
is wrong as we are no longer tracking POP/PUSH events so when the stack
is inspected later nothing guarantees that the frames are still valid.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
