### PR TITLE
Switch the RecursionGuard to use pthread APIs

### DIFF
--- a/news/732.bugfix.rst
+++ b/news/732.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug with macOS version 15.4 that was causing memray to crash when the internal TLS variables were being created or destroyed.

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -559,11 +559,7 @@ Tracker::Tracker(
 {
     static std::once_flag once;
     call_once(once, [] {
-#ifndef __linux__
-        if (0 != pthread_key_create(&RecursionGuard::isActiveKey, NULL)) {
-            throw std::runtime_error{"Failed to create pthread key"};
-        }
-#endif
+        RecursionGuard::initialize();
         // We use the pthread TLS API for this vector because we must be able
         // to re-create it while TLS destructors are running (a destructor can
         // call malloc, hitting our malloc hook). POSIX guarantees multiple

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -134,6 +134,12 @@ PyTraceTrampoline(PyObject* obj, PyFrameObject* frame, int what, PyObject* arg);
 void
 install_trace_function();
 
+/**
+ * Install our pthread fork handlers.
+ */
+void
+set_up_pthread_fork_handlers();
+
 class NativeTrace
 {
   public:

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -91,7 +91,8 @@ struct RecursionGuard
 
     static __attribute__((always_inline)) inline void setValue(bool value)
     {
-        if (pthread_setspecific(isActiveKey, value ? (void*)1 : (void*)0) != 0) {
+        static bool true_constant = true;
+        if (pthread_setspecific(isActiveKey, value ? &true_constant : (void*)0) != 0) {
             abort();
         }
         return;

--- a/src/memray/_memray/tracking_api.pxd
+++ b/src/memray/_memray/tracking_api.pxd
@@ -6,6 +6,7 @@ from libcpp.string cimport string
 
 
 cdef extern from "tracking_api.h" namespace "memray::tracking_api":
+    void set_up_pthread_fork_handlers() except+
     void install_trace_function() except*
 
     cdef cppclass Tracker:
@@ -35,12 +36,6 @@ cdef extern from "tracking_api.h" namespace "memray::tracking_api":
 
         @staticmethod
         void registerThreadNameById(uint64_t, const char*) except+
-
-        @staticmethod
-        void prepareFork() noexcept nogil
-
-        @staticmethod
-        void parentFork() noexcept nogil
 
         @staticmethod
         void childFork() noexcept nogil


### PR DESCRIPTION
In the last macOS version (15.4) some change in the way Apple builds the
linker shared cache bundle has changed the layout to have a single
GOT-like entry for every PLT-like entry. This makes that if we patch a
single library we are patching all of them and our filtering of the
linker libraries is not working properly and memray crashes when the
TLS-releted calls recurse into our malloc calls.

To avoid this, use a pthread-based system for the RecursionGuard only on
macOS as we were already doing for the native unwinding TLS.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.


Closes: #733 
