### PR TITLE
Clarify that `attach --duration` keeps tracking in the background

### DIFF
--- a/docs/attach.rst
+++ b/docs/attach.rst
@@ -35,7 +35,13 @@ also provide most of the options that ``memray run`` accepts. See :ref:`the
 CLI reference <memray attach CLI reference>` for details.
 
 If you use the ``-o`` option, the process will continue recording allocations
-to the capture file even after ``memray attach`` has returned. Otherwise,
+to the capture file even after ``memray attach`` has returned. This is also
+true when ``--duration`` is supplied: ``memray attach`` exits as soon as the
+tracker has been injected, and the target process records allocations for the
+requested duration in the background. Use ``memray detach`` to stop tracking
+before the duration elapses.
+
+If you don't use the ``-o`` option, then
 allocations are tracked only for as long as the :doc:`live mode TUI <live>`
 continues running. Once you quit the TUI, the attached process will stop
 tracking allocations. If you later reattach to the same process, it will start

--- a/news/831.feature.rst
+++ b/news/831.feature.rst
@@ -1,0 +1,1 @@
+When ``memray attach -o`` is used with ``--duration``, print a message clarifying that tracking continues in the target process after the command exits, and how to stop it early with ``memray detach``.

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -547,6 +547,11 @@ class AttachCommand(_DebuggerCommand):
                     f"Failed to start tracking in remote process: {err}",
                     exit_code=1,
                 )
+            if duration:
+                print(
+                    f"memray: tracking PID {args.pid} for {duration}s in the"
+                    f" background. Run `memray detach {args.pid}` to stop early."
+                )
             return
 
         # If an error prevents the tracked process from binding a server to


### PR DESCRIPTION
## Summary
  - `memray attach -o ... --duration N` exits as soon as the tracker is injected; the target process keeps recording for
   N seconds. Documented, but has surprised multiple users (#701, #831).
  - Print a notice on exit pointing at `memray detach` for early stop.
  - Call out the background behavior explicitly in `docs/attach.rst`.

  ## Test plan
  - [ ] `memray attach -o out.bin --duration 10 <pid>` prints the new notice and exits.
  - [ ] `memray detach <pid>` still stops tracking before duration elapses.
  - [ ] Existing `tests/unit/test_attach.py` passes.

  Closes #831