### PR TITLE
Fix ARM Linux infinite loop in attach / live mode

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -111,7 +111,7 @@ jobs:
           CIBW_ARCHS_LINUX: auto
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test
-          CIBW_TEST_COMMAND: python -um pytest -vvv {package}/tests
+          CIBW_TEST_COMMAND: python -um pytest --log-cli-level=DEBUG -s -vvv {package}/tests
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.wheel_type }}${{ matrix.manylinux2010_hack }}-wheels
@@ -158,7 +158,7 @@ jobs:
           CIBW_BUILD: "cp3{8..13}-*"
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test
-          CIBW_TEST_COMMAND: python -um pytest -vvv {package}/tests
+          CIBW_TEST_COMMAND: python -um pytest --log-cli-level=DEBUG -s -vvv {package}/tests
           CIBW_BUILD_VERBOSITY: 1
           CFLAGS: "${{env.CFLAGS}} -I${{env.LZ4_INSTALL_DIR}}/include"
           LDFLAGS: "-L${{env.LZ4_INSTALL_DIR}}/lib -Wl,-rpath,${{env.LZ4_INSTALL_DIR}}/lib"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -111,7 +111,7 @@ jobs:
           CIBW_ARCHS_LINUX: auto
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test
-          CIBW_TEST_COMMAND: python -m pytest {package}/tests
+          CIBW_TEST_COMMAND: python -um pytest -vvv {package}/tests
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.wheel_type }}${{ matrix.manylinux2010_hack }}-wheels
@@ -158,7 +158,7 @@ jobs:
           CIBW_BUILD: "cp3{8..13}-*"
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test
-          CIBW_TEST_COMMAND: pytest {package}/tests
+          CIBW_TEST_COMMAND: python -um pytest -vvv {package}/tests
           CIBW_BUILD_VERBOSITY: 1
           CFLAGS: "${{env.CFLAGS}} -I${{env.LZ4_INSTALL_DIR}}/include"
           LDFLAGS: "-L${{env.LZ4_INSTALL_DIR}}/lib -Wl,-rpath,${{env.LZ4_INSTALL_DIR}}/lib"

--- a/docs/_static/flamegraphs/.gitattributes
+++ b/docs/_static/flamegraphs/.gitattributes
@@ -1,0 +1,1 @@
+*.html -diff

--- a/news/737.bugfix.rst
+++ b/news/737.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that could result in an infinite loop on ARM Linux systems when a process that Memray is attached to abruptly dies.

--- a/src/memray/_memray/source.cpp
+++ b/src/memray/_memray/source.cpp
@@ -193,6 +193,7 @@ SocketSource::SocketSource(int port)
     while (curr_address == nullptr) {
         Py_BEGIN_ALLOW_THREADS;
         if ((rv = ::getaddrinfo(nullptr, port_str.c_str(), &hints, &all_addresses)) != 0) {
+            Py_UNBLOCK_THREADS;
             LOG(ERROR) << "Encountered error in 'getaddrinfo' call: " << ::gai_strerror(rv);
             throw IoError{"Failed to resolve host IP and port"};
         }

--- a/src/memray/_memray/source.cpp
+++ b/src/memray/_memray/source.cpp
@@ -273,16 +273,16 @@ SocketSource::is_open()
 bool
 SocketSource::getline(std::string& result, char delimiter)
 {
-    char buf;
+    int buf;
     while (true) {
-        buf = static_cast<char>(d_socket_buf->sbumpc());
-        if (buf == delimiter || buf == SocketBuf::traits_type::eof()) {
+        buf = d_socket_buf->sbumpc();
+        if (buf == static_cast<int>(delimiter) || buf == SocketBuf::traits_type::eof()) {
             if (!d_is_open) {
                 return false;
             }
             break;
         }
-        result.push_back(buf);
+        result.push_back(static_cast<char>(buf));
     }
     return true;
 }

--- a/tests/integration/test_ipython.py
+++ b/tests/integration/test_ipython.py
@@ -3,13 +3,19 @@ import os
 import pytest
 from IPython.core.displaypub import CapturingDisplayPublisher
 from IPython.core.interactiveshell import InteractiveShell
+from traitlets.config import Config
 
 
 def run_in_ipython_shell(tmpdir, cells):
     """Run the given cells in an IPython shell and return the HTML output."""
     InteractiveShell.clear_instance()
 
-    shell = InteractiveShell.instance(display_pub_class=CapturingDisplayPublisher)
+    config = Config()
+    config.HistoryAccessor.enabled = False  # Disable sqlite history
+    shell = InteractiveShell.instance(
+        display_pub_class=CapturingDisplayPublisher,
+        config=config,
+    )
     prev_running_dir = os.getcwd()
     try:
         os.chdir(tmpdir)

--- a/tests/integration/test_socket.py
+++ b/tests/integration/test_socket.py
@@ -410,12 +410,13 @@ class TestSocketReaderAccess:
         MAX_TRACES = 10
 
         # WHEN
-        with subprocess.Popen(code) as proc, SocketReader(port=free_port) as reader:
-            while len(traces) < MAX_TRACES:
-                for allocation in reader.get_current_snapshot(merge_threads=False):
-                    traces.update(allocation.stack_trace())
+        with subprocess.Popen(code) as proc:
+            with SocketReader(port=free_port) as reader:
+                while len(traces) < MAX_TRACES:
+                    for allocation in reader.get_current_snapshot(merge_threads=False):
+                        traces.update(allocation.stack_trace())
 
-            proc.terminate()
+                proc.terminate()
 
         # THEN
         assert len(traces) >= MAX_TRACES

--- a/tests/integration/test_socket.py
+++ b/tests/integration/test_socket.py
@@ -419,4 +419,3 @@ class TestSocketReaderAccess:
 
         # THEN
         assert len(traces) >= MAX_TRACES
-        proc.returncode == 0


### PR DESCRIPTION
On ARM Linux, `char` is unsigned, unlike on all of our other platforms.
Since EOF is equal to `-1`, this means that we need to be careful to
avoid assuming that:

    EOF == static_cast<char>(EOF)

On all of our other platforms that's true, but on aarch64 Linux machines
that compares `-1 == 255` instead. And when you want to loop until EOF
but don't recognize EOF, that's an infinite loop...

Also fix a bug where we could potentially return from extension code to
Python code without holding the GIL.

Also, have CI run pytest unbuffered and in verbose mode. This way, if
a crash occurs, we should at least be able to see what test was running
when things went wrong.

Also: Prevent IPython from writing history files in our tests.
We don't need the history features, so the extra thread managing
a sqlite database just gets in our way.

Also, mark the flamegraphs in our docs as binary files.
This stops them from having textual diffs shown for them, and from
showing up in the result of `git grep`. We never want to see the
contents of these files, since they're programmatically generated.