### PR TITLE
ci: Modernize PyPI publishing config

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -179,4 +179,4 @@ jobs:
           ls -R dist
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          skip_existing: true
+          skip-existing: true


### PR DESCRIPTION
Our last PyPI publish printed out:

    Warning: Input 'skip_existing' has been deprecated with message:
    The inputs have been normalized to use kebab-case.
    Use `skip-existing` instead.

Adjust our config accordingly.
