### PR TITLE
Support free threading

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.1
         env:
-          CIBW_BUILD: "cp3{7..14}-${{ matrix.wheel_type }}"
+          CIBW_BUILD: "cp3{7..14}{t,}-${{ matrix.wheel_type }}"
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux || 'auto' }}
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test
@@ -130,7 +130,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.1
         env:
-          CIBW_BUILD: "cp3{8..14}-*"
+          CIBW_BUILD: "cp3{8..14}{t,}-*"
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: python -um pytest --log-cli-level=DEBUG -s -vvv {package}/tests

--- a/news/808.bugfix.rst
+++ b/news/808.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a potential use-after-free bug in ``memray attach``.

--- a/news/808.feature.rst
+++ b/news/808.feature.rst
@@ -1,0 +1,1 @@
+Free-threaded builds of Python 3.14 are now supported.

--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ COMPILER_DIRECTIVES = {
     "linetrace": False,
     "c_string_type": "unicode",
     "c_string_encoding": "utf8",
+    "freethreading_compatible": True,
 }
 EXTRA_COMPILE_ARGS = []
 EXTRA_LINK_ARGS = []
@@ -180,6 +181,7 @@ if TEST_BUILD:
         "infer_types": True,
         "c_string_type": "unicode",
         "c_string_encoding": "utf8",
+        "freethreading_compatible": True,
     }
     EXTRA_COMPILE_ARGS = []
     UNDEF_MACROS = ["NDEBUG"]

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -122,6 +122,8 @@ cpdef enum PythonAllocatorType:
     PYTHON_ALLOCATOR_PYMALLOC_DEBUG = 2
     PYTHON_ALLOCATOR_MALLOC = 3
     PYTHON_ALLOCATOR_OTHER = 4
+    PYTHON_ALLOCATOR_MIMALLOC = 5
+    PYTHON_ALLOCATOR_MIMALLOC_DEBUG = 6
 
 cpdef enum FileFormat:
     ALL_ALLOCATIONS = _FileFormat.ALL_ALLOCATIONS
@@ -761,6 +763,8 @@ cdef _create_metadata(header, peak_memory):
     allocator_id_to_name = {
         PythonAllocatorType.PYTHON_ALLOCATOR_PYMALLOC: "pymalloc",
         PythonAllocatorType.PYTHON_ALLOCATOR_PYMALLOC_DEBUG: "pymalloc debug",
+        PythonAllocatorType.PYTHON_ALLOCATOR_MIMALLOC: "mimalloc",
+        PythonAllocatorType.PYTHON_ALLOCATOR_MIMALLOC_DEBUG: "mimalloc debug",
         PythonAllocatorType.PYTHON_ALLOCATOR_MALLOC: "malloc",
         PythonAllocatorType.PYTHON_ALLOCATOR_OTHER: "unknown",
     }

--- a/src/memray/_memray/compat.h
+++ b/src/memray/_memray/compat.h
@@ -87,6 +87,39 @@ threadStateGetInterpreter(PyThreadState* tstate)
 #endif
 }
 
+#if PY_VERSION_HEX >= 0x030E0000
+
+extern "C" void
+_PyEval_StopTheWorld(PyInterpreterState*);
+extern "C" void
+_PyEval_StartTheWorld(PyInterpreterState*);
+
+inline void
+stopTheWorld(PyInterpreterState* interp)
+{
+    _PyEval_StopTheWorld(interp);
+}
+
+inline void
+startTheWorld(PyInterpreterState* interp)
+{
+    _PyEval_StartTheWorld(interp);
+}
+
+#else
+
+inline void
+stopTheWorld(PyInterpreterState*)
+{
+}
+
+inline void
+startTheWorld(PyInterpreterState*)
+{
+}
+
+#endif
+
 void
 setprofileAllThreads(Py_tracefunc func, PyObject* arg);
 

--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -917,6 +917,12 @@ RecordReader::dumpAllRecords()
         case PythonAllocatorType::PYTHONALLOCATOR_PYMALLOC_DEBUG:
             python_allocator = "pymalloc debug";
             break;
+        case PythonAllocatorType::PYTHONALLOCATOR_MIMALLOC:
+            python_allocator = "mimalloc";
+            break;
+        case PythonAllocatorType::PYTHONALLOCATOR_MIMALLOC_DEBUG:
+            python_allocator = "mimalloc debug";
+            break;
         case PythonAllocatorType::PYTHONALLOCATOR_MALLOC:
             python_allocator = "pymalloc";
             break;

--- a/src/memray/_memray/record_writer.cpp
+++ b/src/memray/_memray/record_writer.cpp
@@ -38,6 +38,12 @@ getPythonAllocator()
     if (allocator_name == "pymalloc_debug") {
         return PythonAllocatorType::PYTHONALLOCATOR_PYMALLOC_DEBUG;
     }
+    if (allocator_name == "mimalloc") {
+        return PythonAllocatorType::PYTHONALLOCATOR_MIMALLOC;
+    }
+    if (allocator_name == "mimalloc_debug") {
+        return PythonAllocatorType::PYTHONALLOCATOR_MIMALLOC_DEBUG;
+    }
     if (allocator_name == "malloc") {
         return PythonAllocatorType::PYTHONALLOCATOR_MALLOC;
     }

--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -99,6 +99,8 @@ enum PythonAllocatorType : unsigned char {
     PYTHONALLOCATOR_PYMALLOC_DEBUG = 2,
     PYTHONALLOCATOR_MALLOC = 3,
     PYTHONALLOCATOR_OTHER = 4,
+    PYTHONALLOCATOR_MIMALLOC = 5,
+    PYTHONALLOCATOR_MIMALLOC_DEBUG = 6,
 };
 
 enum FileFormat : unsigned char {

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -111,6 +111,7 @@ def track_for_duration(duration=5):
         deactivate_last_tracker()
 
     thread = threading.Timer(duration, deactivate_because_timer_elapsed)
+    thread.daemon = False
     thread.start()
     memray._attach_event_threads.append(thread)
 

--- a/src/memray/reporters/flamegraph.py
+++ b/src/memray/reporters/flamegraph.py
@@ -340,9 +340,8 @@ class FlameGraphReporter:
             "strings": all_strings.strings,
         }
 
-        if interval_list:
+        if temporal:
             data["intervals"] = interval_list
-        if no_imports_interval_list:
             data["no_imports_interval_list"] = no_imports_interval_list
 
         return cls(data, memory_records=memory_records)

--- a/src/memray/reporters/templates/base.html
+++ b/src/memray/reporters/templates/base.html
@@ -55,19 +55,21 @@
   <main class="container-fluid">
     <div class="row">
       <div class="col bg-light py-3">
-        {% if show_memory_leaks and metadata.python_allocator == "pymalloc" and not metadata.trace_python_allocators %}
+        {% if show_memory_leaks
+           and metadata.python_allocator != "malloc"
+           and metadata.python_allocator != "malloc_debug"
+           and not metadata.trace_python_allocators %}
         <div class="alert alert-warning alert-dismissible fade show" role="alert">
-          <p><strong>Report generated using "--leaks" using pymalloc allocator</strong></p>
+          <p><strong>Report generated using <code>--leaks</code> with an arena allocator</strong></p>
           <p>
-            This report for memory leaks was generated with the pymalloc
-            allocator active, but without tracking enabled for calls to the
-            pymalloc allocator. This will show confusing results because the
-            pymalloc allocator will retain memory in memory pools even after
-            the objects that requested that memory are deallocated, and Memray
-            won't be able to distinguish memory set aside for reuse from leaked
-            memory. You should rerun your application with the
-            `PYTHONMALLOC=malloc` environment variable set or pass the
-            `--trace-python-allocators` flag when profiling your application.
+            This memory leaks report was generated with the {{metadata.python_allocator}}
+            allocator active, but without tracking enabled for object
+            deallocations. This will show misleading results because the
+            allocator retains memory in memory pools even after the objects
+            that requested that memory are deallocated, and Memray won't be
+            able to distinguish memory set aside for reuse from leaked memory.
+            For a more useful memory leaks report, you should pass the
+            <code>--trace-python-allocators</code> flag when profiling your application.
             <a href="https://bloomberg.github.io/memray/python_allocators.html">
             Click here</a> for more information.
           </p>
@@ -78,7 +80,7 @@
         {% endif %}
 
         {% block content %}
-        [penseive debug] Please place your content here.
+        [memray debug] Please place your content here.
         {% endblock content %}
       </div>
     </div>

--- a/tests/integration/misbehaving_extension/misbehaving.cpp
+++ b/tests/integration/misbehaving_extension/misbehaving.cpp
@@ -91,18 +91,14 @@ static PyMethodDef methods[] = {
         {NULL, NULL, 0, NULL},
 };
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT, "misbehaving", "", -1, methods};
 
 PyMODINIT_FUNC
 PyInit_misbehaving(void)
 {
-    return PyModule_Create(&moduledef);
-}
-#else
-PyMODINIT_FUNC
-initmisbehaving(void)
-{
-    Py_InitModule("misbehaving", methods);
-}
+    PyObject *mod = PyModule_Create(&moduledef);
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
 #endif
+    return mod;
+}

--- a/tests/integration/multithreaded_extension/testext.cpp
+++ b/tests/integration/multithreaded_extension/testext.cpp
@@ -102,18 +102,14 @@ static PyMethodDef methods[] = {
         {NULL, NULL, 0, NULL},
 };
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT, "testext", "", -1, methods};
 
 PyMODINIT_FUNC
 PyInit_testext(void)
 {
-    return PyModule_Create(&moduledef);
-}
-#else
-PyMODINIT_FUNC
-inittestext(void)
-{
-    Py_InitModule("testext", methods);
-}
+    PyObject *mod = PyModule_Create(&moduledef);
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
 #endif
+    return mod;
+}

--- a/tests/integration/native_extension/native_ext.c
+++ b/tests/integration/native_extension/native_ext.c
@@ -114,18 +114,14 @@ static PyMethodDef methods[] = {
         {NULL, NULL, 0, NULL},
 };
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT, "native_ext", "", -1, methods};
 
 PyMODINIT_FUNC
 PyInit_native_ext(void)
 {
-    return PyModule_Create(&moduledef);
-}
-#else
-PyMODINIT_FUNC
-initnative_ext(void)
-{
-    Py_InitModule("native_ext", methods);
-}
+    PyObject *mod = PyModule_Create(&moduledef);
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
 #endif
+    return mod;
+}

--- a/tests/integration/rpath_extension/ext.c
+++ b/tests/integration/rpath_extension/ext.c
@@ -42,5 +42,9 @@ static struct PyModuleDef module = {
 };
 
 PyMODINIT_FUNC PyInit_ext(void) {
-    return PyModule_Create(&module);
+    PyObject *mod = PyModule_Create(&module);
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+#endif
+    return mod;
 }

--- a/tests/integration/test_attach.py
+++ b/tests/integration/test_attach.py
@@ -107,7 +107,7 @@ def generate_detach_command(method, *args):
 def run_process(cmd, wait_for_stderr=False):
     process_stderr = ""
     tracked_process = subprocess.Popen(
-        [sys.executable, "-uc", PROGRAM],
+        [sys.executable, "-Wignore", "-uc", PROGRAM],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -139,7 +139,8 @@ def run_process(cmd, wait_for_stderr=False):
         print("1", file=tracked_process.stdin, flush=True)
         if wait_for_stderr:
             process_stderr = tracked_process.stderr.readline()
-            while "WARNING" in process_stderr:
+            # Skip any lines like 'WARNING: Correcting symbol for malloc'
+            while "warning" in process_stderr.lower():
                 process_stderr = tracked_process.stderr.readline()
         tracked_process.stdin.close()
         tracked_process.wait()
@@ -165,7 +166,7 @@ def get_relevant_vallocs(records):
 @functools.lru_cache(maxsize=None)
 def debugging_method_works(method):
     proc = subprocess.Popen(
-        [sys.executable, "-uc", r'input("ready\n")'],
+        [sys.executable, "-Wignore", "-uc", r'input("ready\n")'],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         text=True,

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -122,7 +122,7 @@ def generate_sample_results(
 ):
     results_file = tmp_path / "result.bin"
     env = os.environ.copy()
-    env["PYTHONMALLOC"] = "malloc" if disable_pymalloc else "pymalloc"
+    env["PYTHONMALLOC"] = "malloc" if disable_pymalloc else "default"
     subprocess.run(
         [
             sys.executable,
@@ -906,7 +906,7 @@ class TestFlamegraphSubCommand:
         output_file = tmp_path / "memray-flamegraph-result.html"
         assert output_file.exists()
         assert warning_expected == (
-            'Report generated using "--leaks" using pymalloc allocator'
+            "Report generated using <code>--leaks</code> with an arena allocator"
             in output_file.read_text()
         )
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -7,6 +7,7 @@ import re
 import signal
 import subprocess
 import sys
+import sysconfig
 import textwrap
 import time
 from pathlib import Path
@@ -32,7 +33,6 @@ def simple_test_file(tmp_path):
         print("Allocating some memory!")
         allocator = MemoryAllocator()
         allocator.valloc(1024)
-        allocator.free()
         """
     )
     code_file.write_text(program)
@@ -873,6 +873,10 @@ class TestFlamegraphSubCommand:
         trace_python_allocators,
         disable_pymalloc,
     ):
+        if disable_pymalloc and sysconfig.get_config_var("Py_GIL_DISABLED"):
+            pytest.skip("PYTHONMALLOC=malloc is not supported in free-threading builds")
+
+        # GIVEN
         results_file, _ = generate_sample_results(
             tmp_path,
             simple_test_file,

--- a/tests/integration/test_native_tracking.py
+++ b/tests/integration/test_native_tracking.py
@@ -334,7 +334,7 @@ def test_hybrid_stack_of_allocations_inside_ceval(tmpdir):
         import functools
         import sys
 
-        import memray
+        import memray._test
         import native_ext
 
 
@@ -343,6 +343,12 @@ def test_hybrid_stack_of_allocations_inside_ceval(tmpdir):
 
 
         def bar(_):
+            allocator = memray._test.MemoryAllocator()
+            allocator.valloc(1234)
+            baz()
+
+
+        def baz():
             pass
 
 
@@ -351,7 +357,6 @@ def test_hybrid_stack_of_allocations_inside_ceval(tmpdir):
         """
     )
     env = os.environ.copy()
-    env["PYTHONMALLOC"] = "malloc"
     env["PYTHONPATH"] = str(extension_path)
 
     # WHEN
@@ -373,7 +378,7 @@ def test_hybrid_stack_of_allocations_inside_ceval(tmpdir):
         print(stack)
 
         # This function never allocates anything, so we should never see it.
-        assert "bar" not in stack
+        assert "baz" not in stack
 
         if "run_recursive" in stack:
             found_an_interesting_stack = True

--- a/tests/integration/test_processes.py
+++ b/tests/integration/test_processes.py
@@ -125,7 +125,11 @@ def test_allocations_with_multiprocessing_following_fork(tmpdir):
 
     num_expected = 5000 + 4000 + 3000 + 2000 + 1000 + 100 + 10 + 1
     assert len(child_vallocs) == num_expected
-    assert len(child_frees) == num_expected
+
+    # We may be missing up to 1 free per process in the pool due to our
+    # heuristic for recovering from truncated files (see the comment
+    # where d_readable_size is set in source.cpp)
+    assert 0 <= len(child_vallocs) - len(child_frees) <= 3
     for valloc in child_vallocs:
         assert valloc.size == 1234
 

--- a/tests/integration/test_tracking.py
+++ b/tests/integration/test_tracking.py
@@ -1595,6 +1595,8 @@ class TestHeader:
             ("malloc", "malloc"),
             ("pymalloc", "pymalloc"),
             ("pymalloc_debug", "pymalloc debug"),
+            ("mimalloc", "mimalloc"),
+            ("mimalloc_debug", "mimalloc debug"),
         ],
     )
     def test_header_allocator(self, allocator, allocator_name, tmpdir):


### PR DESCRIPTION
- Handle incomplete files from process pools in tests. Our strategy for recovering from capture files that were not gracefully closed can lead to us losing up to 1 record per pool worker process.
- Declare that our distributed extension modules support free-threading.
- Declare that our test extension modules support free-threading.
- Build our inject extension against the stable ABI even for free-threaded Python versions.
- Ignore warnings printed by the target process in our `memray attach` tests.
- Update tests to handle `PYTHONMALLOC=malloc` not being supported in free-threaded builds.
- Update Memray to recognize and handle the `mimalloc` allocator used by free-threaded builds.
- Fix the flamegraph reporter to use the correct title for temporal reports with no allocations.
- Fix a bug that could result in a use-after-free when a Memray tracker gets attached to an already running process.
- Produce binary wheels for free-threaded Python 3.14
