### PR TITLE
Improve UX for memray attach and detach commands

### DIFF
--- a/news/841.feature.rst
+++ b/news/841.feature.rst
@@ -1,0 +1,1 @@
+Improve UX for memray attach and detach commands. A new ``--wait`` flag is provided that displays a live progress bar showing time elapsed and remaining.


### PR DESCRIPTION
Users reported confusion when using memray attach with the --duration flag
because the command would exit immediately without any indication that
tracking had started successfully or was still running. This made it
difficult to know if the attach operation worked, and if interrupted,
there was no clear feedback about what would happen to the background
tracking.

Additionally, users would waste time going through the entire attach
process only to discover at the end that their output file already existed,
requiring them to restart with the --force flag.

This change addresses these issues by checking the output file existence
upfront before any injection work begins, and by showing detailed progress
through each phase of the attach and detach operations. Users can now see
exactly which step is in progress, making it easier to diagnose slow or
stuck operations.

For users who want the command to wait until tracking completes, a new
--wait flag is provided that displays a live progress bar showing time
elapsed and remaining. This makes the behavior more predictable while
maintaining backward compatibility for users who expect the command to
return immediately.

Fixes #831
Fixes #701

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
