### PR TITLE
Support Python 3.15

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -181,6 +181,10 @@ jobs:
           rmdir dist/{sdist,*-wheels}
           rm -r dist/tests
           ls -R dist
+      - name: Avoid publishing Python 3.15 wheels
+        run: |
+          rm -f dist/*cp315*
+          ls -R dist
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           skip-existing: true

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -84,9 +84,9 @@ jobs:
         run: |
           echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
       - name: Build wheels
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        uses: pypa/cibuildwheel@54327ab9d35de03b359ac25c97de9417d94639c0 # v4.0.0rc1
         env:
-          CIBW_BUILD: "cp3{7..14}{t,}-${{ matrix.wheel_type }}"
+          CIBW_BUILD: "cp3{7..15}{t,}-${{ matrix.wheel_type }}"
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux || 'auto' }}
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test
@@ -133,9 +133,9 @@ jobs:
         run: |
           echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV
       - name: Build wheels
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        uses: pypa/cibuildwheel@54327ab9d35de03b359ac25c97de9417d94639c0 # v4.0.0rc1
         env:
-          CIBW_BUILD: "cp3{8..14}{t,}-*"
+          CIBW_BUILD: "cp3{8..15}{t,}-*"
           CIBW_ARCHS: "${{matrix.arch}}"
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_EXTRAS: test

--- a/news/920.feature.rst
+++ b/news/920.feature.rst
@@ -1,0 +1,1 @@
+Python 3.15 is now supported. The wheels are not yet published because the ABI is not yet frozen.

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -129,11 +129,11 @@ cpdef enum AllocatorType:
     MMAP = 14
     MUNMAP = 15
 
-# Note: enumerator values are negative because they must be unique
+# Note: enumerator values are greater than 100 because they must be unique
 #       from the enumerator values of the AllocatorType enum above
 cpdef enum ObjectTrackingEvent:
-    OBJECT_CREATED = -1
-    OBJECT_DESTROYED = -2
+    OBJECT_CREATED = 101
+    OBJECT_DESTROYED = 102
 
 cpdef enum PythonAllocatorType:
     PYTHON_ALLOCATOR_PYMALLOC = 1
@@ -251,7 +251,7 @@ cdef hybrid_stack_trace(
         # Check for Python frame boundaries: traditional _PyEval_EvalFrameDefault
         # or Python 3.14 tail call interpreter LLVM-generated functions
         is_python_frame_boundary = "_PyEval_EvalFrameDefault" in symbol or (
-            symbol.startswith("_TAIL_CALL_") and ".llvm." in symbol
+            symbol.startswith("_TAIL_CALL_")
         )
         if pidx >= 0 and is_python_frame_boundary:
             while True:

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -112,7 +112,7 @@ def set_log_level(int level):
     setLogThreshold(level)
 
 
-cpdef enum AllocatorType:
+cpdef enum class AllocatorType:
     PYMALLOC_FREE = 1
     PYMALLOC_MALLOC = 2
     PYMALLOC_CALLOC = 3
@@ -129,13 +129,13 @@ cpdef enum AllocatorType:
     MMAP = 14
     MUNMAP = 15
 
-# Note: enumerator values are greater than 100 because they must be unique
+# Note: enumerator values are negative because they must be unique
 #       from the enumerator values of the AllocatorType enum above
-cpdef enum ObjectTrackingEvent:
-    OBJECT_CREATED = 101
-    OBJECT_DESTROYED = 102
+cpdef enum class ObjectTrackingEvent:
+    OBJECT_CREATED = -1
+    OBJECT_DESTROYED = -2
 
-cpdef enum PythonAllocatorType:
+cpdef enum class PythonAllocatorType:
     PYTHON_ALLOCATOR_PYMALLOC = 1
     PYTHON_ALLOCATOR_PYMALLOC_DEBUG = 2
     PYTHON_ALLOCATOR_MALLOC = 3
@@ -143,7 +143,7 @@ cpdef enum PythonAllocatorType:
     PYTHON_ALLOCATOR_MIMALLOC = 5
     PYTHON_ALLOCATOR_MIMALLOC_DEBUG = 6
 
-cpdef enum FileFormat:
+cpdef enum class FileFormat:
     ALL_ALLOCATIONS = _FileFormat.ALL_ALLOCATIONS
     AGGREGATED_ALLOCATIONS = _FileFormat.AGGREGATED_ALLOCATIONS
 
@@ -1662,7 +1662,7 @@ cdef class SocketReader:
             (<AllocationRecord> alloc)._reader = self._reader
             yield alloc
 
-cpdef enum SymbolicSupport:
+cpdef enum class SymbolicSupport:
     NONE = 1
     FUNCTION_NAME_ONLY = 2
     TOTAL = 3

--- a/src/memray/_memray_test_utils.pyx
+++ b/src/memray/_memray_test_utils.pyx
@@ -125,7 +125,7 @@ cdef class MemoryAllocator:
             pthread_join(thread, NULL)
 
 
-cpdef enum PymallocDomain:
+cpdef enum class PymallocDomain:
     PYMALLOC_RAW = 1
     PYMALLOC_MEM = 2
     PYMALLOC_OBJECT = 3
@@ -142,22 +142,22 @@ cdef class PymallocMemoryAllocator:
     def free(self):
         if self.ptr == NULL:
             raise RuntimeError("Pointer cannot be NULL")
-        if self.domain == PYMALLOC_RAW:
+        if self.domain == PymallocDomain.PYMALLOC_RAW:
             PyMem_RawFree(self.ptr)
-        elif self.domain == PYMALLOC_MEM:
+        elif self.domain == PymallocDomain.PYMALLOC_MEM:
             PyMem_Free(self.ptr)
-        elif self.domain == PYMALLOC_OBJECT:
+        elif self.domain == PymallocDomain.PYMALLOC_OBJECT:
             PyObject_Free(self.ptr)
         else:
             raise RuntimeError("Invlid pymalloc domain")
         self.ptr = NULL
 
     def malloc(self, size_t size):
-        if self.domain == PYMALLOC_RAW:
+        if self.domain == PymallocDomain.PYMALLOC_RAW:
             self.ptr = PyMem_RawMalloc(size)
-        elif self.domain == PYMALLOC_MEM:
+        elif self.domain == PymallocDomain.PYMALLOC_MEM:
             self.ptr = PyMem_Malloc(size)
-        elif self.domain == PYMALLOC_OBJECT:
+        elif self.domain == PymallocDomain.PYMALLOC_OBJECT:
             self.ptr = PyObject_Malloc(size)
         else:
             raise RuntimeError("Invlid pymalloc domain")
@@ -165,11 +165,11 @@ cdef class PymallocMemoryAllocator:
         return self.ptr != NULL
 
     def calloc(self, size_t size):
-        if self.domain == PYMALLOC_RAW:
+        if self.domain == PymallocDomain.PYMALLOC_RAW:
             self.ptr = PyMem_RawCalloc(1, size)
-        elif self.domain == PYMALLOC_MEM:
+        elif self.domain == PymallocDomain.PYMALLOC_MEM:
             self.ptr = PyMem_Calloc(1, size)
-        elif self.domain == PYMALLOC_OBJECT:
+        elif self.domain == PymallocDomain.PYMALLOC_OBJECT:
             self.ptr = PyObject_Calloc(1, size)
         else:
             raise RuntimeError("Invlid pymalloc domain")
@@ -177,11 +177,11 @@ cdef class PymallocMemoryAllocator:
         return self.ptr != NULL
 
     def realloc(self, size_t size):
-        if self.domain == PYMALLOC_RAW:
+        if self.domain == PymallocDomain.PYMALLOC_RAW:
             self.ptr = PyMem_RawRealloc(self.ptr, size)
-        elif self.domain == PYMALLOC_MEM:
+        elif self.domain == PymallocDomain.PYMALLOC_MEM:
             self.ptr = PyMem_Realloc(self.ptr, size)
-        elif self.domain == PYMALLOC_OBJECT:
+        elif self.domain == PymallocDomain.PYMALLOC_OBJECT:
             self.ptr = PyObject_Realloc(self.ptr, size)
         else:
             raise RuntimeError("Invlid pymalloc domain")


### PR DESCRIPTION
Closes #920 

**Describe your changes**
We switch to `enum class` instead of `enum` because cython uses `IntFlag` for `enum` and that messes up negative values in 3.15.
We also remove the `".llvm." in symbol` check  in `hybrid_stack_trace` as that no longer appears to be the case.
We add 3.15 in CI and we have to use the `cibuildwheel` release candidate to get 3.15.

**Testing performed**
Tested locally with 3.14 and 3.15 and the tests pass. We'll see what the CI says
