### PR TITLE
Track Apache Arrow mimalloc allocations

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,7 +57,7 @@ jobs:
           echo /home/runner/node_modules/.bin >>"$GITHUB_PATH"
       - name: Install Python dependencies
         run: |
-          ${PYTHON} -m pip install --upgrade pip scikit-build-core cython pkgconfig
+          ${PYTHON} -m pip install --upgrade pip scikit-build-core cython pkgconfig "pyarrow>=25.0"
           make test-install
       - name: Disable ptrace security restrictions
         run: |

--- a/news/943.feature.rst
+++ b/news/943.feature.rst
@@ -1,0 +1,1 @@
+Track individual allocations made by Apache Arrow 25.0 and newer when it uses mimalloc on Linux.

--- a/src/memray/_memray/elf_shenanigans.cpp
+++ b/src/memray/_memray/elf_shenanigans.cpp
@@ -41,9 +41,17 @@ patch_symbol(
         const Hook& hook,
         typename Hook::signature_t intercept,
         const char* symname,
+        const SymbolTable& symbols,
         Addr addr,
         bool restore_original)
 {
+    const bool is_arrow_mimalloc_hook = strncmp(symname, "arrow_mi_", 9) == 0;
+    if (is_arrow_mimalloc_hook
+        && (!hook || symbols.getSymbolAddress(symname) != reinterpret_cast<Addr>(hook.d_original)))
+    {
+        return;
+    }
+
     // Make sure that we can read and write to the page where the address that we are trying to
     // patch;
     if (unprotect_page(addr) < 0) {
@@ -89,6 +97,7 @@ overwrite_elf_table(
                 MEMRAY_ORIG(hookname),                                                                  \
                 &intercept::hookname,                                                                   \
                 symname,                                                                                \
+                symbols,                                                                                \
                 symbol_addr,                                                                            \
                 restore_original);                                                                      \
         continue;                                                                                       \

--- a/src/memray/_memray/hooks.cpp
+++ b/src/memray/_memray/hooks.cpp
@@ -418,6 +418,59 @@ aligned_alloc(size_t alignment, size_t size) noexcept
     return ret;
 }
 
+// Apache Arrow mimalloc wrapper hooks (apache/arrow#41128). These wrap
+// mimalloc allocations that are otherwise opaque to memray because mimalloc
+// is statically linked into libarrow and serves allocations out of mmap
+// arenas. Tracked under the existing aligned-alloc / realloc / free families.
+void*
+arrow_mi_malloc_aligned(size_t size, size_t alignment) noexcept
+{
+    assert(MEMRAY_ORIG(arrow_mi_malloc_aligned));
+
+    void* ret;
+    {
+        tracking_api::RecursionGuard guard;
+        ret = MEMRAY_ORIG(arrow_mi_malloc_aligned)(size, alignment);
+    }
+    if (ret) {
+        tracking_api::Tracker::trackAllocation(ret, size, hooks::Allocator::ALIGNED_ALLOC);
+    }
+    return ret;
+}
+
+void*
+arrow_mi_realloc_aligned(void* ptr, size_t new_size, size_t alignment) noexcept
+{
+    assert(MEMRAY_ORIG(arrow_mi_realloc_aligned));
+
+    void* ret;
+    {
+        tracking_api::RecursionGuard guard;
+        ret = MEMRAY_ORIG(arrow_mi_realloc_aligned)(ptr, new_size, alignment);
+    }
+    if (ret) {
+        if (ptr != nullptr) {
+            tracking_api::Tracker::trackDeallocation(ptr, 0, hooks::Allocator::FREE);
+        }
+        tracking_api::Tracker::trackAllocation(ret, new_size, hooks::Allocator::REALLOC);
+    }
+    return ret;
+}
+
+void
+arrow_mi_free(void* ptr) noexcept
+{
+    assert(MEMRAY_ORIG(arrow_mi_free));
+
+    if (ptr != nullptr) {
+        tracking_api::Tracker::trackDeallocation(ptr, 0, hooks::Allocator::FREE);
+    }
+    {
+        tracking_api::RecursionGuard guard;
+        MEMRAY_ORIG(arrow_mi_free)(ptr);
+    }
+}
+
 #if defined(__linux__)
 
 void*

--- a/src/memray/_memray/hooks.cpp
+++ b/src/memray/_memray/hooks.cpp
@@ -102,6 +102,19 @@ ensureAllHooksAreValid()
 #undef FOR_EACH_HOOKED_FUNCTION
 }
 
+void
+ensureArrowHooksAreValid()
+{
+#if defined(__linux__)
+    MEMRAY_ORIG(arrow_mi_malloc_aligned).ensureValidOriginalSymbol();
+    if (!MEMRAY_ORIG(arrow_mi_malloc_aligned)) {
+        return;
+    }
+    MEMRAY_ORIG(arrow_mi_realloc_aligned).ensureValidOriginalSymbol();
+    MEMRAY_ORIG(arrow_mi_free).ensureValidOriginalSymbol();
+#endif
+}
+
 }  // namespace memray::hooks
 
 namespace memray::intercept {
@@ -431,6 +444,56 @@ aligned_alloc(size_t alignment, size_t size) noexcept
 }
 
 #if defined(__linux__)
+
+// Arrow's statically linked mimalloc is otherwise visible only as mmap arenas.
+void*
+arrow_mi_malloc_aligned(size_t size, size_t alignment) noexcept
+{
+    assert(MEMRAY_ORIG(arrow_mi_malloc_aligned));
+
+    void* ret;
+    {
+        tracking_api::RecursionGuard guard;
+        ret = MEMRAY_ORIG(arrow_mi_malloc_aligned)(size, alignment);
+    }
+    if (ret) {
+        tracking_api::Tracker::trackAllocation(ret, size, hooks::Allocator::ALIGNED_ALLOC);
+    }
+    return ret;
+}
+
+void*
+arrow_mi_realloc_aligned(void* ptr, size_t new_size, size_t alignment) noexcept
+{
+    assert(MEMRAY_ORIG(arrow_mi_realloc_aligned));
+
+    void* ret;
+    {
+        tracking_api::RecursionGuard guard;
+        ret = MEMRAY_ORIG(arrow_mi_realloc_aligned)(ptr, new_size, alignment);
+    }
+    if (ret) {
+        if (ptr != nullptr) {
+            tracking_api::Tracker::trackDeallocation(ptr, 0, hooks::Allocator::FREE);
+        }
+        tracking_api::Tracker::trackAllocation(ret, new_size, hooks::Allocator::REALLOC);
+    }
+    return ret;
+}
+
+void
+arrow_mi_free(void* ptr) noexcept
+{
+    assert(MEMRAY_ORIG(arrow_mi_free));
+
+    if (ptr != nullptr) {
+        tracking_api::Tracker::trackDeallocation(ptr, 0, hooks::Allocator::FREE);
+    }
+    {
+        tracking_api::RecursionGuard guard;
+        MEMRAY_ORIG(arrow_mi_free)(ptr);
+    }
+}
 
 void*
 memalign(size_t alignment, size_t size) noexcept

--- a/src/memray/_memray/hooks.h
+++ b/src/memray/_memray/hooks.h
@@ -24,6 +24,16 @@
 #include "compat.h"
 #include "logging.h"
 
+// Apache Arrow mimalloc wrapper symbols (apache/arrow#41128). Declared weak
+// so memray links even when the host binary doesn't depend on libarrow.
+// At runtime memray's phdr scanner resolves the real address from libarrow.so.
+extern "C" {
+__attribute__((weak)) void* arrow_mi_malloc_aligned(size_t size, size_t alignment);
+__attribute__((weak)) void* arrow_mi_realloc_aligned(void* ptr, size_t new_size,
+                                                    size_t alignment);
+__attribute__((weak)) void arrow_mi_free(void* ptr);
+}
+
 #if defined(__APPLE__)
 #    define MEMRAY_PLATFORM_HOOKED_FUNCTIONS
 #elif defined(__GLIBC__)
@@ -51,6 +61,9 @@
     FOR_EACH_HOOKED_FUNCTION(dlopen)                                                                    \
     FOR_EACH_HOOKED_FUNCTION(dlclose)                                                                   \
     FOR_EACH_HOOKED_FUNCTION(PyGILState_Ensure)                                                         \
+    FOR_EACH_HOOKED_FUNCTION(arrow_mi_malloc_aligned)                                                   \
+    FOR_EACH_HOOKED_FUNCTION(arrow_mi_realloc_aligned)                                                  \
+    FOR_EACH_HOOKED_FUNCTION(arrow_mi_free)                                                             \
     MEMRAY_PLATFORM_HOOKED_FUNCTIONS
 
 namespace memray::hooks {
@@ -178,6 +191,15 @@ posix_memalign(void** memptr, size_t alignment, size_t size) noexcept;
 
 void*
 aligned_alloc(size_t alignment, size_t size) noexcept;
+
+void*
+arrow_mi_malloc_aligned(size_t size, size_t alignment) noexcept;
+
+void*
+arrow_mi_realloc_aligned(void* ptr, size_t new_size, size_t alignment) noexcept;
+
+void
+arrow_mi_free(void* ptr) noexcept;
 
 void*
 memalign(size_t alignment, size_t size) noexcept;

--- a/src/memray/_memray/hooks.h
+++ b/src/memray/_memray/hooks.h
@@ -36,6 +36,24 @@ free_sized(void*, size_t) MAYBE_MISSING;
 extern "C" void
 free_aligned_sized(void*, size_t, size_t) MAYBE_MISSING;
 
+#ifdef __linux__
+// Arrow defines these wrappers only when built with mimalloc.
+extern "C" {
+void*
+arrow_mi_malloc_aligned(size_t size, size_t alignment) MAYBE_MISSING;
+void*
+arrow_mi_realloc_aligned(void* ptr, size_t new_size, size_t alignment) MAYBE_MISSING;
+void
+arrow_mi_free(void* ptr) MAYBE_MISSING;
+}
+#    define MEMRAY_ARROW_HOOKED_FUNCTIONS                                                               \
+        FOR_EACH_HOOKED_FUNCTION(arrow_mi_malloc_aligned)                                               \
+        FOR_EACH_HOOKED_FUNCTION(arrow_mi_realloc_aligned)                                              \
+        FOR_EACH_HOOKED_FUNCTION(arrow_mi_free)
+#else
+#    define MEMRAY_ARROW_HOOKED_FUNCTIONS
+#endif
+
 #if defined(__APPLE__)
 #    define MEMRAY_PLATFORM_HOOKED_FUNCTIONS
 #elif defined(__GLIBC__)
@@ -65,6 +83,7 @@ free_aligned_sized(void*, size_t, size_t) MAYBE_MISSING;
     FOR_EACH_HOOKED_FUNCTION(PyGILState_Ensure)                                                         \
     FOR_EACH_HOOKED_FUNCTION(free_sized)                                                                \
     FOR_EACH_HOOKED_FUNCTION(free_aligned_sized)                                                        \
+    MEMRAY_ARROW_HOOKED_FUNCTIONS                                                                       \
     MEMRAY_PLATFORM_HOOKED_FUNCTIONS
 
 namespace memray::hooks {
@@ -100,8 +119,8 @@ struct SymbolHook
         symbol_query query{0, d_symbol, nullptr};
         dl_iterate_phdr(&phdr_symfind_callback, (void*)&query);
         auto symbol_addr = reinterpret_cast<signature_t>(query.address);
-        if (symbol_addr != nullptr) {
-            if (symbol_addr != d_original) {
+        if (symbol_addr != nullptr && symbol_addr != d_original) {
+            if (d_original != nullptr) {
                 LOG(WARNING) << "Correcting symbol for " << d_symbol << " from " << std::hex
                              << reinterpret_cast<void*>(d_original) << " to "
                              << reinterpret_cast<void*>(symbol_addr);
@@ -127,6 +146,9 @@ struct SymbolHook
 
 void
 ensureAllHooksAreValid();
+
+void
+ensureArrowHooksAreValid();
 
 // Allocators are roughly ordered by the likelihood of any given allocation
 // record using them. The allocators assigned 1 to 7 have a more compact
@@ -192,6 +214,17 @@ posix_memalign(void** memptr, size_t alignment, size_t size) noexcept;
 
 void*
 aligned_alloc(size_t alignment, size_t size) noexcept;
+
+#ifdef __linux__
+void*
+arrow_mi_malloc_aligned(size_t size, size_t alignment) noexcept;
+
+void*
+arrow_mi_realloc_aligned(void* ptr, size_t new_size, size_t alignment) noexcept;
+
+void
+arrow_mi_free(void* ptr) noexcept;
+#endif
 
 void*
 memalign(size_t alignment, size_t size) noexcept;

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -898,6 +898,11 @@ Tracker::~Tracker()
 {
     RecursionGuard guard;
     tracking_api::Tracker::deactivate();
+#ifdef MEMRAY_HAS_GHOST_STACK
+    if (d_fast_unwind) {
+        ghost_stack_dump_stats();
+    }
+#endif
 
     PythonStackTracker::s_native_tracking_enabled = false;
     d_background_thread->stop();
@@ -1233,6 +1238,12 @@ Tracker::trackObjectImpl(PyObject* obj, int event, const std::optional<NativeTra
 void
 Tracker::invalidate_module_cache_impl()
 {
+    // Re-resolve hook originals before patching: hooked symbols defined in
+    // libraries loaded at runtime (e.g. libarrow.so's arrow_mi_*) are not
+    // present when ensureAllHooksAreValid() runs at tracker init; without
+    // this call, the patcher would rewrite GOT entries to point at our
+    // intercepts, which would then call a null d_original and crash.
+    hooks::ensureAllHooksAreValid();
     d_patcher.overwrite_symbols();
     updateModuleCacheImpl();
 }

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -872,6 +872,8 @@ Tracker::Tracker(
 #endif
     });
 
+    hooks::ensureArrowHooksAreValid();
+
     d_writer->setMainTidAndSkippedFrames(thread_id(), computeMainTidSkip());
     if (!d_writer->writeHeader(false)) {
         throw IoError{"Failed to write output header: " + std::string(strerror(errno))};
@@ -1235,6 +1237,8 @@ Tracker::trackObjectImpl(PyObject* obj, int event, const std::optional<NativeTra
 void
 Tracker::invalidate_module_cache_impl()
 {
+    // libarrow can be loaded after tracking starts.
+    hooks::ensureArrowHooksAreValid();
     d_patcher.overwrite_symbols();
     updateModuleCacheImpl();
 }

--- a/tests/integration/test_pyarrow.py
+++ b/tests/integration/test_pyarrow.py
@@ -1,0 +1,68 @@
+import subprocess
+import sys
+
+import pytest
+
+from memray import AllocatorType
+from memray import FileReader
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux", reason="Arrow hooks use ELF interposition"
+)
+
+
+PYARROW_TEST = """
+import sys
+
+from memray import Tracker
+
+output, load_timing = sys.argv[1:]
+
+if load_timing == "before_tracking":
+    import pyarrow
+elif load_timing == "between_trackers":
+    with Tracker(output + ".initial"):
+        pass
+    import pyarrow
+
+with Tracker(output):
+    if load_timing == "while_tracking":
+        import pyarrow
+    assert pyarrow.default_memory_pool().backend_name == "mimalloc"
+    buffer = pyarrow.allocate_buffer(4096, resizable=True)
+    allocated = buffer.address
+    buffer.resize(8192)
+    reallocated = buffer.address
+    del buffer
+
+print(allocated, reallocated)
+"""
+
+
+@pytest.mark.parametrize(
+    "load_timing", ["before_tracking", "while_tracking", "between_trackers"]
+)
+def test_tracks_pyarrow_mimalloc_buffers(tmp_path, load_timing):
+    pytest.importorskip("pyarrow", minversion="25.0.0")
+    output = tmp_path / "test.bin"
+
+    result = subprocess.run(
+        [sys.executable, "-c", PYARROW_TEST, output, load_timing],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    allocated, reallocated = map(int, result.stdout.split())
+    addresses = {allocated, reallocated}
+    records = [
+        (record.address, record.size, record.allocator)
+        for record in FileReader(output).get_allocation_records()
+        if record.address in addresses
+    ]
+    assert records == [
+        (allocated, 4096, AllocatorType.ALIGNED_ALLOC),
+        (allocated, 0, AllocatorType.FREE),
+        (reallocated, 8192, AllocatorType.REALLOC),
+        (reallocated, 0, AllocatorType.FREE),
+    ]


### PR DESCRIPTION
Hook the `arrow_mi_malloc_aligned`, `arrow_mi_realloc_aligned`, and `arrow_mi_free` symbols introduced in Apache Arrow 25 so Memray can attribute Arrow logical allocations instead of seeing only mimalloc mmap arenas.

Scope: Linux Arrow 25+ builds using mimalloc with interposable `arrow_mi_*` wrapper symbols. Official PyArrow 25 Linux wheels satisfy these requirements.

The hooks are re-resolved when libraries are loaded after Tracker initialization. To avoid crossing independent statically linked mimalloc instances, Memray patches only the ELF object that defines the selected wrapper; if multiple providers are loaded, later providers are left untracked rather than routed through the wrong allocator.

Tests cover loading Arrow before tracking, during tracking, and between Tracker sessions, plus isolation between multiple providers.