### PR TITLE
Update Dockerfile from Debian bookworm to trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Description
Updates Dockerfile to use Debian 13 "trixie" (current stable) instead of Debian 12 "bookworm", which is transitioning to Long-Term Support.

## Changes
- Updated `FROM debian:bookworm` to `FROM debian:trixie` in Dockerfile
- [List any other files you changed]

## Testing
- ✅ Built Docker image successfully without errors
- ✅ Container starts and runs correctly
- ✅ Verified Debian version is trixie in running container
- ✅ [Any project-specific tests you ran]

## Related Issues
Closes #[issue-number]