### PR TITLE
Add a timeout to the socket in `memray attach`

### DIFF
--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -352,7 +352,14 @@ class _DebuggerCommand:
             if errmsg:
                 raise MemrayCommandError(errmsg, exit_code=1)
 
-            return server.accept()[0]
+            server.settimeout(10)
+            try:
+                return server.accept()[0]
+            except TimeoutError:
+                raise MemrayCommandError(
+                    f"Timed out waiting for connection from pid {pid}",
+                    exit_code=1,
+                )
 
 
 class AttachCommand(_DebuggerCommand):


### PR DESCRIPTION
*Issue number of the reported bug or feature request: N/A*

**Describe your changes**
Adds a timeout to `memray attach` to prevent some rare hangs if the attached Python process crashed or begins finalizing.

**Testing performed**
Removed [this line](https://github.com/bloomberg/memray/blob/864fc2df02c7ccde7a0578ddf79ae062b89b3658/src/memray/_memray/inject.cpp#L235) to simulate the process never attaching.

**Additional context**
I arbitrarily chose 10 seconds as the timeout. It's probably fine to shorten that, but I don't know how long it usually takes for Memray to connect on slower systems.

cc @godlygeek