### PR TITLE
Remove setuptools from rpath_extension test

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -61,6 +61,9 @@ jobs:
           - os: ubuntu-latest
           - wheel_type: manylinux_aarch64
             os: ubuntu-24.04-arm
+          - wheel_type: manylinux_i686
+            os: ubuntu-latest
+            cibw_archs_linux: auto32
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -80,7 +83,7 @@ jobs:
         uses: pypa/cibuildwheel@v3.1.1
         env:
           CIBW_BUILD: "cp3{7..13}-${{ matrix.wheel_type }}"
-          CIBW_ARCHS_LINUX: auto
+          CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux || 'auto' }}
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: python -um pytest --log-cli-level=DEBUG -s -vvv {package}/tests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ greenlet; python_version < '3.14'
 pytest
 pytest-cov
 ipython
-setuptools; python_version >= '3.12'
+setuptools
 pkgconfig
 pytest-textual-snapshot
 textual >= 0.43, != 0.65.2, != 0.66

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ test_requires = [
     "pytest",
     "pytest-cov",
     "ipython",
-    "setuptools; python_version >= '3.12'",
+    "setuptools",
     "pytest-textual-snapshot",
     "textual >= 0.43, != 0.65.2, != 0.66",
     "packaging",


### PR DESCRIPTION
Some of our tests fail because setuptools in not installed
in the virtual environment and we cannot build extensions.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
