### PR TITLE
Hide memory graph button for temporal flamegraph

### DIFF
--- a/src/memray/reporters/templates/classic_base.html
+++ b/src/memray/reporters/templates/classic_base.html
@@ -3,7 +3,7 @@
 
 {% block topbar_buttons %}
 {{ super() }}
-<button id="usageOverTimeButton" class="btn btn-outline-light mr-3" data-toggle="modal" data-target="#memoryModal" onclick="javascript:resizeMemoryGraph();">Usage Over Time</button>
+<button id="memoryGraphButton" class="btn btn-outline-light mr-3" data-toggle="modal" data-target="#memoryModal" onclick="javascript:resizeMemoryGraph();">Memory Graph</button>
 {% endblock %}
 
 {% block extra_nav %}

--- a/src/memray/reporters/templates/flamegraph.html
+++ b/src/memray/reporters/templates/flamegraph.html
@@ -44,7 +44,9 @@
   </label>
 </div>
 <button id="resetZoomButton" class="btn btn-outline-light mr-3">Reset Zoom</button>
+{% if kind == "flamegraph" %}
 {{ super() }}
+{% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #712 *

**Describe your changes**
Temporal graph already shows the temporal graph for memory usage. Hide the button in topbar for the same.

**Testing performed**
Tested locally with and without `--temporal` argument.
