### PR TITLE
Fix a race condition under Textual 3.3.0

### DIFF
--- a/src/memray/reporters/tui.py
+++ b/src/memray/reporters/tui.py
@@ -768,8 +768,6 @@ class TUIApp(App[None]):
         super().__init__()
 
     def on_mount(self) -> None:
-        self._update_thread.start()
-
         self.set_interval(self._poll_interval, self._update_thread.schedule_update)
         cmd_line = (
             self._cmdline_override
@@ -789,6 +787,7 @@ class TUIApp(App[None]):
             native=self._reader.has_native_traces,
         )
         self.push_screen(self.tui)
+        self._update_thread.start()
 
     def on_unmount(self) -> None:
         self._update_thread.cancel()


### PR DESCRIPTION
Textual 3.3.0 introduced a race condition that leads to errors if an app's message queue is first accessed from a different thread. See https://github.com/Textualize/textual/issues/5845

This potentially affects the live mode TUI, which starts a background thread early on in app startup to monitor the memory usage reports coming in from the application being profiled and update the screen. We can work around this by starting our update thread a bit later in the startup process, at a point where the message queue will already have been accessed by the thread running the app.
