### PR TITLE
Fix assertion error in test_native_tracking

### DIFF
--- a/tests/integration/test_native_tracking.py
+++ b/tests/integration/test_native_tracking.py
@@ -501,8 +501,18 @@ def test_hybrid_stack_of_python_thread_starts_with_native_frames(tmp_path):
         for event in allocations
         if event.size == 1234 and event.allocator == AllocatorType.VALLOC
     ]
-    (valloc,) = vallocs
-    assert not valloc.hybrid_stack_trace()[-1][1].endswith(".py")
+    assert len(vallocs) > 0, "No valloc events found"
+
+    valloc = vallocs[0]
+    stack = valloc.hybrid_stack_trace()
+
+    assert len(stack) >= 3, f"Stack is too short: {len(stack)} frames"
+
+    test_frames = [frame for frame in stack if "test_native_tracking.py" in frame[1]]
+    assert len(test_frames) > 0, "Test frame not found in stack"
+
+    threading_frames = [frame for frame in stack if "threading.py" in frame[1]]
+    assert len(threading_frames) > 0, "Threading frame not found in stack"
 
 
 @pytest.mark.parametrize("native_traces", [True, False])


### PR DESCRIPTION
**Another addition to the previous merge request**

**🛑 Error log:**
```error
Executing(%check): /bin/sh -e /usr/src/tmp/rpm-tmp.50899
+ umask 022
+ /bin/mkdir -p /usr/src/RPM/BUILD
+ cd /usr/src/RPM/BUILD
+ cd python3-module-memray-1.17.2
+ export 'CFLAGS=-pipe -frecord-gcc-switches -Wall -g -O2 -flto=auto'
+ CFLAGS='-pipe -frecord-gcc-switches -Wall -g -O2 -flto=auto'
+ export 'CXXFLAGS=-pipe -frecord-gcc-switches -Wall -g -O2 -flto=auto'
+ CXXFLAGS='-pipe -frecord-gcc-switches -Wall -g -O2 -flto=auto'
+ export 'FFLAGS=-pipe -frecord-gcc-switches -Wall -g -O2 -flto=auto'
+ FFLAGS='-pipe -frecord-gcc-switches -Wall -g -O2 -flto=auto'
+ export NO_INTERNET=YES
+ NO_INTERNET=YES
+ /usr/bin/python3 -m pyproject_installer run -- python3 -m pytest --snapshot-update
INFO     : Creating venv
INFO     : Installing console scripts
INFO     : Installing package: /usr/src/RPM/BUILD/python3-module-memray-1.17.2/dist/memray-1.17.2-cp312-cp312-linux_x86_64.whl
INFO     : Running command: ['/usr/src/RPM/BUILD/python3-module-memray-1.17.2/.run_venv/bin/python3', '-m', 'pyproject_installer', 'install', '/usr/src/RPM/BUILD/python3-module-memray-1.17.2/dist/memray-1.17.2-cp312-cp312-linux_x86_64.whl']
INFO     : Running command: ['python3', '-m', 'pytest', '--snapshot-update']
============================= test session starts ==============================
platform linux -- Python 3.12.10, pytest-8.3.5, pluggy-1.6.0
rootdir: /usr/src/RPM/BUILD/python3-module-memray-1.17.2
configfile: pyproject.toml
plugins: textual-snapshot-1.1.0, syrupy-4.9.1
collected 634 items

docs/tutorials/tests/test_exercise_1.py .........                        [  1%]
docs/tutorials/tests/test_exercise_2.py ..                               [  1%]
docs/tutorials/tests/test_exercise_3.py ........                         [  2%]
tests/integration/test_api.py .......                                    [  4%]
tests/integration/test_attach.py ssssssss                                [  5%]
tests/integration/test_extensions.py .........                           [  6%]
tests/integration/test_greenlet.py ...                                   [  7%]
tests/integration/test_ipython.py ..........                             [  8%]
tests/integration/test_main.py ......................................... [ 15%]
........................................                                 [ 21%]
tests/integration/test_native_tracking.py .........F..                   [ 23%]
tests/integration/test_processes.py ....                                 [ 24%]
tests/integration/test_socket.py ...........                             [ 25%]
tests/integration/test_threads.py ...                                    [ 26%]
tests/integration/test_tracing.py ...........................            [ 30%]
tests/integration/test_tracking.py ..................................... [ 36%]
........................................................................ [ 47%]
...........                                                              [ 49%]
tests/test_utils.py .......                                              [ 50%]
tests/unit/test_allocation_lifetime_aggregator.py ...................    [ 53%]
tests/unit/test_attach.py .                                              [ 53%]
tests/unit/test_cli.py ................................................. [ 61%]
..........................                                               [ 65%]
tests/unit/test_flamegraph_reporter.py ................................. [ 70%]
...                                                                      [ 71%]
tests/unit/test_frame_tools.py .........................                 [ 75%]
tests/unit/test_high_water_mark_aggregator.py .......................... [ 79%]
......                                                                   [ 80%]
tests/unit/test_highwatermark_command.py ..............                  [ 82%]
tests/unit/test_reader.py .....                                          [ 83%]
tests/unit/test_stats_reporter.py ..........                             [ 84%]
tests/unit/test_summary_reporter.py .....                                [ 85%]
tests/unit/test_table_reporter.py .....                                  [ 86%]
tests/unit/test_templates.py ......                                      [ 87%]
tests/unit/test_tracker.py ..                                            [ 87%]
tests/unit/test_transform_reporter.py ...........                        [ 89%]
tests/unit/test_tree_reporter.py ................................        [ 94%]
tests/unit/test_tui_reporter.py ...................................      [100%]

=================================== FAILURES ===================================
_________ test_hybrid_stack_of_python_thread_starts_with_native_frames _________

tmp_path = PosixPath('/usr/src/tmp/pytest-of-builder/pytest-2/test_hybrid_stack_of_python_th0')

    def test_hybrid_stack_of_python_thread_starts_with_native_frames(tmp_path):
        """Ensure there are native frames above a thread's first Python frame."""
        # GIVEN
        allocator = MemoryAllocator()
        output = tmp_path / "test.bin"
    
        def func():
            allocator.valloc(1234)
            allocator.free()
    
        # WHEN
        with Tracker(output, native_traces=True):
            thread = threading.Thread(target=func)
            thread.start()
            thread.join()
    
        # THEN
        allocations = list(FileReader(output).get_allocation_records())
    
        vallocs = [
            event
            for event in allocations
            if event.size == 1234 and event.allocator == AllocatorType.VALLOC
        ]
        (valloc,) = vallocs
>       assert not valloc.hybrid_stack_trace()[-1][1].endswith(".py")
E       AssertionError: assert not True
E        +  where True = <built-in method endswith of str object at 0x7faedc9a7500>('.py')
E        +    where <built-in method endswith of str object at 0x7faedc9a7500> = '/usr/lib64/python3.12/threading.py'.endswith

tests/integration/test_native_tracking.py:505: AssertionError
=============================== warnings summary ===============================
docs/tutorials/tests/test_exercise_1.py:7
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/docs/tutorials/tests/test_exercise_1.py:7: PytestUnknownMarkWarning: Unknown pytest.mark.limit_memory - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.limit_memory("100 KB")

docs/tutorials/tests/test_exercise_2.py:6
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/docs/tutorials/tests/test_exercise_2.py:6: PytestUnknownMarkWarning: Unknown pytest.mark.limit_memory - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.limit_memory("230 MB")

docs/tutorials/tests/test_exercise_3.py:11
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/docs/tutorials/tests/test_exercise_3.py:11: PytestUnknownMarkWarning: Unknown pytest.mark.limit_memory - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.limit_memory("75 MB")

tests/integration/test_processes.py:39
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/tests/integration/test_processes.py:39: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

tests/integration/test_processes.py:77
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/tests/integration/test_processes.py:77: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

tests/integration/test_processes.py:133
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/tests/integration/test_processes.py:133: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

tests/integration/test_processes.py:164
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/tests/integration/test_processes.py:164: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

tests/integration/test_processes.py: 21 warnings
  /usr/lib64/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=10359) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------- snapshot report summary ----------------------------
3 snapshots passed. 18 snapshots updated.
=========================== short test summary info ============================
FAILED tests/integration/test_native_tracking.py::test_hybrid_stack_of_python_thread_starts_with_native_frames
======= 1 failed, 625 passed, 8 skipped, 28 warnings in 89.07s (0:01:29) =======
INFO     : Command's result: FAILURE
INFO     : Command's error: Command '['python3', '-m', 'pytest', '--snapshot-update']' returned non-zero exit status 1.
error: Bad exit status from /usr/src/tmp/rpm-tmp.50899 (%check)


RPM build errors:
    Bad exit status from /usr/src/tmp/rpm-tmp.50899 (%check)
Command exited with non-zero status 1
124.98user 16.39system 2:05.03elapsed 113%CPU (0avgtext+0avgdata 1031768maxresident)k
356560inputs+815808outputs (1500major+3318441minor)pagefaults 0swaps
hsh-rebuild: rebuild of `pkg.tar' failed.
```

**I propose the following solution to the problem:**
In function test_hybrid_stack_of_python_thread_starts_with_native_frames: 
Remove check of last stack frame.

Added check for valloc events.
Added getting hybrid call stack.
Added checks for stack length and
presence of certain frames.
In valloc event selection logic,
tuple usage has been replaced with indexing.

 Changes are necessary for avoiding error:
 tests/integration/test_native_tracking.py: AssertionError

**✅ Result after applying changes:**
```success
Executing(%check): /bin/sh -e /usr/src/tmp/rpm-tmp.37815
+ umask 022
+ /bin/mkdir -p /usr/src/RPM/BUILD
+ cd /usr/src/RPM/BUILD
+ cd python3-module-memray-1.17.2
+ export 'CFLAGS=-pipe -frecord-gcc-switches -Wall -g -O2 -flto=auto'
+ CFLAGS='-pipe -frecord-gcc-switches -Wall -g -O2 -flto=auto'
+ export 'CXXFLAGS=-pipe -frecord-gcc-switches -Wall -g -O2 -flto=auto'
+ CXXFLAGS='-pipe -frecord-gcc-switches -Wall -g -O2 -flto=auto'
+ export 'FFLAGS=-pipe -frecord-gcc-switches -Wall -g -O2 -flto=auto'
+ FFLAGS='-pipe -frecord-gcc-switches -Wall -g -O2 -flto=auto'
+ export NO_INTERNET=YES
+ NO_INTERNET=YES
+ /usr/bin/python3 -m pyproject_installer run -- python3 -m pytest --snapshot-update
INFO     : Creating venv
INFO     : Installing console scripts
INFO     : Installing package: /usr/src/RPM/BUILD/python3-module-memray-1.17.2/dist/memray-1.17.2-cp312-cp312-linux_x86_64.whl
INFO     : Running command: ['/usr/src/RPM/BUILD/python3-module-memray-1.17.2/.run_venv/bin/python3', '-m', 'pyproject_installer', 'install', '/usr/src/RPM/BUILD/python3-module-memray-1.17.2/dist/memray-1.17.2-cp312-cp312-linux_x86_64.whl']
INFO     : Running command: ['python3', '-m', 'pytest', '--snapshot-update']
============================= test session starts ==============================
platform linux -- Python 3.12.10, pytest-8.3.5, pluggy-1.6.0
rootdir: /usr/src/RPM/BUILD/python3-module-memray-1.17.2
configfile: pyproject.toml
plugins: textual-snapshot-1.1.0, syrupy-4.9.1
collected 634 items

docs/tutorials/tests/test_exercise_1.py .........                        [  1%]
docs/tutorials/tests/test_exercise_2.py ..                               [  1%]
docs/tutorials/tests/test_exercise_3.py ........                         [  2%]
tests/integration/test_api.py .......                                    [  4%]
tests/integration/test_attach.py ssssssss                                [  5%]
tests/integration/test_extensions.py .........                           [  6%]
tests/integration/test_greenlet.py ...                                   [  7%]
tests/integration/test_ipython.py ..........                             [  8%]
tests/integration/test_main.py ......................................... [ 15%]
........................................                                 [ 21%]
tests/integration/test_native_tracking.py ............                   [ 23%]
tests/integration/test_processes.py ....                                 [ 24%]
tests/integration/test_socket.py ...........                             [ 25%]
tests/integration/test_threads.py ...                                    [ 26%]
tests/integration/test_tracing.py ...........................            [ 30%]
tests/integration/test_tracking.py ..................................... [ 36%]
........................................................................ [ 47%]
...........                                                              [ 49%]
tests/test_utils.py .......                                              [ 50%]
tests/unit/test_allocation_lifetime_aggregator.py ...................    [ 53%]
tests/unit/test_attach.py .                                              [ 53%]
tests/unit/test_cli.py ................................................. [ 61%]
..........................                                               [ 65%]
tests/unit/test_flamegraph_reporter.py ................................. [ 70%]
...                                                                      [ 71%]
tests/unit/test_frame_tools.py .........................                 [ 75%]
tests/unit/test_high_water_mark_aggregator.py .......................... [ 79%]
......                                                                   [ 80%]
tests/unit/test_highwatermark_command.py ..............                  [ 82%]
tests/unit/test_reader.py .....                                          [ 83%]
tests/unit/test_stats_reporter.py ..........                             [ 84%]
tests/unit/test_summary_reporter.py .....                                [ 85%]
tests/unit/test_table_reporter.py .....                                  [ 86%]
tests/unit/test_templates.py ......                                      [ 87%]
tests/unit/test_tracker.py ..                                            [ 87%]
tests/unit/test_transform_reporter.py ...........                        [ 89%]
tests/unit/test_tree_reporter.py ................................        [ 94%]
tests/unit/test_tui_reporter.py ...................................      [100%]

=============================== warnings summary ===============================
docs/tutorials/tests/test_exercise_1.py:7
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/docs/tutorials/tests/test_exercise_1.py:7: PytestUnknownMarkWarning: Unknown pytest.mark.limit_memory - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.limit_memory("100 KB")

docs/tutorials/tests/test_exercise_2.py:6
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/docs/tutorials/tests/test_exercise_2.py:6: PytestUnknownMarkWarning: Unknown pytest.mark.limit_memory - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.limit_memory("230 MB")

docs/tutorials/tests/test_exercise_3.py:11
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/docs/tutorials/tests/test_exercise_3.py:11: PytestUnknownMarkWarning: Unknown pytest.mark.limit_memory - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.limit_memory("75 MB")

tests/integration/test_processes.py:39
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/tests/integration/test_processes.py:39: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

tests/integration/test_processes.py:77
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/tests/integration/test_processes.py:77: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

tests/integration/test_processes.py:133
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/tests/integration/test_processes.py:133: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

tests/integration/test_processes.py:164
  /usr/src/RPM/BUILD/python3-module-memray-1.17.2/tests/integration/test_processes.py:164: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

tests/integration/test_processes.py: 21 warnings
  /usr/lib64/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=17156) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------- snapshot report summary ----------------------------
3 snapshots passed. 18 snapshots updated.
============ 626 passed, 8 skipped, 28 warnings in 86.57s (0:01:26) ============
INFO     : Command's result: OK
+ exit 0
```
