### PR TITLE
Update test_exercise_3.py

### DIFF
--- a/docs/tutorials/tests/test_exercise_3.py
+++ b/docs/tutorials/tests/test_exercise_3.py
@@ -8,7 +8,7 @@ from exercise_3.lru_cache import generate_factorial_plus_last_digit
 # Memory tests
 
 
-@pytest.mark.limit_memory("75 MB")
+@pytest.mark.limit_memory("200 MB")
 def test_lru_cache():
     compare_counts_different_factorials()
 


### PR DESCRIPTION
#743 testing in Python version 3.13, the solution uses a bit more memory than previously in Python version 3.12.

I saw an increase up to about 170MB of memory used for my run.

The provided example which is meant to use too much memory uses about 740MB.

So I think a new threshold of 200MB should be sufficient. This will also be backwards compatible.