### PR TITLE
Drop wheels for old platforms

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -51,45 +51,17 @@ jobs:
 
   build_linux_wheels:
     needs: [build_sdist, choose_linux_wheel_types]
-    name: ${{ matrix.wheel_type }}${{ matrix.manylinux2010_hack }} wheels
+    name: ${{ matrix.wheel_type }} wheels
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         wheel_type: ${{ fromJSON(needs.choose_linux_wheel_types.outputs.wheel_types) }}
-        manylinux2010_hack: [""]
         include:
           - os: ubuntu-latest
           - wheel_type: manylinux_aarch64
             os: ubuntu-24.04-arm
-          - wheel_type: manylinux_x86_64
-            os: ubuntu-latest
-            manylinux2010_hack: "_manylinux2010_hack"
     steps:
-      - name: Build manylinux2010 image containing Python 3.11 and 3.12
-        if: matrix.manylinux2010_hack
-        run: |
-          echo "CIBW_SKIP=*cp3{7,8,9,10,13}*" >> $GITHUB_ENV
-          echo "CIBW_MANYLINUX_X86_64_IMAGE=manylinux2010-with-modern-cpython" >> $GITHUB_ENV
-          docker build -t manylinux2010-with-modern-cpython - <<'EOF'
-          # syntax=docker/dockerfile:1
-          FROM quay.io/pypa/manylinux2010_x86_64:latest
-          RUN curl https://pyenv.run | bash && \
-           export PYENV_ROOT="$HOME/.pyenv" && \
-           export PATH="$PYENV_ROOT/bin:$PATH" && \
-           eval "$(pyenv init -)" && \
-           yum install -y make patch zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel perl-IPC-Cmd && \
-           curl -L https://www.openssl.org/source/openssl-3.0.12.tar.gz >openssl-3.0.12.tar.gz && \
-           tar xzf openssl-3.0.12.tar.gz && \
-           (cd openssl-3.0.12 && ./config no-shared --prefix=/usr/local/ssl --openssldir=/usr/local/ssl --libdir=lib && make && make install_sw) && \
-           rm -rf openssl-3.0.12.tar.gz && \
-           rm -rf openssl-3.0.12 && \
-           PYTHON_CONFIGURE_OPTS=--with-openssl=/usr/local/ssl pyenv install 3.11 && \
-           ln -s /root/.pyenv/versions/3.11* /opt/python/cp311-cp311 && \
-           PYTHON_CONFIGURE_OPTS=--with-openssl=/usr/local/ssl pyenv install 3.12 && \
-           ln -s /root/.pyenv/versions/3.12* /opt/python/cp312-cp312 && \
-           true
-          EOF
       - uses: actions/download-artifact@v4
         with:
           name: sdist
@@ -114,7 +86,7 @@ jobs:
           CIBW_TEST_COMMAND: python -um pytest --log-cli-level=DEBUG -s -vvv {package}/tests
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.wheel_type }}${{ matrix.manylinux2010_hack }}-wheels
+          name: ${{ matrix.wheel_type }}-wheels
           path: ./wheelhouse/*.whl
 
   build_macosx_wheels:

--- a/docs/supported_environments.rst
+++ b/docs/supported_environments.rst
@@ -48,9 +48,8 @@ We require a C++17 runtime. As noted above, macOS 11 or higher is required for
 a C++17 runtime on Mac.
 
 On Linux we support glibc and musl libc. Other libc's have not been tested, and
-issues are likely. For Python 3.10 and earlier we support platforms compatible
-with the ``manylinux2010`` specification, and for Python 3.11 onward we require
-``manylinux2014`` compatibility.
+issues are likely. We support platforms compatible with the ``manylinux2014``
+specification.
 
 Known issues and limitations
 ----------------------------

--- a/news/742.removal.1.rst
+++ b/news/742.removal.1.rst
@@ -1,0 +1,1 @@
+We no longer provide manylinux2010 wheels. Previously they were provided for Python 3.7 through 3.12, now we provide manylinux2014 wheels for those Python versions instead. The manylinux project dropped support for manylinux2010 on August 1st, 2022.

--- a/news/742.removal.2.rst
+++ b/news/742.removal.2.rst
@@ -1,0 +1,1 @@
+We no longer provide musllinux_1_1 wheels. Previously they were provided for Python 3.7 through 3.13, now we provide musllinux_1_2 wheels for those Python versions instead. The manylinux project dropped support for musllinux_1_1 on November 1st, 2024.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
 skip = "*musllinux*{i686,aarch64}*"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
-musllinux-x86_64-image = "musllinux_1_1"
+musllinux-x86_64-image = "musllinux_1_2"
 
 [tool.cibuildwheel.linux]
 before-all = [
@@ -142,33 +142,22 @@ before-all = [
   # dependency of elfutils.
   "apk del gettext-dev glib-dev",
 
-  # Build musl-fts from source. This is a build dependency of elfutils, but
-  # isn't in the Alpine repos of the musllinux_1_1 image. The build steps come
-  # from https://git.alpinelinux.org/aports/tree/main/musl-fts/APKBUILD
-  # Setting PATH before calling boostrap.sh fixes an automake failure. I think
-  # the failure may be caused by a different pkg-config in /usr/local/bin.
-  "cd /",
-  "apk add --update automake autoconf libtool",
-  "VERS=1.2.7",
-  "curl -L https://github.com/void-linux/musl-fts/archive/refs/tags/v$VERS.tar.gz > ./musl-fts.tar.gz",
-  "tar -xf musl-fts.tar.gz",
-  "cd musl-fts-$VERS",
-  "PATH=/usr/bin:/bin ./bootstrap.sh",
-  "CFLAGS=-fPIC ./configure",
-  "make install",
-
   # Build the latest elfutils from source. The build steps come from
   # https://git.alpinelinux.org/aports/tree/main/elfutils, and the need to
   # set the FNM_EXTMATCH macro to get the build to succeed is seen here:
   # https://git.alpinelinux.org/aports/tree/main/elfutils/musl-macros.patch
   "cd /",
-  "apk add --update argp-standalone bison bsd-compat-headers bzip2-dev curl-dev flex-dev libtool linux-headers musl-libintl musl-obstack-dev xz-dev zlib-dev zstd-dev",
+  "apk add --update argp-standalone bison bsd-compat-headers bzip2-dev curl-dev flex-dev libtool linux-headers musl-fts-dev musl-libintl musl-obstack-dev xz-dev zlib-dev zstd-dev",
   "VERS=0.191",
   "curl -L https://mirrors.kernel.org/sourceware/elfutils/$VERS/elfutils-$VERS.tar.bz2 >./elfutils.tar.bz2",
   "tar -xf elfutils.tar.bz2",
   "cd elfutils-$VERS",
   "CFLAGS='-Wno-error -DFNM_EXTMATCH=0 -g -O3' CXXFLAGS='-Wno-error -g -O3' ./configure --enable-libdebuginfod --disable-debuginfod --disable-nls --with-zstd",
   "make install",
+
+  # Reinstall libintl, as the Python interpreter requires it
+  "apk del musl-libintl",
+  "apk add libintl",
 
   # Install Memray's other build and test dependencies
   "apk add --update libunwind-dev lz4-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,11 +67,6 @@ manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 musllinux-x86_64-image = "musllinux_1_1"
 
-[[tool.cibuildwheel.overrides]]
-select = "cp3{7,8,9,10}-*"
-manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"
-
 [tool.cibuildwheel.linux]
 before-all = [
   # Build the latest curl from source.


### PR DESCRIPTION
Switch from musllinux_1_1 wheels to musllinux_1_2, and switch from manylinux2010 to manylinux2014.

Previously, we built manylinux2010 wheels for Python 3.7 through 3.12, and manylinux2014 wheels for Python 3.11 through 3.13.
    
Stop producing the manylinux2010 wheels. For each of the versions that previously had only manylinux2010 wheels, instead build manylinux2014 wheels.