### PR TITLE
Add diagnostic message for missing permissions on attach

### DIFF
--- a/news/940.bugfix.rst
+++ b/news/940.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that crashed target processes when ``memray attach`` fails. The underlying permissions issue is now accounted for and a troubleshooting message prints when it arises.

--- a/src/memray/commands/_attach.gdb
+++ b/src/memray/commands/_attach.gdb
@@ -18,6 +18,13 @@ p "MEMRAY: Process is Python 3.7+."
 set scheduler-locking on
 call (int)Py_AddPendingCall(&PyCallable_Check, (void*)0)
 
+p "Checking if we can access the library"
+set $result = (int)access($libpath, 5)
+if $result != 0
+    p "cannot open shared object file"
+    quit 1
+end
+
 # When updating this list, also update the "commands" call below,
 # and the breakpoints hardcoded for lldb in attach.py
 b malloc

--- a/src/memray/commands/_attach.lldb
+++ b/src/memray/commands/_attach.lldb
@@ -9,7 +9,10 @@ p ((void(*)(void*))PyMem_Free)
 
 p "MEMRAY: Process is Python 3.7+."
 
-# When adding new breakpoints, also update _attach.gdb
+# When adding new breakpoints, also update _attach.gdb - but note that
+# PyErr_CheckSignals and PyCallable_Check are intentionally excluded,
+# as for some reason including them caused lldb on Linux to stop at
+# breakpoints that had already been deleted.
 breakpoint set -b malloc -b calloc -b realloc -b free -b PyMem_Malloc -b PyMem_Calloc -b PyMem_Realloc -b PyMem_Free
 
 # Set commands to execute when breakpoint is reached
@@ -21,7 +24,8 @@ expr auto $dlerror = $dlsym($rtld_default, "dlerror")
 expr auto $dll = ((void*(*)(const char*, int))$dlopen)($libpath, $rtld_now)
 p ((char*(*)(void))$dlerror)()
 expr auto $spawn = $dlsym($dll, "memray_spawn_client")
-p ((int(*)(int))$spawn)($port)?"FAILURE":"SUCCESS"
+p ((char*(*)(void))$dlerror)()
+p (!$dll || !$spawn || ((int(*)(int))$spawn)($port)) ? "FAILURE" : "SUCCESS"
 DONE
 
 continue

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -231,6 +231,13 @@ def debugger_inject(debugger: str, pid: int, port: int, verbose: bool) -> str | 
         if "MEMRAY: Process is Python 3.7+." not in output:
             return "The process does not seem to be running Python 3.7 or newer."
 
+    if "cannot open shared object file" in output:
+        return (
+            "The target process couldn't open the memray shared library.\n"
+            "This can occur if the memray installation is owned by a different user "
+            "and is inaccessible to the target process."
+        )
+
     return "An unexpected error occurred. Run with --verbose to debug the failure."
 
 


### PR DESCRIPTION
Resolves #925.

**Describe your changes**
When the debugger calls `dlopen()` on the memray library in the target
process, it does so from the context of the target process' user. This
is ordinarily not a problem; but if memray was installed by another user
to a location inaccessible from the target user, the `dlopen()` fails,
causing the subsequent `dlsym()` and `memray_spawn_client()` calls to
fail as well. #925 is an instance of this problem where memray was
installed by the root user.

This changeset adjusts the attach scripts to short-circuit on `dlopen()`
failure before attempting to run `memray_spawn_client()`. When failure
happens, we match upon the `dlerror()` output and print a diagnostic
message.

**Testing performed**
Installed and ran memray as root, attaching to a target process running
as another user. The diagnostic message surfaced correctly. Tested with
the following configuration:

```
Linux nixos 6.18.19 #1-NixOS SMP Thu Mar 19 15:08:51 UTC 2026 aarch64 GNU/Linux
GNU gdb (GDB) 17.1
lldb version 18.1.8
Python 3.13.12 (main, Mar 20 2026, 00:36:06) [Clang 22.1.1 ]
```

**Additional context**
Future work might involve gracefully handling this case by copying the
required shared library and other resources to a permissive temporary
directory.
