### PR TITLE
Add `Usage Over Time` button to topBar

### DIFF
--- a/src/memray/reporters/templates/classic_base.html
+++ b/src/memray/reporters/templates/classic_base.html
@@ -1,6 +1,11 @@
 {# Extends base.html and adds zoomable memory chart without sliders. #}
 {% extends "base.html" %}
 
+{% block topbar_buttons %}
+{{ super() }}
+<button id="usageOverTimeButton" class="btn btn-outline-light mr-3" data-toggle="modal" data-target="#memoryModal" onclick="javascript:resizeMemoryGraph();">Usage Over Time</button>
+{% endblock %}
+
 {% block extra_nav %}
 <nav class="navbar navbar-dark bg-dark px-0">
   <div id="smallMemoryGraph" class="w-100" data-toggle="modal" data-target="#memoryModal" onclick="javascript:resizeMemoryGraph();"></div>

--- a/src/memray/reporters/templates/flamegraph.html
+++ b/src/memray/reporters/templates/flamegraph.html
@@ -44,6 +44,7 @@
   </label>
 </div>
 <button id="resetZoomButton" class="btn btn-outline-light mr-3">Reset Zoom</button>
+{{ super() }}
 {% endblock %}
 
 {% block content %}

--- a/src/memray/reporters/templates/table.html
+++ b/src/memray/reporters/templates/table.html
@@ -1,5 +1,9 @@
 {% extends "classic_base.html" %}
 
+{% block topbar_buttons %}
+{{ super() }}
+{% endblock %}
+
 {% block content %}
 <div class="chart-container">
   <table class="table table-striped" id="the_table">


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #712 *

**Describe your changes**
Add a button to open the zoomed in RSS/Heap usage over time chart. Currently, it is not clear that clicking on the flamegraph opens this chart.

**Testing performed**
Tested locally by creating a table and flamegraph reporter using tutorial/exercise 2.

