### PR TITLE
Add error logging
  around FileSink and header serialization failures

### DIFF
--- a/news/747.feature.rst
+++ b/news/747.feature.rst
@@ -1,0 +1,1 @@
+Log the underlying error (and a hint to try a different output location) when ``mmap`` or ``posix_fallocate`` fails inside ``FileSink``, and when the capture file header can't be serialized. Previously these failures surfaced only as a generic ``Failed to write output header`` ``RuntimeError`` with no information about the cause.

--- a/src/memray/_memray/sink.cpp
+++ b/src/memray/_memray/sink.cpp
@@ -3,6 +3,7 @@
 
 #include <cerrno>
 #include <cstdio>
+#include <sstream>
 
 #include <arpa/inet.h>
 #include <fcntl.h>
@@ -13,6 +14,7 @@
 #include <utility>
 
 #include "exceptions.h"
+#include "logging.h"
 #include "lz4_stream.h"
 #include "sink.h"
 
@@ -134,6 +136,14 @@ FileSink::seek(off_t offset, int whence)
     //       though not to write beyond the end.
     d_buffer = static_cast<char*>(mmap(d_buffer, BUFFER_SIZE, PROT_WRITE, MAP_SHARED, d_fd, offset));
     if (d_buffer == MAP_FAILED) {
+        std::ostringstream msg;
+        msg << "Failed to mmap " << BUFFER_SIZE << " bytes of output file " << d_filename
+            << " at offset " << offset << ": " << strerror(errno);
+        if (offset == 0) {
+            msg << ". The destination filesystem may not support shared writable mmap;"
+                   " try writing the capture file to a different location (e.g. /tmp).";
+        }
+        LOG(ERROR) << msg.str();
         d_buffer = nullptr;
         return false;
     }
@@ -163,6 +173,19 @@ FileSink::grow(size_t needed)
     } while (rc == EINTR);
 
     if (rc != 0) {
+        std::ostringstream msg;
+        msg << "Failed to grow output file " << d_filename << " by " << delta
+            << " bytes: " << strerror(rc);
+        if (d_fileSize == 0) {
+#ifdef __APPLE__
+            msg << ". The destination filesystem may not support F_PREALLOCATE;"
+                   " try writing the capture file to a different location (e.g. /tmp).";
+#else
+            msg << ". The destination filesystem may not support posix_fallocate;"
+                   " try writing the capture file to a different location (e.g. /tmp).";
+#endif
+        }
+        LOG(ERROR) << msg.str();
         errno = rc;
         return false;
     }


### PR DESCRIPTION
Refs #747, #731

  ## Summary
  - `FileSink::seek` and `FileSink::grow` now log the failing syscall (`mmap`, `munmap`, `lseek`, `posix_fallocate`),
  the errno string, and a hint to try writing the capture file to a different location such as `/tmp`.
  - `RecordWriter::writeHeaderCommon` now logs when header serialization fails, pointing readers at the preceding
  sink-level log entries for the underlying cause.
  - Previously, filesystems that do not support shared writable `mmap` or `posix_fallocate` (issue #731) surfaced only
  as a generic `RuntimeError: Failed to write output header` with no diagnostic information.

  ## Test plan
  - [x] Extension rebuilds cleanly.
  - [x] `tests/unit/test_tracker.py` passes against the rebuilt extension.
  - [ ] CI