### PR TITLE
Revise handling of removed profile functions

### DIFF
--- a/news/803.bugfix.rst
+++ b/news/803.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that could have resulted in a use-after-free in a program where Memray's profile hooks were uninstalled by a call to ``PyEval_SetProfileAllThreads``.

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -566,18 +566,6 @@ cdef class TemporalAllocationGenerator:
 
 MemorySnapshot = collections.namedtuple("MemorySnapshot", "time rss heap")
 
-cdef class ProfileFunctionGuard:
-    def __dealloc__(self):
-        """When our profile function gets deregistered, drop our cached stack.
-
-        This drops our references to frames that may now be destroyed without
-        us finding out. Note that the profile function is automatically
-        deregistered when the PyThreadState is destroyed, so we can also use
-        this to perform some cleanup when a thread dies.
-        """
-        NativeTracker.forgetPythonStack()
-
-
 tracker_creation_lock = threading.Lock()
 
 

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -76,15 +76,33 @@ thread_id()
 
 // Tracker interface
 
-// This class must have a trivial destructor (and therefore all its instance
-// attributes must be POD). This is required because the libc implementation
-// can perform allocations even after the thread local variables for a thread
-// have been destroyed. If a TLS variable that is not trivially destructable is
-// accessed after that point by our allocation hooks, it will be resurrected,
-// and then it will be freed when the thread dies, but its destructor either
-// won't be called at all, or will be called on freed memory when some
-// arbitrary future thread is destroyed (if the pthread struct is reused for
-// another thread).
+// If a TLS variable has not been constructed, accessing it will cause it to be
+// constructed. That's normally great, but we need to prevent that from
+// happening unexpectedly for the TLS vector owned by this class.
+//
+// Methods of this class can be called during thread teardown. It's possible
+// that, after the TLS vector for a dying thread has already been destroyed,
+// libpthread makes a call to free() that calls into our Tracker, and if it
+// does, we must prevent it touching the vector again and re-constructing it.
+// Otherwise, it would be re-constructed immediately but its destructor would
+// be added to this thread's list of finalizers after all the finalizers for
+// the thread already ran.  If that happens, the vector will be free()d before
+// its destructor runs. Worse, its destructor will remain on the list of
+// finalizers for the current thread's pthread struct, and its destructor will
+// later be run on that already free()d memory if this thread's pthread struct
+// is ever reused. When that happens it tends to cause heap corruption, because
+// another vector is placed at the same location as the original one, and the
+// vector destructor runs twice on it (once for the newly created vector, and
+// once for the vector that had been created before the thread died and the
+// pthread struct was reused).
+//
+// To prevent that, we create the vector in one method, pushLazilyEmittedFrame.
+// All other methods access a pointer called `d_stack` that is set to the TLS
+// stack when it is created by pushLazilyEmittedFrame, and set to a null
+// pointer when the TLS stack is destroyed.
+//
+// This can result in this class being constructed during thread teardown, but
+// that doesn't cause the same problem because it has a trivial destructor.
 class PythonStackTracker
 {
   private:
@@ -309,11 +327,30 @@ void
 PythonStackTracker::pushLazilyEmittedFrame(const LazilyEmittedFrame& frame)
 {
     // Note: this function does not require the GIL.
-    if (!d_stack) {
-        d_stack = new std::vector<LazilyEmittedFrame>;
-        d_stack->reserve(1024);
+    if (d_stack) {
+        d_stack->push_back(frame);
+        return;
     }
-    d_stack->push_back(frame);
+
+    struct StackCreator
+    {
+        std::vector<LazilyEmittedFrame> stack;
+
+        StackCreator()
+        {
+            const size_t INITIAL_PYTHON_STACK_FRAMES = 1024;
+            stack.reserve(INITIAL_PYTHON_STACK_FRAMES);
+            PythonStackTracker::getUnsafe().d_stack = &stack;
+        }
+        ~StackCreator()
+        {
+            PythonStackTracker::getUnsafe().d_stack = nullptr;
+        }
+    };
+
+    MEMRAY_FAST_TLS static thread_local StackCreator t_stack_creator;
+    t_stack_creator.stack.push_back(frame);
+    assert(d_stack);  // The above call sets d_stack if it wasn't already set.
 }
 
 void
@@ -552,8 +589,6 @@ PythonStackTracker::clear()
         d_stack->pop_back();
     }
     emitPendingPushesAndPops();
-    delete d_stack;
-    d_stack = nullptr;
 }
 
 Tracker::Tracker(

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -118,14 +118,6 @@ int
 PyTraceFunction(PyObject* obj, PyFrameObject* frame, int what, PyObject* arg);
 
 /**
- * Trampoline that serves as the initial profiling function for each thread.
- *
- * This performs some one-time setup, then installs PyTraceFunction.
- */
-int
-PyTraceTrampoline(PyObject* obj, PyFrameObject* frame, int what, PyObject* arg);
-
-/**
  * Installs the trace function in the current thread.
  *
  * This function installs the trace function in the current thread using the C-API.
@@ -365,14 +357,6 @@ class Tracker
     static bool isActive();
     static void activate();
     static void deactivate();
-
-    /**
-     * Drop any references to frames on this thread's stack.
-     *
-     * This should be called when either the thread is dying or our profile
-     * function is being uninstalled from it.
-     */
-    static void forgetPythonStack();
 
     /**
      * Sets a flag to enable integration with the `greenlet` module.

--- a/src/memray/_memray/tracking_api.pxd
+++ b/src/memray/_memray/tracking_api.pxd
@@ -26,9 +26,6 @@ cdef extern from "tracking_api.h" namespace "memray::tracking_api":
         Tracker* getTracker()
 
         @staticmethod
-        void forgetPythonStack() except+
-
-        @staticmethod
         void beginTrackingGreenlets() except+
 
         @staticmethod


### PR DESCRIPTION
Memray needs to be able to report the current Python stack at the point where
a memory allocation occurs, but at that point the GIL may not be held, and so
we can't use the Python API to retrieve the current Python stack. We work
around this with a trick: we maintain a shadow stack of our own that tracks
what frames are on the Python stack, using a profile function similar to those
installed with `sys.setprofile`, and when an allocation occurs we consult our
shadow stack to see what Python frames exist.

That shadow stack holds borrowed references to Python frames, which means we
rely on the profile function for memory safety: we need it to tell us when
a Python frame is being popped off the stack, so that we don't try to reference
that frame after it has been freed. This leaves us with a problem: how do we
handle it if the user calls `sys.setprofile` themselves, and removes Memray's
profile hook?

Up until now we've handled that by having the each thread's profile function
store a reference to an object that, when GC'd, will cause us to drop the
shadow stack for that thread. This had a subtle bug: it was possible that the
GC'ing would happen in a different thread, due to a call to
`PyEval_SetProfileAllThreads` changing the profile function for many threads
from one thread, and that would lead to us clearing the wrong thread's shadow
stack. There's no easy fix for this: we can neither control what thread the
GC'ing happens on, nor can we make one thread clear another's shadow stack
without introducing expensive and complex synchronization between threads.

So, we've settled on a new, different approach: before any time when we would
reference the threads on the shadow stack, we check if our profile function is
still installed for the thread where the allocation has occurred. If it is, we
assume that the shadow stack must be valid, but otherwise we clear the shadow
stack, dropping our references to frames that may have been destroyed. This is
reasonably safe because, once our profile function has been uninstalled, the
user can't easily reinstall it; they would need to directly use the CPython
C API because of the particular type of profile function we've installed.

This requires returning to an old method for managing the lifetime of our
shadow stack by reverting 87d82ffe8c50e955d0db2c848b5efcc593b19540.
That commit was a simplification that tied the deletion of the vector
containing the shadow stack to the lifetime of the thread state via the profile
guard, but that could result in leaks since we now know that there were
situations where the profile guard would delete the wrong thread's shadow
stack.

Reverting that commit returns us to an older approach which, though more
complex, should work correctly even in the situations where the profile
function guard object did not.