### PR TITLE
Wheelfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -333,6 +333,7 @@ setup(
         compiler_directives=COMPILER_DIRECTIVES,
     ),
     include_package_data=True,
+    exclude_package_data={"memray": ["_memray/*"]},
     install_requires=install_requires,
     extras_require={
         "test": test_requires,


### PR DESCRIPTION
Addresses #768 

Addresses the issue by being more specific about which file types should be included. This was tested by comparing the contents of the wheel before and after the change. Notably, trying to use exclude_package_data to specifically exclude memray/_memray didn't seem to work in this case.
