### PR TITLE
Add per-module allocation statistics to memray stats

### DIFF
--- a/news/765.feature.rst
+++ b/news/765.feature.rst
@@ -1,0 +1,1 @@
+Add per-module allocation statistics to ``memray stats``, showing the top allocating non-stdlib modules by size and by number of allocations.

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -1493,6 +1493,8 @@ def compute_statistics(
     report_progress=False,
     num_largest=5,
 ):
+    from memray.reporters.module_tools import ModuleResolver
+
     cdef shared_ptr[RecordReader] reader_sp = make_shared[RecordReader](
         unique_ptr[FileSource](new FileSource(file_name))
     )
@@ -1512,15 +1514,28 @@ def compute_statistics(
         total=total,
         report_progress=report_progress,
     )
+
+    # Aggregate allocation counts and bytes per distinct call stack using a C++
+    # integer map keyed by frame_index. Many allocations share the same stack,
+    # so this avoids duplicating work.
+    cdef unordered_map[size_t, pair[size_t, size_t]] stats_by_stack
+    cdef pair[size_t, size_t]* stack_entry
+
     with progress_indicator:
         while True:
             PyErr_CheckSignals()
             ret = reader.nextRecord()
             if ret == RecordResult.RecordResultAllocationRecord:
+                allocation = reader.getLatestAllocation()
                 aggregator.addAllocation(
-                    reader.getLatestAllocation(),
-                    reader.getLatestPythonLocationId(reader.getLatestAllocation()),
+                    allocation,
+                    reader.getLatestPythonLocationId(allocation),
                 )
+
+                if not isDeallocator(allocation.allocator):
+                    stack_entry = &stats_by_stack[allocation.frame_index]
+                    stack_entry.first += 1
+                    stack_entry.second += allocation.size
                 progress_indicator.update(1)
             elif ret == RecordResult.RecordResultMemoryRecord:
                 pass
@@ -1554,6 +1569,34 @@ def compute_statistics(
         for count_and_loc in aggregator.topLocationsByCount(num_largest)
     ]
 
+    # Resolve each distinct call stack to a module name, adding its aggregated
+    # counts into the per-module totals.
+    module_resolver = ModuleResolver()
+    module_stats = {}  # module -> [num_allocations, total_bytes]
+    cdef pair[size_t, pair[size_t, size_t]] stack_stats
+    for stack_stats in stats_by_stack:
+        stack = reader.Py_GetStackFrame(stack_stats.first)
+        module_name = module_resolver.get_module_for_stack(stack)
+        entry = module_stats.setdefault(module_name, [0, 0])
+        entry[0] += stack_stats.second.first
+        entry[1] += stack_stats.second.second
+
+    top_modules_by_count = sorted(
+        module_stats.items(), key=lambda x: x[1][0], reverse=True
+    )[:num_largest]
+    top_modules_by_allocation_count = [
+        (name, count, total_bytes)
+        for name, (count, total_bytes) in top_modules_by_count
+    ]
+
+    top_modules_by_size = sorted(
+        module_stats.items(), key=lambda x: x[1][1], reverse=True
+    )[:num_largest]
+    top_modules_by_allocation_size = [
+        (name, count, total_bytes)
+        for name, (count, total_bytes) in top_modules_by_size
+    ]
+
     # And we're done!
     cdef uint64_t peak_memory = aggregator.peakBytesAllocated()
     return Stats(
@@ -1565,6 +1608,8 @@ def compute_statistics(
         allocation_count_by_allocator=allocation_count_by_allocator,
         top_locations_by_size=top_locations_by_size,
         top_locations_by_count=top_locations_by_count,
+        top_modules_by_allocation_size=top_modules_by_allocation_size,
+        top_modules_by_allocation_count=top_modules_by_allocation_count,
     )
 
 

--- a/src/memray/_stats.py
+++ b/src/memray/_stats.py
@@ -1,4 +1,7 @@
 from dataclasses import dataclass
+from dataclasses import field
+from typing import List
+from typing import Tuple
 
 from ._metadata import Metadata
 
@@ -13,3 +16,9 @@ class Stats:
     allocation_count_by_allocator: dict
     top_locations_by_size: list
     top_locations_by_count: list
+    top_modules_by_allocation_size: List[Tuple[str, int, int]] = field(
+        default_factory=list
+    )
+    top_modules_by_allocation_count: List[Tuple[str, int, int]] = field(
+        default_factory=list
+    )

--- a/src/memray/_stats.pyi
+++ b/src/memray/_stats.pyi
@@ -13,3 +13,5 @@ class Stats:
     allocation_count_by_allocator: dict[str, int]
     top_locations_by_size: list[tuple[PythonStackElement, int]]
     top_locations_by_count: list[tuple[PythonStackElement, int]]
+    top_modules_by_allocation_size: list[tuple[str, int, int]]
+    top_modules_by_allocation_count: list[tuple[str, int, int]]

--- a/src/memray/reporters/module_tools.py
+++ b/src/memray/reporters/module_tools.py
@@ -1,0 +1,134 @@
+"""Utilities for extracting module names from file paths."""
+
+import site
+import sys
+import sysconfig
+from pathlib import Path
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from typing_extensions import TypedDict
+
+
+class PathInfo(TypedDict):
+    stdlib: Optional[Path]
+    site_packages: List[Path]
+    sys_path: List[Path]
+
+
+def get_python_path_info() -> PathInfo:
+    """Get information about Python's search paths.
+
+    Returns:
+        dict: Dictionary containing stdlib path, site-packages paths, and sys.path entries.
+    """
+    libdest = sysconfig.get_config_var("LIBDEST")
+    stdlib: Optional[Path] = Path(libdest) if libdest else None
+
+    # Get site-packages directories
+    site_packages: List[Path] = [Path(p) for p in site.getsitepackages()]
+
+    # Get user site-packages
+    user_site = site.getusersitepackages()
+    if Path(user_site).exists():
+        site_packages.append(Path(user_site))
+
+    return {
+        "stdlib": stdlib,
+        "site_packages": site_packages,
+        "sys_path": [Path(p) for p in sys.path if p],
+    }
+
+
+def _is_relative_to(path: Path, base: Path) -> bool:
+    try:
+        path.relative_to(base)
+        return True
+    except ValueError:
+        return False
+
+
+def _path_to_module(path: Path) -> str:
+    if path.is_absolute():
+        raise ValueError(f"Expected a relative path, got: {path}")
+
+    if path.name == "__init__.py":
+        path = path.parent
+    elif path.suffix == ".py":
+        path = path.with_suffix("")
+
+    return ".".join(path.parts)
+
+
+class ModuleResolver:
+    """Resolve file paths to module names, caching results per file name.
+
+    Holds the Python search path info and a cache so that the (relatively
+    expensive) classification is only computed once per file name.
+    """
+
+    def __init__(self, path_info: Optional[PathInfo] = None) -> None:
+        self._path_info: PathInfo = (
+            path_info if path_info is not None else get_python_path_info()
+        )
+        self._cache: Dict[str, Tuple[str, str]] = {}
+
+    def extract_module_name_and_type(self, filename: str) -> Tuple[str, str]:
+        """Extract Python module name and type from a file path.
+
+        Returns:
+            tuple: (module_name, module_type) where module_type is one of:
+                   'stdlib', 'site-packages', 'project', or 'unknown'
+        """
+        try:
+            return self._cache[filename]
+        except KeyError:
+            result = self._extract_module_name_and_type_impl(filename)
+            self._cache[filename] = result
+            return result
+
+    def _extract_module_name_and_type_impl(self, filename: str) -> Tuple[str, str]:
+        if not filename:
+            return ("unknown", "unknown")
+
+        if filename.startswith("<frozen "):
+            return (filename[len("<frozen ") : -1], "stdlib")
+
+        file_path = Path(filename)
+
+        for site_pkg in self._path_info["site_packages"]:
+            if _is_relative_to(file_path, site_pkg):
+                return (
+                    _path_to_module(file_path.relative_to(site_pkg)),
+                    "site-packages",
+                )
+
+        stdlib = self._path_info["stdlib"]
+        if stdlib and _is_relative_to(file_path, stdlib):
+            return (_path_to_module(file_path.relative_to(stdlib)), "stdlib")
+
+        for path_entry in self._path_info["sys_path"]:
+            if _is_relative_to(file_path, path_entry):
+                return (_path_to_module(file_path.relative_to(path_entry)), "project")
+
+        # Fallback: use just the filename, not the full absolute path
+        return (_path_to_module(Path(file_path.name)), "unknown")
+
+    def get_module_for_stack(self, stack: Iterable[Tuple[str, str, int]]) -> str:
+        """Find the top-level module of the closest non-stdlib frame in a stack.
+
+        Walks frames from leaf to root, returning the first non-stdlib module's
+        top-level package name. Returns "<root>" if we reach Memray's own calls
+        into the user's code, or if all frames are stdlib or the stack's empty.
+        """
+        for frame in stack:
+            module_name, module_type = self.extract_module_name_and_type(frame[1])
+            if module_type != "stdlib":
+                top_level = module_name.split(".")[0]
+                if top_level == "memray":
+                    return "<root>"
+                return top_level
+        return "<root>"

--- a/src/memray/reporters/stats.py
+++ b/src/memray/reporters/stats.py
@@ -162,6 +162,25 @@ class StatsReporter:
         for location, count in self._get_top_allocations_by_count():
             print(f"\t- {self._format_location(location)} -> {count}")
 
+        for modules, sort_label in [
+            (self._stats.top_modules_by_allocation_size, "by size"),
+            (
+                self._stats.top_modules_by_allocation_count,
+                "by number of allocations",
+            ),
+        ]:
+            if not modules:
+                continue
+            print()
+            rich.print(
+                f"🥇 [bold]Top {self.num_largest} allocating modules ({sort_label}):[/]"
+            )
+            for module_name, num_allocs, total_bytes in modules:
+                print(
+                    f"\t- {module_name}: {size_fmt(total_bytes)} total"
+                    f" | {num_allocs} allocations"
+                )
+
     def _render_to_json(self, histogram_params: Dict[str, int], out_path: Path) -> None:
         alloc_size_hist = describe_histogram_databins(
             get_histogram_databins(
@@ -188,6 +207,26 @@ class StatsReporter:
             "top_allocations_by_count": [
                 {"location": self._format_location(location), "count": count}
                 for location, count in self._get_top_allocations_by_count()
+            ],
+            "top_modules_by_allocation_size": [
+                {
+                    "module": module_name,
+                    "num_allocations": num_allocs,
+                    "total_bytes": total_bytes,
+                }
+                for module_name, num_allocs, total_bytes in (
+                    self._stats.top_modules_by_allocation_size
+                )
+            ],
+            "top_modules_by_allocation_count": [
+                {
+                    "module": module_name,
+                    "num_allocations": num_allocs,
+                    "total_bytes": total_bytes,
+                }
+                for module_name, num_allocs, total_bytes in (
+                    self._stats.top_modules_by_allocation_count
+                )
             ],
             "metadata": metadata,
         }

--- a/tests/integration/test_tracking.py
+++ b/tests/integration/test_tracking.py
@@ -1797,3 +1797,51 @@ class TestMemorySnapshots:
         assert record.n_allocations == 1
         assert record.allocator == AllocatorType.MALLOC
         assert record.size == 2 << 10
+
+
+@pytest.mark.parametrize(["allocator_func", "allocator_type"], ALLOCATORS)
+def test_module_stats_only_counts_allocations(allocator_func, allocator_type, tmp_path):
+    # GIVEN
+    output = tmp_path / "test.bin"
+    allocator = MemoryAllocator()
+
+    # WHEN
+    with Tracker(output):
+        res = getattr(allocator, allocator_func)(1234)
+        if res:
+            allocator.free()
+
+    if not res:
+        pytest.skip(f"Allocator {allocator_func} not supported on this platform")
+
+    # THEN
+    stats = compute_statistics(str(output), num_largest=5)
+    total_module_allocs = sum(
+        count for _, count, _ in stats.top_modules_by_allocation_size
+    )
+    assert total_module_allocs <= stats.total_num_allocations
+
+
+def test_module_stats_attributes_to_non_stdlib(tmp_path):
+    # GIVEN
+    output = tmp_path / "test.bin"
+
+    def tracking_function():
+        return [{str(k): k for k in range(50)} for _ in range(1000)]
+
+    # WHEN
+    with Tracker(output, trace_python_allocators=True):
+        tracking_function()
+
+    # THEN
+    stats = compute_statistics(str(output), num_largest=5)
+    module_names = [name for name, _, _ in stats.top_modules_by_allocation_size]
+    assert len(module_names) > 0
+    # The allocations are driven by tracking_function in this test module, so
+    # they must be attributed to this module's top-level package (the nearest
+    # non-stdlib frame) rather than to the stdlib frames doing the actual work.
+    assert __name__.split(".")[0] in module_names
+    for module_name, count, total_bytes in stats.top_modules_by_allocation_size:
+        assert isinstance(module_name, str)
+        assert count > 0
+        assert total_bytes > 0

--- a/tests/unit/test_module_tools.py
+++ b/tests/unit/test_module_tools.py
@@ -1,0 +1,201 @@
+from pathlib import Path
+
+import pytest
+
+from memray.reporters.module_tools import ModuleResolver
+from memray.reporters.module_tools import _path_to_module
+from memray.reporters.module_tools import get_python_path_info
+
+
+@pytest.fixture(scope="module")
+def path_info():
+    return get_python_path_info()
+
+
+@pytest.fixture
+def resolver(path_info):
+    return ModuleResolver(path_info)
+
+
+def test_path_info_has_expected_keys():
+    info = get_python_path_info()
+    assert "stdlib" in info
+    assert "site_packages" in info
+    assert "sys_path" in info
+
+
+def test_path_info_stdlib_points_to_sysconfig_libdest():
+    import sysconfig
+
+    info = get_python_path_info()
+    assert info["stdlib"] is not None
+    assert info["stdlib"] == Path(sysconfig.get_config_var("LIBDEST"))
+
+
+def test_path_info_site_packages_is_list_of_paths():
+    info = get_python_path_info()
+    assert isinstance(info["site_packages"], list)
+    for p in info["site_packages"]:
+        assert isinstance(p, Path)
+
+
+def test_path_info_sys_path_is_list_of_paths():
+    info = get_python_path_info()
+    assert isinstance(info["sys_path"], list)
+    for p in info["sys_path"]:
+        assert isinstance(p, Path)
+
+
+def test_path_info_includes_user_site_packages(tmp_path):
+    import unittest.mock
+
+    user_site = tmp_path / "user-site-packages"
+    user_site.mkdir()
+    with unittest.mock.patch("site.getusersitepackages", return_value=str(user_site)):
+        info = get_python_path_info()
+    assert Path(user_site) in info["site_packages"]
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("mymodule.py", "mymodule"),
+        ("pandas/io/parsers.py", "pandas.io.parsers"),
+        ("requests/__init__.py", "requests"),
+        ("pkg/utils", "pkg.utils"),
+        ("numpy/core/__init__.py", "numpy.core"),
+    ],
+)
+def test_path_to_module(path, expected):
+    assert _path_to_module(Path(path)) == expected
+
+
+def test_extract_module_name_and_type_empty(resolver):
+    name, mtype = resolver.extract_module_name_and_type("")
+    assert name == "unknown"
+    assert mtype == "unknown"
+
+
+def test_extract_module_name_and_type_frozen(resolver):
+    name, mtype = resolver.extract_module_name_and_type("<frozen importlib._bootstrap>")
+    assert name == "importlib._bootstrap"
+    assert mtype == "stdlib"
+
+
+def test_extract_module_name_and_type_stdlib(resolver, path_info):
+    stdlib_file = str(path_info["stdlib"] / "json" / "__init__.py")
+    name, mtype = resolver.extract_module_name_and_type(stdlib_file)
+    assert mtype == "stdlib"
+    assert "json" in name
+
+
+def test_extract_module_name_and_type_site_packages(resolver):
+    name, mtype = resolver.extract_module_name_and_type(pytest.__file__)
+    assert mtype == "site-packages"
+    assert "pytest" in name
+
+
+def test_extract_module_name_and_type_project(resolver):
+    _, mtype = resolver.extract_module_name_and_type(__file__)
+    assert mtype in ("project", "unknown")
+
+
+def test_extract_module_name_and_type_unknown(resolver):
+    name, mtype = resolver.extract_module_name_and_type(
+        "/nonexistent/random/mymodule.py"
+    )
+    assert mtype == "unknown"
+    assert name == "mymodule"
+
+
+def test_extract_module_name_and_type_is_cached(resolver):
+    # GIVEN / WHEN
+    first = resolver.extract_module_name_and_type(pytest.__file__)
+    second = resolver.extract_module_name_and_type(pytest.__file__)
+
+    # THEN
+    assert first == second
+    assert resolver._cache[pytest.__file__] == first
+
+
+def test_skips_stdlib_leaf_frame(resolver, path_info):
+    # GIVEN
+    stdlib_path = str(path_info["stdlib"] / "json" / "__init__.py")
+    stack = [
+        ("loads", stdlib_path, 346),
+        ("safe_load", pytest.__file__, 10),
+    ]
+
+    # THEN
+    assert resolver.get_module_for_stack(stack) == "pytest"
+
+
+def test_skips_frozen_stdlib_frame(resolver):
+    # GIVEN
+    stack = [
+        ("_find", "<frozen importlib._bootstrap>", 100),
+        ("safe_load", pytest.__file__, 10),
+    ]
+
+    # THEN
+    assert resolver.get_module_for_stack(stack) == "pytest"
+
+
+def test_returns_non_stdlib_leaf_immediately(resolver, path_info):
+    # GIVEN
+    stdlib_path = str(path_info["stdlib"] / "json" / "__init__.py")
+    stack = [
+        ("safe_load", pytest.__file__, 10),
+        ("loads", stdlib_path, 346),
+    ]
+
+    # THEN
+    assert resolver.get_module_for_stack(stack) == "pytest"
+
+
+def test_all_stdlib_returns_root(resolver, path_info):
+    # GIVEN
+    stdlib = path_info["stdlib"]
+    stack = [
+        ("loads", str(stdlib / "json" / "__init__.py"), 346),
+        ("decode", str(stdlib / "json" / "decoder.py"), 337),
+    ]
+
+    # THEN
+    assert resolver.get_module_for_stack(stack) == "<root>"
+
+
+def test_empty_stack_returns_root(resolver):
+    assert resolver.get_module_for_stack([]) == "<root>"
+
+
+def _memray_frame_path(path_info):
+    site_packages = path_info["site_packages"]
+    if not site_packages:
+        pytest.skip("No site-packages directory to anchor a memray path")
+    return str(site_packages[0] / "memray" / "commands" / "run.py")
+
+
+def test_memray_own_frames_return_root(resolver, path_info):
+    # GIVEN
+    stdlib_path = str(path_info["stdlib"] / "json" / "__init__.py")
+    stack = [
+        ("loads", stdlib_path, 346),
+        ("_run_tracker", _memray_frame_path(path_info), 100),
+    ]
+
+    # THEN
+    # memray's own driver frames must not be attributed as a module; they are
+    # treated as the root boundary.
+    assert resolver.get_module_for_stack(stack) == "<root>"
+
+
+def test_memray_frames_do_not_shadow_user_frames(resolver, path_info):
+    # GIVEN
+    stack = [
+        ("work", pytest.__file__, 10),
+        ("_run_tracker", _memray_frame_path(path_info), 100),
+    ]
+
+    # THEN
+    assert resolver.get_module_for_stack(stack) == "pytest"

--- a/tests/unit/test_stats_reporter.py
+++ b/tests/unit/test_stats_reporter.py
@@ -121,8 +121,53 @@ def fake_stats():
             (("fake_func2", "fake.py", 10), 3 * 2**10),
             (("__main__", "fake.py", 15), 4),
         ],
+        top_modules_by_allocation_size=[
+            ("fake", 20, sum(mem_allocation_list)),
+        ],
+        top_modules_by_allocation_count=[
+            ("fake", 20, sum(mem_allocation_list)),
+        ],
     )
     return s
+
+
+@pytest.fixture(scope="module")
+def empty_module_stats():
+    """Stats with no module attribution (top_modules_by_allocation_size is empty)."""
+    return Stats(
+        metadata=Metadata(
+            start_time=datetime(2023, 1, 1, 1),
+            end_time=datetime(2023, 1, 1, 2),
+            total_allocations=20,
+            total_frames=4,
+            peak_memory=2500000,
+            command_line="python -c 'import json; json.dumps(range(100))'",
+            pid=123456,
+            python_allocator="pymalloc",
+            has_native_traces=False,
+            trace_python_allocators=True,
+            file_format=FileFormat.ALL_ALLOCATIONS,
+            main_thread_id=0x1,
+        ),
+        total_num_allocations=20,
+        total_memory_allocated=3341500,
+        peak_memory_allocated=2500000,
+        allocation_count_by_size=Counter({256: 12, 512: 8}),
+        allocation_count_by_allocator={
+            AT.MALLOC.name: 15,
+            AT.REALLOC.name: 5,
+        },
+        top_locations_by_count=[
+            (("loads", "/usr/lib/python3.11/json/__init__.py", 346), 12),
+            (("decode", "/usr/lib/python3.11/json/decoder.py", 337), 8),
+        ],
+        top_locations_by_size=[
+            (("loads", "/usr/lib/python3.11/json/__init__.py", 346), 2500000),
+            (("decode", "/usr/lib/python3.11/json/decoder.py", 337), 841500),
+        ],
+        top_modules_by_allocation_size=[],
+        top_modules_by_allocation_count=[],
+    )
 
 
 # tests begin here
@@ -389,7 +434,13 @@ def test_stats_output(fake_stats):
         "🥇 [bold]Top 5 largest allocating locations (by number of allocations):[/]\n"
         "\t- fake_func:fake.py:5 -> 20\n"
         "\t- fake_func2:fake.py:10 -> 50\n"
-        "\t- __main__:fake.py:15 -> 1"
+        "\t- __main__:fake.py:15 -> 1\n"
+        "\n"
+        "🥇 [bold]Top 5 allocating modules (by size):[/]\n"
+        "\t- fake: 3.341MB total | 20 allocations\n"
+        "\n"
+        "🥇 [bold]Top 5 allocating modules (by number of allocations):[/]\n"
+        "\t- fake: 3.341MB total | 20 allocations"
     )
     printed = "\n".join(" ".join(x[0]) for x in mocked_print.call_args_list)
     assert expected == printed
@@ -430,6 +481,12 @@ def test_stats_output_json(fake_stats, tmp_path):
             {"location": "fake_func2:fake.py:10", "count": 50},
             {"location": "__main__:fake.py:15", "count": 1},
         ],
+        "top_modules_by_allocation_size": [
+            {"module": "fake", "num_allocations": 20, "total_bytes": 3341500},
+        ],
+        "top_modules_by_allocation_count": [
+            {"module": "fake", "num_allocations": 20, "total_bytes": 3341500},
+        ],
         "metadata": {
             "start_time": "2023-01-01 01:00:00",
             "end_time": "2023-01-01 02:00:00",
@@ -447,3 +504,21 @@ def test_stats_output_json(fake_stats, tmp_path):
     }
     actual = json.loads(output_file.read_text())
     assert expected == actual
+
+
+def test_stats_terminal_skips_empty_modules(empty_module_stats):
+    reporter = StatsReporter(empty_module_stats, 5)
+    with patch("builtins.print") as mocked_print:
+        with patch("rich.print", print):
+            reporter.render()
+    printed = "\n".join(" ".join(x[0]) for x in mocked_print.call_args_list)
+    assert "allocating modules" not in printed
+
+
+def test_stats_json_includes_empty_module_list(empty_module_stats, tmp_path):
+    output_file = tmp_path / "out.json"
+    reporter = StatsReporter(empty_module_stats, 5)
+    reporter.render(json_output_file=output_file)
+    data = json.loads(output_file.read_text())
+    assert data["top_modules_by_allocation_size"] == []
+    assert data["top_modules_by_allocation_count"] == []


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #765*

**Describe your changes**
Display the top N modules responsible for the most allocations in the memray stats reporter. For each allocation, walk the call stack to locate the nearest non-stdlib Python frame and extract its top-level module name. Aggregate allocation counts and allocated bytes by module, and include the top N results in both terminal and JSON output.

**Testing performed**
Unit tests + running `memray stats` on the example below:
```
"""Test script for memray stats module attribution."""

import json

import psutil
import rich.text
import yaml


def allocate_with_yaml():
    docs = [yaml.dump({"key": i, "nested": {"values": list(range(20))}}) for i in range(2000)]
    return [yaml.safe_load(d) for d in docs]


def allocate_with_psutil():
    procs = []
    for _ in range(100):
        procs.append(psutil.Process().memory_info())
        procs.append(psutil.Process().cpu_times())
    return procs


def allocate_with_rich():
    texts = [rich.text.Text(f"Hello world {i} " * 50) for i in range(3000)]
    return texts


def allocate_with_json():
    data = [json.dumps({"key": i, "values": list(range(50))}) for i in range(5000)]
    return [json.loads(d) for d in data]


def main():
    a = allocate_with_yaml()
    b = allocate_with_psutil()
    c = allocate_with_rich()
    d = allocate_with_json()
    print(f"Done: {len(a)} yaml, {len(b)} psutil, {len(c)} rich, {len(d)} json")


if __name__ == "__main__":
    main()

```

Output:
```
...

🥇 Top 5 allocating modules (by size):
        - yaml: 225.162MB total | 690815 allocations
        - test_modules: 37.624MB total | 43279 allocations
        - rich: 2.642MB total | 3000 allocations
        - psutil: 1.016MB total | 780 allocations
        - src: 352.635kB total | 199 allocations

🥇 Top 5 allocating modules (by number of allocations):
        - yaml: 225.162MB total | 690815 allocations
        - test_modules: 37.624MB total | 43279 allocations
        - rich: 2.642MB total | 3000 allocations
        - psutil: 1.016MB total | 780 allocations
        - src: 352.635kB total | 199 allocations
```

JSON Output:
```
...
],
"top_allocations_by_module": [
    {
      "module": "yaml",
      "num_allocations": 690815,
      "total_bytes": 225161828
    },
    {
      "module": "test_modules",
      "num_allocations": 43279,
      "total_bytes": 37623961
    },
    {
      "module": "rich",
      "num_allocations": 3000,
      "total_bytes": 2641500
    },
    {
      "module": "psutil",
      "num_allocations": 780,
      "total_bytes": 1016183
    },
    {
      "module": "src",
      "num_allocations": 199,
      "total_bytes": 352635
    }
  ],
  "top_allocations_by_module_by_count": [
    {
      "module": "yaml",
      "num_allocations": 690815,
      "total_bytes": 225161828
    },
    {
      "module": "test_modules",
      "num_allocations": 43279,
      "total_bytes": 37623961
    },
    {
      "module": "rich",
      "num_allocations": 3000,
      "total_bytes": 2641500
    },
    {
      "module": "psutil",
      "num_allocations": 780,
      "total_bytes": 1016183
    },
    {
      "module": "src",
      "num_allocations": 199,
      "total_bytes": 352635
    }
  ],
  "metadata": {
  ...
```

**Additional context**
Add any other context about your contribution here.
