### PR TITLE
ci: Ignore memory leaks in `PyInit_readline`

### DIFF
--- a/valgrind.supp
+++ b/valgrind.supp
@@ -30,6 +30,17 @@
    ...
 }
 
+# Valgrind is now reporting leaks in the `readline` module, but
+# these are certainly not relevant to Memray.
+{
+   <ignore_leaks_in_readline_module>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:PyInit_readline
+   ...
+}
+
 # CPython does not deallocate multitude of immortal objects
 # and this confuses valgrind. For this, we want to suppress
 # all traces that are not 'definite lost' that originated from


### PR DESCRIPTION
These are triggered by the importing the `readline` module, which is part of the Python standard library. Any leaks here aren't our responsibility to find or fix.