### PR TITLE
tests: Discover pytest tests only in tests/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ markers = [
     "valgrind",
 ]
 xfail_strict = true
+testpaths = ["tests"]
 
 [tool.check-manifest]
 ignore = [


### PR DESCRIPTION
A user reported that the tutorial-specific tests in docs/tutorials/tests were being discovered when `pytest` was run from the repo root, leading to failures as these tests aren't part of our test suite.