### PR TITLE
Build and test Python 3.15 wheels with cibuildwheel

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/---bug-report.yaml
@@ -47,14 +47,13 @@ body:
       description: What version of Python are you running?
       multiple: true
       options:
-        - "3.7"
-        - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"
         - "3.12"
         - "3.13"
         - "3.14"
+        - "3.15"
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
       - name: Build wheels
-        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           CIBW_BUILD: "cp3{9..15}{t,}-${{ matrix.wheel_type }}"
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux || 'auto' }}
@@ -133,7 +133,7 @@ jobs:
         run: |
           echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV
       - name: Build wheels
-        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           CIBW_BUILD: "cp3{9..15}{t,}-*"
           CIBW_ARCHS: "${{matrix.arch}}"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -90,7 +90,7 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux || 'auto' }}
           CIBW_ENABLE: cpython-prerelease
           CIBW_TEST_EXTRAS: test
-          CIBW_TEST_COMMAND: python -um pytest --log-cli-level=DEBUG -s -vvv {package}/tests
+          CIBW_TEST_COMMAND: python -um pytest --log-cli-level=DEBUG -s --showlocals -vvv {package}/tests
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.wheel_type }}-wheels
@@ -139,7 +139,7 @@ jobs:
           CIBW_ARCHS: "${{matrix.arch}}"
           CIBW_ENABLE: cpython-prerelease
           CIBW_TEST_EXTRAS: test
-          CIBW_TEST_COMMAND: python -um pytest --log-cli-level=DEBUG -s -vvv {package}/tests
+          CIBW_TEST_COMMAND: python -um pytest --log-cli-level=DEBUG -s --showlocals -vvv {package}/tests
           CIBW_BUILD_VERBOSITY: 1
           CPPFLAGS: "${{env.CPPFLAGS}} -I${{env.LZ4_INSTALL_DIR}}/include"
           LDFLAGS: "-L${{env.LZ4_INSTALL_DIR}}/lib -Wl,-rpath,${{env.LZ4_INSTALL_DIR}}/lib"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -84,11 +84,11 @@ jobs:
         run: |
           echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
       - name: Build wheels
-        uses: pypa/cibuildwheel@54327ab9d35de03b359ac25c97de9417d94639c0 # v4.0.0rc1
+        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         env:
-          CIBW_BUILD: "cp3{7..15}{t,}-${{ matrix.wheel_type }}"
+          CIBW_BUILD: "cp3{9..15}{t,}-${{ matrix.wheel_type }}"
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux || 'auto' }}
-          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_ENABLE: cpython-prerelease
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: python -um pytest --log-cli-level=DEBUG -s -vvv {package}/tests
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -133,11 +133,11 @@ jobs:
         run: |
           echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV
       - name: Build wheels
-        uses: pypa/cibuildwheel@54327ab9d35de03b359ac25c97de9417d94639c0 # v4.0.0rc1
+        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         env:
-          CIBW_BUILD: "cp3{8..15}{t,}-*"
+          CIBW_BUILD: "cp3{9..15}{t,}-*"
           CIBW_ARCHS: "${{matrix.arch}}"
-          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_ENABLE: cpython-prerelease
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: python -um pytest --log-cli-level=DEBUG -s -vvv {package}/tests
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/test_uv_python.yml
+++ b/.github/workflows/test_uv_python.yml
@@ -16,21 +16,25 @@ permissions: {}
 
 jobs:
   test_uv_python:
-    name: "Test with UV Python 3.14"
+    name: "Test with UV Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14", "3.15"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
-      - name: Install uv and set Python 3.14
+      - name: Install uv and set Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          python-version: "3.14"
+          python-version: "${{ matrix.python-version }}"
 
       - name: Create virtual environment
         run: |
-          uv venv --python 3.14
+          uv venv --python ${{ matrix.python-version }}
 
       - name: Set up system dependencies
         run: |

--- a/.github/workflows/test_uv_python.yml
+++ b/.github/workflows/test_uv_python.yml
@@ -16,25 +16,21 @@ permissions: {}
 
 jobs:
   test_uv_python:
-    name: "Test with UV Python ${{ matrix.python-version }}"
+    name: "Test with UV Python 3.14"
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.14", "3.14t", "3.15", "3.15t"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
-      - name: Install uv and set Python ${{ matrix.python-version }}
+      - name: Install uv and set Python 3.14
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          python-version: "${{ matrix.python-version }}"
+          python-version: "3.14"
 
       - name: Create virtual environment
         run: |
-          uv venv --python ${{ matrix.python-version }}
+          uv venv --python 3.14
 
       - name: Set up system dependencies
         run: |

--- a/.github/workflows/test_uv_python.yml
+++ b/.github/workflows/test_uv_python.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.14", "3.15"]
+        python-version: ["3.14", "3.14t", "3.15", "3.15t"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ It really makes a difference!
 
 # Installation
 
-Memray requires Python 3.7+ and can be easily installed using most common Python
+Memray requires Python 3.9+ and can be easily installed using most common Python
 packaging tools. We recommend installing the latest stable release from
 [PyPI](https://pypi.org/project/memray/) with pip:
 

--- a/news/946.removal.1.rst
+++ b/news/946.removal.1.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.7, which reached end-of-life in June 2023.

--- a/news/946.removal.2.rst
+++ b/news/946.removal.2.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.8, which reached end-of-life in October 2024.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
 build-backend = 'setuptools.build_meta'
 
 [dependency-groups]
-test=['Cython', 'coverage[toml]', "greenlet; python_version < '3.14'", 'pytest', 'pytest-cov', 'ipython', 'setuptools', 'pkgconfig', 'pytest-textual-snapshot', 'textual >= 0.43, != 0.65.2, != 0.66', 'packaging']
+test=['Cython', 'coverage[toml]', "greenlet; python_version < '3.15'", 'pytest', 'pytest-cov', 'ipython', 'setuptools', 'pkgconfig', 'pytest-textual-snapshot', 'textual >= 0.43, != 0.65.2, != 0.66', 'packaging']
 docs=['IPython', 'sphinx','sphinx-autobuild', 'sphinx-argparse', 'furo']
 extra=['mypy', 'bump2version','towncrier', 'prek', {include-group = "docs"}]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,8 @@ ignore = [
 exclude="tests/integration/(native_extension|multithreaded_extension)/"
 
 [tool.cibuildwheel]
-build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
+build = ["cp3{9..15}{t,}-*"]
+enable = ["cpython-prerelease"]
 skip = "*musllinux*{i686,aarch64}*"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ class BuildMemray(build_ext_orig):
 
 install_requires = [
     "jinja2 >= 2.9",
-    "typing_extensions; python_version < '3.8.0'",
     "rich >= 11.2.0",
     "textual >= 0.41.0",
 ]
@@ -305,7 +304,7 @@ LONG_DESCRIPTION = (HERE / "README.md").read_text(encoding="utf-8")
 setup(
     name="memray",
     version=about["__version__"],
-    python_requires=">=3.7.0",
+    python_requires=">=3.9.0",
     description="A memory profiler for Python applications",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
@@ -316,14 +315,13 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",
+        "Programming Language :: Python :: 3.15",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Software Development :: Debuggers",
     ],

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ lint_requires = [
 
 test_requires = [
     "Cython",
-    "greenlet; python_version < '3.14'",
+    "greenlet; python_version < '3.15'",
     "pytest",
     "pytest-cov",
     "ipython",

--- a/src/memray/_memray/compat.cpp
+++ b/src/memray/_memray/compat.cpp
@@ -14,28 +14,9 @@ setprofileAllThreads(Py_tracefunc func, PyObject* arg)
     for (PyThreadState* tstate = PyInterpreterState_ThreadHead(interp); tstate != nullptr;
          tstate = PyThreadState_Next(tstate))
     {
-#    if PY_VERSION_HEX >= 0x03090000
         if (_PyEval_SetProfile(tstate, func, arg) < 0) {
             _PyErr_WriteUnraisableMsg("in PyEval_SetProfileAllThreads", nullptr);
         }
-#    else
-        // For 3.7 and 3.8, backport _PyEval_SetProfile from 3.9
-        // https://github.com/python/cpython/blob/v3.9.13/Python/ceval.c#L4738-L4767
-        PyObject* profileobj = tstate->c_profileobj;
-
-        tstate->c_profilefunc = NULL;
-        tstate->c_profileobj = NULL;
-        /* Must make sure that tracing is not ignored if 'profileobj' is freed */
-        tstate->use_tracing = tstate->c_tracefunc != NULL;
-        Py_XDECREF(profileobj);
-
-        Py_XINCREF(arg);
-        tstate->c_profileobj = arg;
-        tstate->c_profilefunc = func;
-
-        /* Flag that tracing or profiling is turned on */
-        tstate->use_tracing = (func != NULL) || (tstate->c_tracefunc != NULL);
-#    endif
     }
 #endif
 }

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -11,6 +11,7 @@ import signal
 import socket
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import textwrap
 import threading
@@ -133,7 +134,16 @@ elif {mode!r} == "FOR_DURATION":
 
 def debugger_inject(debugger: str, pid: int, port: int, verbose: bool) -> str | None:
     """Execute a file in a running Python process using a debugger."""
-    injecter = pathlib.Path(memray.__file__).parent / "_inject.abi3.so"
+    # The injecter is a limited-API extension, so its filename carries an ABI
+    # tag. That tag is normally "abi3", but free-threaded builds get their own
+    # stable ABI ("abi3t") starting in 3.15 (PEP 803). Earlier free-threaded
+    # builds (e.g. 3.14t) still use "abi3".
+    free_threaded = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+    if free_threaded and sys.version_info >= (3, 15):
+        abi = "abi3t"
+    else:
+        abi = "abi3"
+    injecter = pathlib.Path(memray.__file__).parent / f"_inject.{abi}.so"
     assert injecter.exists()
 
     gdb_cmd = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import socket
-import sys
+from importlib import metadata  # Added in 3.8
 
 import pytest
 from packaging import version
@@ -20,12 +20,6 @@ def free_port():
 
 
 def _snapshot_skip_reason():
-    if sys.version_info < (3, 8):
-        # Every version available for 3.7 is too old
-        return f"snapshot tests require textual>={SNAPSHOT_MINIMUM_VERSIONS['textual']}"
-
-    from importlib import metadata  # Added in 3.8
-
     for lib, min_ver in SNAPSHOT_MINIMUM_VERSIONS.items():
         try:
             ver = version.parse(metadata.version(lib))

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -627,8 +627,10 @@ class TestParseSubcommand:
         for record in records:
             record_count_by_type[record.partition(" ")[0]] += 1
 
-        for count in record_count_by_type.values():
-            assert count > 0
+        for record_type, count in record_count_by_type.items():
+            assert (
+                count > 0
+            ), f"no {record_type} records found in {record_count_by_type}"
 
     def test_successful_parse_of_aggregated_capture_file(self, tmp_path):
         # GIVEN
@@ -687,8 +689,10 @@ class TestParseSubcommand:
         for record in records:
             record_count_by_type[record.partition(" ")[0]] += 1
 
-        for count in record_count_by_type.values():
-            assert count > 0
+        for record_type, count in record_count_by_type.items():
+            assert (
+                count > 0
+            ), f"no {record_type} records found in {record_count_by_type}"
 
     def test_error_when_stdout_is_a_tty(self, tmp_path, simple_test_file):
         # GIVEN

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -596,8 +596,20 @@ class TestParseSubcommand:
             from memray._test import MemoryAllocator
             print("Allocating some memory!")
             allocator = MemoryAllocator()
-            allocator.valloc(1024)
-            allocator.free()
+
+            def foo():
+                allocator.valloc(1024)
+                allocator.free()
+
+            def bar():
+                allocator.valloc(2048)
+                allocator.free()
+
+            # Ensure we see multiple allocation locations to guarantee
+            # that there's at least one FRAME_POP record.
+            foo()
+            bar()
+
             # Give it time to generate some memory records
             time.sleep(0.1)
             """

--- a/tests/integration/test_tracking.py
+++ b/tests/integration/test_tracking.py
@@ -128,15 +128,6 @@ def test_simple_cpp_allocation_tracking(tmp_path):
 def test_simple_pymalloc_allocation_tracking(
     allocator_func, allocator_type, domain, tmp_path
 ):
-    # TODO: Remove this entire check once we stop using 3.15.0b2
-    if (
-        sys.version_info >= (3, 15)
-        and sys.version_info <= (3, 15, 0, "beta", 2)
-        and domain == PymallocDomain.PYMALLOC_OBJECT
-        and allocator_func == "realloc"
-    ):
-        pytest.skip("Skipped for https://github.com/python/cpython/issues/151297")
-
     # GIVEN
     allocator = PymallocMemoryAllocator(domain)
     output = tmp_path / "test.bin"

--- a/tests/integration/test_tracking.py
+++ b/tests/integration/test_tracking.py
@@ -128,6 +128,15 @@ def test_simple_cpp_allocation_tracking(tmp_path):
 def test_simple_pymalloc_allocation_tracking(
     allocator_func, allocator_type, domain, tmp_path
 ):
+    # TODO: Remove this entire check once we stop using 3.15.0b2
+    if (
+        sys.version_info >= (3, 15)
+        and sys.version_info <= (3, 15, 0, "beta", 2)
+        and domain == PymallocDomain.PYMALLOC_OBJECT
+        and allocator_func == "realloc"
+    ):
+        pytest.skip("Skipped for https://github.com/python/cpython/issues/151297")
+
     # GIVEN
     allocator = PymallocMemoryAllocator(domain)
     output = tmp_path / "test.bin"

--- a/tests/integration/test_tracking.py
+++ b/tests/integration/test_tracking.py
@@ -175,6 +175,15 @@ def test_simple_pymalloc_allocation_tracking(
 def test_pymalloc_allocation_tracking_deactivated(
     allocator_func, allocator_type, domain, tmp_path
 ):
+    # TODO: Remove this entire check once we stop using 3.15.0b2
+    if (
+        sys.version_info >= (3, 15)
+        and sys.version_info <= (3, 15, 0, "beta", 2)
+        and domain == PymallocDomain.PYMALLOC_OBJECT
+        and allocator_func == "realloc"
+    ):
+        pytest.skip("Skipped for https://github.com/python/cpython/issues/151297")
+
     # GIVEN
     allocator = PymallocMemoryAllocator(domain)
     output = tmp_path / "test.bin"


### PR DESCRIPTION
Follow-up of https://github.com/bloomberg/memray/pull/927
cibuildwheel 4.0 is now released (not an RC anymore) so we update CI to that.
We also fix its config. We have to enable `cpython-prerelease` to build for python 3.15 (went unnoticed in the other PR) and we also fix the request for the python versions in CI and pyproject.toml. cibuildwheel 4.0 supports python 3.9 - 3.15. Asking for 3.7 or 3.8 like the CI did so far does not do anything. Looking at the existing wheels https://pypi.org/project/memray/#files, there are no wheels for 3.7 even though the CI was so far trying to ask for them. One has to use an older cibuildwheel version for older python versions.