### PR TITLE
Install shared libraries with the executable bit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,4 +209,10 @@ target_include_directories(_inject PRIVATE
 )
 
 # Install targets
-install(TARGETS _memray _test_utils _inject LIBRARY DESTINATION memray)
+install(TARGETS _memray _test_utils _inject
+    LIBRARY DESTINATION memray
+    PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+)


### PR DESCRIPTION
This likely doesn't really matter much, as the shared libraries are only ever loaded by `dlopen` which only needs read and not exec privileges, but this was an unintentional change introduced by the switch to `scikit-build-core`, so we may as well fix it.