### PR TITLE
Fix flamegraph rendering in Jupyter

### DIFF
--- a/docs/jupyter_magic.rst
+++ b/docs/jupyter_magic.rst
@@ -19,6 +19,11 @@ followed by some code whose memory usage you want to profile. Memray will run
 that cell's code, tracking its memory allocations, and then display a flame
 graph directly in Jupyter for you to analyze.
 
+.. note::
+
+    The flame graph is written to the current working directory, so Jupyter
+    won't be able to find it if you've changed directories.
+
 It's also possible to provide arguments on the ``%%memray_flamegraph`` line.
 For instance, ``%%memray_flamegraph --trace-python-allocators --leaks`` would
 let you look for memory not freed by the code in the cell::

--- a/news/896.bugfix.rst
+++ b/news/896.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the ``%%memray_flamegraph`` :ref:`Jupyter magic <Jupyter integration>` to correctly embed a flame graph for Python 3.12 and higher. Previously it was giving a 404 error due to ``tempfile.mkdtemp`` changing to return absolute paths.

--- a/src/memray/_ipython/flamegraph.py
+++ b/src/memray/_ipython/flamegraph.py
@@ -159,6 +159,8 @@ class FlamegraphMagics(Magics):
         results_dir.mkdir(exist_ok=True)
 
         tempdir = Path(tempfile.mkdtemp(dir=results_dir))
+        if tempdir.is_absolute():
+            tempdir = tempdir.relative_to(Path.cwd())
         dump_file = Path(tempdir) / "memray.dump"
         code = TEMPLATE.format(
             dump_file=dump_file,
@@ -229,7 +231,7 @@ class FlamegraphMagics(Magics):
                 )
 
         assert reporter is not None
-        flamegraph_path = Path(tempdir) / "flamegraph.html"
+        flamegraph_path = tempdir / "flamegraph.html"
         with open(flamegraph_path, "w") as f:
             reporter.render(
                 outfile=f,


### PR DESCRIPTION
The `%%memray_flamegraph` Jupyter magic stopped working for Python 3.12 and higher because Jupyter refuses to serve files by absolute path (even if they resolve to be within its root directory), and Python 3.12 changed `tempfile.mkdtemp` to always return an absolute path.

Fix this by swapping back to a relative path if we got an absolute one.

Closes #896