### PR TITLE
Fix greenlet integration with greenlet 3.4.0

### DIFF
--- a/news/908.bugfix.rst
+++ b/news/908.bugfix.rst
@@ -1,0 +1,2 @@
+Fix integration with the ``greenlet`` package when greenlet 3.4.0 is installed
+and when tracing is started before the greenlet module is imported.

--- a/news/908.removal.rst
+++ b/news/908.removal.rst
@@ -1,0 +1,1 @@
+Drop integration with 0.x versions of the ``greenlet`` module (which are from 2020 or earlier).

--- a/src/memray/_memray/hooks.cpp
+++ b/src/memray/_memray/hooks.cpp
@@ -380,9 +380,7 @@ dlopen(const char* filename, int flag) noexcept
     }
     if (ret) {
         tracking_api::Tracker::invalidate_module_cache();
-        if (filename
-            && (nullptr != strstr(filename, "/_greenlet.") || nullptr != strstr(filename, "/greenlet.")))
-        {
+        if (filename && nullptr != strstr(filename, "/_greenlet.")) {
             tracking_api::Tracker::beginTrackingGreenlets();
         }
     }

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -537,11 +537,7 @@ PythonStackTracker::installGreenletTraceFunctionIfNeeded()
     // `greenlet._greenlet` has already been imported.
     PyObject* _greenlet = PyDict_GetItemString(modules, "greenlet._greenlet");
     if (!_greenlet) {
-        // Before greenlet 1.0, the extension module was just named "greenlet"
-        _greenlet = PyDict_GetItemString(modules, "greenlet");
-        if (!_greenlet) {
-            return;
-        }
+        return;
     }
 
     // Borrowed reference


### PR DESCRIPTION
Our attempts to handle ancient versions of greenlet are causing us to try to import the `settrace` function from `greenlet` rather than from `greenlet._greenlet`, which is failing because we're trying to import it before greenlet's own `__init__.py` has imported it.

Drop support for greenlet versions older than 1.0, which is more than 5 years out of date at this point, to fix this issue.