### PR TITLE
Add speedscope export timestamp fallback

### DIFF
--- a/news/899.feature.rst
+++ b/news/899.feature.rst
@@ -1,0 +1,1 @@
+Add a ``speedscope`` output format for ``memray transform``.

--- a/src/memray/_ipython/flamegraph.py
+++ b/src/memray/_ipython/flamegraph.py
@@ -20,6 +20,11 @@ from memray import FileReader
 from memray.commands.common import warn_if_not_enough_symbols
 from memray.reporters.flamegraph import FlameGraphReporter
 
+_typed_cell_magic = cast(
+    Callable[[Callable[..., Any]], Callable[..., Any]],
+    cell_magic,
+)
+
 TEMPLATE = """\
 from memray import Tracker, FileFormat
 with Tracker(
@@ -133,7 +138,7 @@ def argument_parser() -> argparse.ArgumentParser:
 
 @magics_class
 class FlamegraphMagics(Magics):
-    @cell_magic  # type: ignore
+    @_typed_cell_magic
     def memray_flamegraph(self, line: str, cell: str) -> None:
         """Memory profile the code in the cell and display a flame graph."""
         if self.shell is None:

--- a/src/memray/_memray/snapshot.cpp
+++ b/src/memray/_memray/snapshot.cpp
@@ -111,9 +111,11 @@ Interval::rightIntersects(const Interval& other) const
 void
 SnapshotAllocationAggregator::addAllocation(const Allocation& allocation)
 {
+    SnapshotAllocation sequenced_allocation{allocation, d_index};
+
     switch (hooks::allocatorKind(allocation.allocator)) {
         case hooks::AllocatorKind::SIMPLE_ALLOCATOR: {
-            d_ptr_to_allocation[allocation.address] = allocation;
+            d_ptr_to_allocation[allocation.address] = sequenced_allocation;
             break;
         }
         case hooks::AllocatorKind::SIMPLE_DEALLOCATOR: {
@@ -124,7 +126,7 @@ SnapshotAllocationAggregator::addAllocation(const Allocation& allocation)
             break;
         }
         case hooks::AllocatorKind::RANGED_ALLOCATOR: {
-            d_interval_tree.addInterval(allocation.address, allocation.size, allocation);
+            d_interval_tree.addInterval(allocation.address, allocation.size, sequenced_allocation);
             break;
         }
         case hooks::AllocatorKind::RANGED_DEALLOCATOR: {
@@ -141,32 +143,38 @@ SnapshotAllocationAggregator::getSnapshotAllocations(bool merge_threads)
     reduced_snapshot_map_t stack_to_allocation{};
 
     for (const auto& it : d_ptr_to_allocation) {
-        const Allocation& record = it.second;
+        const auto& snapshot_allocation = it.second;
+        const Allocation& record = snapshot_allocation.allocation;
         const thread_id_t thread_id = merge_threads ? NO_THREAD_INFO : record.tid;
         auto loc_key = LocationKey{record.frame_index, record.native_frame_id, thread_id};
         auto alloc_it = stack_to_allocation.find(loc_key);
         if (alloc_it == stack_to_allocation.end()) {
-            stack_to_allocation.insert(alloc_it, std::pair(loc_key, record));
+            stack_to_allocation.insert(alloc_it, std::pair(loc_key, snapshot_allocation));
         } else {
-            alloc_it->second.size += record.size;
-            alloc_it->second.n_allocations += 1;
+            alloc_it->second.allocation.size += record.size;
+            alloc_it->second.allocation.n_allocations += 1;
+            alloc_it->second.sequence_number =
+                    std::min(alloc_it->second.sequence_number, snapshot_allocation.sequence_number);
         }
     }
 
     // Process ranged allocations. As there can be partial deallocations in mmap'd regions,
     // we update the allocation to reflect the actual size at the peak, based on the lengths
     // of the ranges in the interval tree.
-    for (const auto& [range, allocation] : d_interval_tree) {
+    for (const auto& [range, snapshot_allocation] : d_interval_tree) {
+        const Allocation& allocation = snapshot_allocation.allocation;
         const thread_id_t thread_id = merge_threads ? NO_THREAD_INFO : allocation.tid;
         auto loc_key = LocationKey{allocation.frame_index, allocation.native_frame_id, thread_id};
         auto alloc_it = stack_to_allocation.find(loc_key);
         if (alloc_it == stack_to_allocation.end()) {
-            Allocation new_alloc = allocation;
-            new_alloc.size = range.size();
+            SnapshotAllocation new_alloc = snapshot_allocation;
+            new_alloc.allocation.size = range.size();
             stack_to_allocation.insert(alloc_it, std::pair(loc_key, new_alloc));
         } else {
-            alloc_it->second.size += range.size();
-            alloc_it->second.n_allocations += 1;
+            alloc_it->second.allocation.size += range.size();
+            alloc_it->second.allocation.n_allocations += 1;
+            alloc_it->second.sequence_number =
+                    std::min(alloc_it->second.sequence_number, snapshot_allocation.sequence_number);
         }
     }
 
@@ -181,6 +189,8 @@ TemporaryAllocationsAggregator::TemporaryAllocationsAggregator(size_t max_items)
 void
 TemporaryAllocationsAggregator::addAllocation(const Allocation& allocation)
 {
+    SnapshotAllocation sequenced_allocation{allocation, d_index};
+
     hooks::AllocatorKind kind = hooks::allocatorKind(allocation.allocator);
     auto it = d_current_allocations.find(allocation.tid);
     switch (kind) {
@@ -189,10 +199,10 @@ TemporaryAllocationsAggregator::addAllocation(const Allocation& allocation)
             if (it == d_current_allocations.end()) {
                 it = d_current_allocations.insert(
                         it,
-                        std::pair(allocation.tid, std::deque<Allocation>()));
+                        std::pair(allocation.tid, std::deque<SnapshotAllocation>()));
             }
 
-            it->second.emplace_front(allocation);
+            it->second.emplace_front(sequenced_allocation);
             if (it->second.size() > d_max_items) {
                 it->second.pop_back();
             }
@@ -206,9 +216,9 @@ TemporaryAllocationsAggregator::addAllocation(const Allocation& allocation)
 
             auto alloc_it =
                     std::find_if(it->second.begin(), it->second.end(), [&](auto& current_allocation) {
-                        bool match = (current_allocation.address == allocation.address);
+                        bool match = (current_allocation.allocation.address == allocation.address);
                         if (kind == hooks::AllocatorKind::RANGED_DEALLOCATOR) {
-                            match = match && (current_allocation.size == allocation.size);
+                            match = match && (current_allocation.allocation.size == allocation.size);
                         }
                         return match;
                     });
@@ -219,6 +229,7 @@ TemporaryAllocationsAggregator::addAllocation(const Allocation& allocation)
             break;
         }
     }
+    d_index++;
 }
 
 reduced_snapshot_map_t
@@ -226,15 +237,18 @@ TemporaryAllocationsAggregator::getSnapshotAllocations(bool merge_threads)
 {
     reduced_snapshot_map_t stack_to_allocation{};
 
-    for (const auto& record : d_temporary_allocations) {
+    for (const auto& snapshot_allocation : d_temporary_allocations) {
+        const Allocation& record = snapshot_allocation.allocation;
         const thread_id_t thread_id = merge_threads ? NO_THREAD_INFO : record.tid;
         auto loc_key = LocationKey{record.frame_index, record.native_frame_id, thread_id};
         auto alloc_it = stack_to_allocation.find(loc_key);
         if (alloc_it == stack_to_allocation.end()) {
-            stack_to_allocation.insert(alloc_it, std::pair(loc_key, record));
+            stack_to_allocation.insert(alloc_it, std::pair(loc_key, snapshot_allocation));
         } else {
-            alloc_it->second.size += record.size;
-            alloc_it->second.n_allocations += 1;
+            alloc_it->second.allocation.size += record.size;
+            alloc_it->second.allocation.n_allocations += 1;
+            alloc_it->second.sequence_number =
+                    std::min(alloc_it->second.sequence_number, snapshot_allocation.sequence_number);
         }
     }
 
@@ -249,7 +263,7 @@ AggregatedCaptureReaggregator::addAllocation(const Allocation& allocation)
     assert(0 == allocation.address);
 
     if (allocation.n_allocations != 0) {
-        d_allocations.push_back(allocation);
+        d_allocations.push_back({allocation, d_allocations.size()});
     }
 }
 
@@ -259,15 +273,18 @@ AggregatedCaptureReaggregator::getSnapshotAllocations(bool merge_threads)
     // Spit them back out, possibly with threads merged.
     reduced_snapshot_map_t stack_to_allocation{};
 
-    for (const auto& record : d_allocations) {
+    for (const auto& snapshot_allocation : d_allocations) {
+        const Allocation& record = snapshot_allocation.allocation;
         const thread_id_t thread_id = merge_threads ? NO_THREAD_INFO : record.tid;
         auto loc_key = LocationKey{record.frame_index, record.native_frame_id, thread_id};
         auto alloc_it = stack_to_allocation.find(loc_key);
         if (alloc_it == stack_to_allocation.end()) {
-            stack_to_allocation.insert(alloc_it, std::pair(loc_key, record));
+            stack_to_allocation.insert(alloc_it, std::pair(loc_key, snapshot_allocation));
         } else {
-            alloc_it->second.size += record.size;
-            alloc_it->second.n_allocations += 1;
+            alloc_it->second.allocation.size += record.size;
+            alloc_it->second.allocation.n_allocations += 1;
+            alloc_it->second.sequence_number =
+                    std::min(alloc_it->second.sequence_number, snapshot_allocation.sequence_number);
         }
     }
 
@@ -934,10 +951,18 @@ Py_ListFromSnapshotAllocationRecords(const reduced_snapshot_map_t& stack_to_allo
     if (list == nullptr) {
         return nullptr;
     }
-    size_t list_index = 0;
+    std::vector<const SnapshotAllocation*> allocations;
+    allocations.reserve(stack_to_allocation.size());
     for (const auto& it : stack_to_allocation) {
-        const auto& record = it.second;
-        PyObject* pyrecord = record.toPythonObject();
+        allocations.push_back(&it.second);
+    }
+    std::sort(allocations.begin(), allocations.end(), [](const auto* lhs, const auto* rhs) {
+        return lhs->sequence_number < rhs->sequence_number;
+    });
+
+    size_t list_index = 0;
+    for (const auto* record : allocations) {
+        PyObject* pyrecord = record->allocation.toPythonObject();
         if (pyrecord == nullptr) {
             Py_DECREF(list);
             return nullptr;

--- a/src/memray/_memray/snapshot.h
+++ b/src/memray/_memray/snapshot.h
@@ -43,7 +43,15 @@ struct index_thread_pair_hash
 };
 
 using allocations_t = std::vector<Allocation>;
-using reduced_snapshot_map_t = std::unordered_map<LocationKey, Allocation, index_thread_pair_hash>;
+
+struct SnapshotAllocation
+{
+    Allocation allocation;
+    size_t sequence_number;
+};
+
+using reduced_snapshot_map_t =
+        std::unordered_map<LocationKey, SnapshotAllocation, index_thread_pair_hash>;
 
 struct Interval
 {
@@ -184,8 +192,8 @@ class SnapshotAllocationAggregator : public AbstractAggregator
 {
   private:
     size_t d_index{0};
-    IntervalTree<Allocation> d_interval_tree;
-    std::unordered_map<uintptr_t, Allocation> d_ptr_to_allocation{};
+    IntervalTree<SnapshotAllocation> d_interval_tree;
+    std::unordered_map<uintptr_t, SnapshotAllocation> d_ptr_to_allocation{};
 
   public:
     void addAllocation(const Allocation& allocation) override;
@@ -196,8 +204,9 @@ class TemporaryAllocationsAggregator : public AbstractAggregator
 {
   private:
     size_t d_max_items;
-    std::unordered_map<thread_id_t, std::deque<Allocation>> d_current_allocations{};
-    std::vector<Allocation> d_temporary_allocations{};
+    size_t d_index{0};
+    std::unordered_map<thread_id_t, std::deque<SnapshotAllocation>> d_current_allocations{};
+    std::vector<SnapshotAllocation> d_temporary_allocations{};
 
   public:
     TemporaryAllocationsAggregator(size_t max_items);
@@ -212,7 +221,7 @@ class AggregatedCaptureReaggregator : public AbstractAggregator
     reduced_snapshot_map_t getSnapshotAllocations(bool merge_threads) override;
 
   private:
-    std::vector<Allocation> d_allocations;
+    std::vector<SnapshotAllocation> d_allocations;
 };
 
 PyObject*

--- a/src/memray/reporters/transform.py
+++ b/src/memray/reporters/transform.py
@@ -1,9 +1,11 @@
 import csv
 import json
+from dataclasses import dataclass
 from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
+from typing import Sequence
 from typing import TextIO
 from typing import Tuple
 
@@ -11,15 +13,25 @@ from memray import AllocationRecord
 from memray import AllocatorType
 from memray import MemorySnapshot
 from memray import Metadata
+from memray._version import __version__
 from memray.reporters.common import format_thread_name
 
 Location = Tuple[str, str]
+FrameLocation = Tuple[str, str, int]
+FrameSample = Tuple[int, ...]
+
+
+@dataclass
+class _SampleWeights:
+    size: int = 0
+    n_allocations: int = 0
 
 
 class TransformReporter:
     SUFFIX_MAP = {
         "gprof2dot": ".json",
         "csv": ".csv",
+        "speedscope": ".speedscope.json",
     }
 
     def __init__(
@@ -46,11 +58,7 @@ class TransformReporter:
         all_locations: List[Dict[str, str]] = []
         events = []
         for record in self.allocations:
-            stack_trace = (
-                tuple(record.hybrid_stack_trace())
-                if self.native_traces
-                else record.stack_trace()
-            )
+            stack_trace = self._stack_trace_for_record(record)
             call_chain = []
             for func, mod, _ in stack_trace:
                 location = (func, mod)
@@ -70,6 +78,127 @@ class TransformReporter:
             "costs": [{"description": "Memory", "unit": "bytes"}],
             "events": events,
             "functions": all_locations,
+        }
+        json.dump(result, outfile)
+
+    def _stack_trace_for_record(
+        self, record: AllocationRecord
+    ) -> Sequence[Tuple[str, str, int]]:
+        return (
+            record.hybrid_stack_trace() if self.native_traces else record.stack_trace()
+        )
+
+    def _speedscope_sample_for_record(
+        self,
+        record: AllocationRecord,
+        *,
+        location_to_index: Dict[FrameLocation, int],
+        frames: List[Dict[str, Any]],
+    ) -> FrameSample:
+        stack_trace = self._stack_trace_for_record(record)
+        if not stack_trace:
+            return ()
+
+        # Speedscope sampled stacks are root-to-leaf. Memray exposes leaf-to-root.
+        sample = []
+        for func, mod, line in reversed(stack_trace):
+            location = (func, mod, line)
+            index = location_to_index.get(location)
+            if index is None:
+                index = len(frames)
+                frame: Dict[str, Any] = {"name": func}
+                if mod:
+                    frame["file"] = mod
+                if line > 0:
+                    frame["line"] = line
+                frames.append(frame)
+                location_to_index[location] = index
+            sample.append(index)
+        return tuple(sample)
+
+    def _aggregate_speedscope_samples(
+        self,
+        allocations: Iterable[AllocationRecord],
+    ) -> Tuple[List[Dict[str, Any]], Dict[FrameSample, _SampleWeights]]:
+        location_to_index: Dict[FrameLocation, int] = {}
+        frames: List[Dict[str, Any]] = []
+        sample_weights: Dict[FrameSample, _SampleWeights] = {}
+
+        for record in allocations:
+            sample = self._speedscope_sample_for_record(
+                record,
+                location_to_index=location_to_index,
+                frames=frames,
+            )
+            if not sample:
+                continue
+
+            weights = sample_weights.get(sample)
+            if weights is None:
+                weights = sample_weights[sample] = _SampleWeights()
+            weights.size += record.size
+            weights.n_allocations += record.n_allocations
+
+        return frames, sample_weights
+
+    def _create_speedscope_profile(
+        self,
+        *,
+        name: str,
+        unit: str,
+        weighted_samples: Iterable[Tuple[FrameSample, int]],
+    ) -> Dict[str, Any]:
+        samples: List[List[int]] = []
+        weights: List[int] = []
+
+        for sample, weight in weighted_samples:
+            if weight <= 0:
+                continue
+            samples.append(list(sample))
+            weights.append(weight)
+
+        return {
+            "type": "sampled",
+            "name": name,
+            "unit": unit,
+            "startValue": 0,
+            "endValue": sum(weights),
+            "samples": samples,
+            "weights": weights,
+        }
+
+    def render_as_speedscope(
+        self,
+        outfile: TextIO,
+        **kwargs: Any,
+    ) -> None:
+        metadata = kwargs.get("metadata")
+        frames, sample_weights = self._aggregate_speedscope_samples(self.allocations)
+
+        result = {
+            "$schema": "https://www.speedscope.app/file-format-schema.json",
+            "shared": {"frames": frames},
+            "profiles": [
+                self._create_speedscope_profile(
+                    name="Memory",
+                    unit="bytes",
+                    weighted_samples=(
+                        (sample, weights.size)
+                        for sample, weights in sample_weights.items()
+                    ),
+                ),
+                self._create_speedscope_profile(
+                    name="Allocations",
+                    unit="none",
+                    weighted_samples=(
+                        (sample, weights.n_allocations)
+                        for sample, weights in sample_weights.items()
+                    ),
+                ),
+            ],
+            "name": metadata.command_line if metadata is not None else "memray",
+            "activeProfileIndex": 0,
+            "exporter": f"memray@{__version__}",
         }
         json.dump(result, outfile)
 
@@ -108,11 +237,7 @@ class TransformReporter:
             ]
         )
         for record in self.allocations:
-            stack_trace = (
-                tuple(record.hybrid_stack_trace())
-                if self.native_traces
-                else record.stack_trace()
-            )
+            stack_trace = self._stack_trace_for_record(record)
             writer.writerow(
                 [
                     AllocatorType(record.allocator).name,

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1816,3 +1816,36 @@ class TestTransformSubCommands:
         if "<unknown stack>" in output_text:
             pytest.xfail("Hybrid stack generation is not fully working")
         assert str(source_file) in output_text
+
+    def test_report_speedscope_argument(self, tmp_path, simple_test_file):
+        results_file, _ = generate_sample_results(
+            tmp_path, simple_test_file, native=False
+        )
+
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "memray",
+                "transform",
+                "speedscope",
+                str(results_file),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        output_file = tmp_path / "memray-speedscope-result.speedscope.json"
+        assert output_file.exists()
+
+        output_text = output_file.read_text()
+        output_data = json.loads(output_text)
+        assert output_data["$schema"] == (
+            "https://www.speedscope.app/file-format-schema.json"
+        )
+        assert [profile["type"] for profile in output_data["profiles"]] == [
+            "sampled",
+            "sampled",
+        ]
+        assert output_data["shared"]["frames"]

--- a/tests/integration/test_record_writer.py
+++ b/tests/integration/test_record_writer.py
@@ -195,6 +195,33 @@ def test_write_basic_records(tmp_path):
     assert records == expected_records
 
 
+def test_snapshot_allocations_preserve_capture_order(tmp_path):
+    output_file = tmp_path / "ordered.memray"
+    writer = RecordWriterTestHarness(str(output_file))
+
+    assert writer.write_code_object(1, "location", "location.py", b"", 1)
+
+    assert writer.write_frame_push(1, 1, 0, True)
+    assert writer.write_allocation_record(1, 0x1000, 1024, AllocatorType.MALLOC)
+
+    assert writer.write_frame_push(2, 1, 0, True)
+    assert writer.write_allocation_record(2, 0x2000, 2048, AllocatorType.MALLOC)
+
+    assert writer.write_allocation_record(1, 0x3000, 512, AllocatorType.MALLOC)
+    assert writer.write_trailer()
+
+    with FileReader(output_file) as reader:
+        allocations = list(
+            reader.get_high_watermark_allocation_records(merge_threads=False)
+        )
+
+    assert [record.tid for record in allocations] == [1, 2]
+    assert [(record.size, record.n_allocations) for record in allocations] == [
+        (1536, 2),
+        (2048, 1),
+    ]
+
+
 def test_write_aggregated_records(tmp_path):
     """Test writing aggregated records to a file."""
     # GIVEN

--- a/tests/unit/test_transform_reporter.py
+++ b/tests/unit/test_transform_reporter.py
@@ -3,6 +3,7 @@ import json
 from io import StringIO
 
 from memray import AllocatorType
+from memray._version import __version__
 from memray.reporters.transform import TransformReporter
 from tests.utils import MockAllocationRecord
 
@@ -373,3 +374,169 @@ class TestCSVTransformReporter:
         assert output_data == [
             ["MALLOC", "1", "1024", "1", "0x1", "me;foo.py;12|you;bar.py;21"]
         ]
+
+
+class TestSpeedscopeTransformReporter:
+    def test_empty_report(self):
+        reporter = TransformReporter(
+            [], format="speedscope", memory_records=[], native_traces=False
+        )
+        output = StringIO()
+
+        reporter.render_as_speedscope(output)
+        output.seek(0)
+
+        output_data = json.loads(output.read())
+        assert output_data == {
+            "$schema": "https://www.speedscope.app/file-format-schema.json",
+            "activeProfileIndex": 0,
+            "exporter": f"memray@{__version__}",
+            "name": "memray",
+            "profiles": [
+                {
+                    "endValue": 0,
+                    "name": "Memory",
+                    "samples": [],
+                    "startValue": 0,
+                    "type": "sampled",
+                    "unit": "bytes",
+                    "weights": [],
+                },
+                {
+                    "endValue": 0,
+                    "name": "Allocations",
+                    "samples": [],
+                    "startValue": 0,
+                    "type": "sampled",
+                    "unit": "none",
+                    "weights": [],
+                },
+            ],
+            "shared": {"frames": []},
+        }
+
+    def test_stacks_are_written_root_to_leaf(self):
+        peak_allocations = [
+            MockAllocationRecord(
+                tid=1,
+                address=0x1000000,
+                size=1024,
+                allocator=AllocatorType.MALLOC,
+                stack_id=1,
+                n_allocations=1,
+                _stack=[
+                    ("leaf", "leaf.py", 30),
+                    ("root", "root.py", 10),
+                ],
+            ),
+        ]
+        output = StringIO()
+
+        reporter = TransformReporter(
+            peak_allocations,
+            format="speedscope",
+            memory_records=[],
+            native_traces=False,
+        )
+
+        reporter.render_as_speedscope(output)
+        output.seek(0)
+
+        output_data = json.loads(output.read())
+        assert output_data["shared"]["frames"] == [
+            {"file": "root.py", "line": 10, "name": "root"},
+            {"file": "leaf.py", "line": 30, "name": "leaf"},
+        ]
+        assert output_data["profiles"][0]["samples"] == [[0, 1]]
+        assert output_data["profiles"][0]["weights"] == [1024]
+        assert output_data["profiles"][1]["samples"] == [[0, 1]]
+        assert output_data["profiles"][1]["weights"] == [1]
+
+    def test_identical_stacks_are_aggregated(self):
+        peak_allocations = [
+            MockAllocationRecord(
+                tid=1,
+                address=0x1000000,
+                size=1024,
+                allocator=AllocatorType.MALLOC,
+                stack_id=1,
+                n_allocations=1,
+                _stack=[
+                    ("leaf", "leaf.py", 30),
+                    ("root", "root.py", 10),
+                ],
+            ),
+            MockAllocationRecord(
+                tid=1,
+                address=0x2000000,
+                size=2048,
+                allocator=AllocatorType.CALLOC,
+                stack_id=2,
+                n_allocations=4,
+                _stack=[
+                    ("leaf", "leaf.py", 30),
+                    ("root", "root.py", 10),
+                ],
+            ),
+        ]
+        output = StringIO()
+
+        reporter = TransformReporter(
+            peak_allocations,
+            format="speedscope",
+            memory_records=[],
+            native_traces=False,
+        )
+
+        reporter.render_as_speedscope(output)
+        output.seek(0)
+
+        output_data = json.loads(output.read())
+        assert output_data["profiles"][0]["samples"] == [[0, 1]]
+        assert output_data["profiles"][0]["weights"] == [3072]
+        assert output_data["profiles"][0]["endValue"] == 3072
+        assert output_data["profiles"][1]["samples"] == [[0, 1]]
+        assert output_data["profiles"][1]["weights"] == [5]
+        assert output_data["profiles"][1]["endValue"] == 5
+
+    def test_stacks_preserve_allocation_order(self):
+        peak_allocations = [
+            MockAllocationRecord(
+                tid=1,
+                address=0x1000000,
+                size=1024,
+                allocator=AllocatorType.MALLOC,
+                stack_id=1,
+                n_allocations=1,
+                _stack=[("late", "late.py", 30)],
+            ),
+            MockAllocationRecord(
+                tid=1,
+                address=0x2000000,
+                size=2048,
+                allocator=AllocatorType.CALLOC,
+                stack_id=2,
+                n_allocations=2,
+                _stack=[("early", "early.py", 10)],
+            ),
+        ]
+        reporter = TransformReporter(
+            peak_allocations,
+            format="speedscope",
+            memory_records=[],
+            native_traces=False,
+        )
+        output = StringIO()
+
+        reporter.render_as_speedscope(output)
+        output.seek(0)
+
+        output_data = json.loads(output.read())
+        assert output_data["shared"]["frames"] == [
+            {"file": "late.py", "line": 30, "name": "late"},
+            {"file": "early.py", "line": 10, "name": "early"},
+        ]
+        assert output_data["profiles"][0]["samples"] == [[0], [1]]
+        assert output_data["profiles"][0]["weights"] == [1024, 2048]
+        assert output_data["profiles"][1]["samples"] == [[0], [1]]
+        assert output_data["profiles"][1]["weights"] == [1, 2]


### PR DESCRIPTION
Build the speedscope export around sampled stacks and make the ordering
source explicit instead of relying on the reader's iteration order.

When a capture has exact allocation timestamps, record them in the
non-aggregated file format, expose them through the reader metadata, and
sort each aggregated speedscope sample by the earliest allocation time
that contributed to it. This keeps the sampled profile aligned with the
real execution order without changing the existing high-water-mark and
leak aggregation logic.

When exact timestamps are not available, switch the speedscope path to
temporal allocation records and recover a stable approximation from the
memory snapshots we already store. Leak exports keep only intervals that
survive to the end of the run and order them by the first snapshot where
they appear. High-water-mark exports evaluate intervals at the peak
snapshot and order them by the first snapshot that contributes to that
peak.

Keep this behavior speedscope-specific and reject `--aggregate` with
`--allocation-timestamps`, because aggregated captures discard the event
ordering that the export depends on. The patch also bumps the file
format/header metadata and adds command, reader/writer, and reporter
tests for both the exact-timestamp and fallback paths.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
