### PR TITLE
Allow opting out of memory-mapped capture file IO

### DIFF
--- a/docs/run.rst
+++ b/docs/run.rst
@@ -274,6 +274,29 @@ it is not.
 If you can live with these limitations, then using ``--aggregate`` results in
 much smaller capture files that can be used seamlessly with most reporters.
 
+.. _buffered file io:
+
+Buffered file I/O
+-----------------
+
+By default, Memray maps its capture file into memory, letting it write to the
+file as if it were a normal memory buffer. This makes Memray faster and more
+resilient to process crashes (including death to the OOM killer), but some
+filesystems don't support shared writable ``mmap`` (or the ``posix_fallocate``
+function Memray uses to grow the file). If you see an error about ``mmap`` or
+``posix_fallocate`` when writing a capture file, and you can't move the capture
+file to a more standard file system, you can pass the ``--buffered-file-io``
+argument to ``memray run`` instead:
+
+.. code-block:: shell
+
+  memray run --buffered-file-io example.py
+
+With this option, Memray buffers captured allocations in memory and writes them
+out with ordinary ``write`` calls, flushing whenever the buffer fills. This
+works on more filesystems, but is slower and less resilient to crashes and
+other unclean exits.
+
 CLI Reference
 -------------
 

--- a/news/748.feature.rst
+++ b/news/748.feature.rst
@@ -1,0 +1,1 @@
+Add a ``--buffered-file-io`` option to ``memray run`` (and a ``buffered=True`` argument to ``memray.FileDestination``) that writes the capture file using buffered ``write`` calls instead of the default memory-mapped file IO. This is useful on filesystems that don't support shared writable ``mmap``, though it's slower and less robust to crashes.

--- a/src/memray/_destination.py
+++ b/src/memray/_destination.py
@@ -17,11 +17,19 @@ class FileDestination(Destination):
         overwrite: By default, if a file already exists at that path an
             exception will be raised. If you provide ``overwrite=True``, then
             the existing file will be overwritten instead.
+        compress_on_exit: By default, the output file is compressed with LZ4
+            after tracking completes. Set this to ``False`` to skip compression.
+        buffered: By default, captured allocations are written to the output
+            file using a shared writable ``mmap``. Some filesystems don't
+            support that; if you provide ``buffered=True``, allocations are
+            instead buffered in memory and written out with ordinary ``write``
+            calls, flushing when the buffer fills.
     """
 
     path: typing.Union[pathlib.Path, str]
     overwrite: bool = False
     compress_on_exit: bool = True
+    buffered: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -38,6 +38,7 @@ from _memray.records cimport FileFormat as _FileFormat
 from _memray.records cimport MemoryRecord
 from _memray.records cimport MemorySnapshot as _MemorySnapshot
 from _memray.records cimport TrackedObject
+from _memray.sink cimport BufferedFileSink
 from _memray.sink cimport FileSink
 from _memray.sink cimport NullSink
 from _memray.sink cimport Sink
@@ -770,6 +771,10 @@ cdef class Tracker:
 
             if is_dev_null:
                 return unique_ptr[Sink](new NullSink())
+            if getattr(destination, "buffered", False):
+                return unique_ptr[Sink](new BufferedFileSink(os.fsencode(destination.path),
+                                                             destination.overwrite,
+                                                             destination.compress_on_exit))
             return unique_ptr[Sink](new FileSink(os.fsencode(destination.path),
                                                  destination.overwrite,
                                                  destination.compress_on_exit))

--- a/src/memray/_memray/sink.cpp
+++ b/src/memray/_memray/sink.cpp
@@ -269,23 +269,21 @@ FileSink::~FileSink()
     }
 }
 
-SocketSink::SocketSink(std::string host, uint16_t port)
-: d_host(std::move(host))
-, d_port(port)
+BufferedSink::BufferedSink(size_t bufferSize)
+: BUFFER_SIZE(bufferSize)
 , d_buffer(new char[BUFFER_SIZE])
 , d_bufferNeedle(d_buffer.get())
 {
-    open();
 }
 
 size_t
-SocketSink::freeSpaceInBuffer()
+BufferedSink::freeSpaceInBuffer()
 {
     return BUFFER_SIZE - (d_bufferNeedle - d_buffer.get());
 }
 
 bool
-SocketSink::writeAll(const char* data, size_t length)
+BufferedSink::writeAll(const char* data, size_t length)
 {
     while (freeSpaceInBuffer() < length) {
         size_t toWrite = freeSpaceInBuffer();
@@ -304,19 +302,27 @@ SocketSink::writeAll(const char* data, size_t length)
 }
 
 bool
-SocketSink::flush()
-{
-    return _flush();
-}
-
-bool
-SocketSink::_flush()
+BufferedSink::flush()
 {
     const char* data = d_buffer.get();
     size_t length = d_bufferNeedle - data;
 
     d_bufferNeedle = d_buffer.get();
 
+    return writeBufferedData(data, length);
+}
+
+SocketSink::SocketSink(std::string host, uint16_t port)
+: BufferedSink(PIPE_BUF)
+, d_host(std::move(host))
+, d_port(port)
+{
+    open();
+}
+
+bool
+SocketSink::writeBufferedData(const char* data, size_t length)
+{
     while (length) {
         ssize_t ret = ::send(d_socket_fd, data, length, 0);
         if (ret < 0 && errno != EINTR) {
@@ -348,7 +354,7 @@ SocketSink::cloneInChildProcess()
 SocketSink::~SocketSink()
 {
     if (d_socket_open) {
-        _flush();
+        flush();
         ::close(d_socket_fd);
         d_socket_open = false;
     }

--- a/src/memray/_memray/sink.cpp
+++ b/src/memray/_memray/sink.cpp
@@ -57,6 +57,41 @@ removeSuffix(const std::string& s, const std::string& suffix)
     return s.substr(0, s.size() - suffix.size());
 }
 
+void
+compressFile(const std::string& filename) noexcept
+{
+    std::ifstream in_file(filename);
+    std::string tmp_filename = filename + ".lz4.tmp";
+    std::ofstream out_file(tmp_filename);
+    bool success = true;
+    constexpr size_t bufsize = 4 * 1024;
+
+    // lz4_stream is using exceptions rather than failbit/badbit
+    try {
+        lz4_stream::ostream lz4_stream(out_file);
+        std::vector<char> buf(bufsize);
+        while (in_file) {
+            in_file.read(&buf[0], buf.size());
+            lz4_stream.write(&buf[0], in_file.gcount());
+        }
+    } catch (...) {
+        success = false;
+    }
+
+    out_file.close();
+    if (!in_file.eof() || !out_file) {
+        success = false;
+    }
+
+    if (!success) {
+        std::cerr << "Failed to compress input file" << std::endl;
+        ::unlink(tmp_filename.c_str());
+    } else if (0 != std::rename(tmp_filename.c_str(), filename.c_str())) {
+        std::perror("Error moving compressed file back to original name");
+        ::unlink(tmp_filename.c_str());
+    }
+}
+
 }  // unnamed namespace
 
 bool
@@ -214,36 +249,7 @@ FileSink::cloneInChildProcess()
 void
 FileSink::compress() noexcept
 {
-    std::ifstream in_file(d_filename);
-    std::string tmp_filename = d_filename + ".lz4.tmp";
-    std::ofstream out_file(tmp_filename);
-    bool success = true;
-    constexpr size_t bufsize = 4 * 1024;
-
-    // lz4_stream is using exceptions rather than failbit/badbit
-    try {
-        lz4_stream::ostream lz4_stream(out_file);
-        std::vector<char> buf(bufsize);
-        while (in_file) {
-            in_file.read(&buf[0], buf.size());
-            lz4_stream.write(&buf[0], in_file.gcount());
-        }
-    } catch (...) {
-        success = false;
-    }
-
-    out_file.close();
-    if (!in_file.eof() || !out_file) {
-        success = false;
-    }
-
-    if (!success) {
-        std::cerr << "Failed to compress input file" << std::endl;
-        ::unlink(tmp_filename.c_str());
-    } else if (0 != std::rename(tmp_filename.c_str(), d_filename.c_str())) {
-        std::perror("Error moving compressed file back to original name");
-        ::unlink(tmp_filename.c_str());
-    }
+    compressFile(d_filename);
 }
 
 FileSink::~FileSink()

--- a/src/memray/_memray/sink.cpp
+++ b/src/memray/_memray/sink.cpp
@@ -176,7 +176,8 @@ FileSink::seek(off_t offset, int whence)
             << " at offset " << offset << ": " << strerror(errno);
         if (offset == 0) {
             msg << ". The destination filesystem may not support shared writable mmap;"
-                   " try writing the capture file to a different location (e.g. /tmp).";
+                   " try writing the capture file to a different location (e.g. /tmp)"
+                   " or run memray with the --buffered-file-io argument if you can't.";
         }
         LOG(ERROR) << msg.str();
         d_buffer = nullptr;
@@ -211,14 +212,15 @@ FileSink::grow(size_t needed)
         std::ostringstream msg;
         msg << "Failed to grow output file " << d_filename << " by " << delta
             << " bytes: " << strerror(rc);
-        if (d_fileSize == 0) {
 #ifdef __APPLE__
-            msg << ". The destination filesystem may not support F_PREALLOCATE;"
-                   " try writing the capture file to a different location (e.g. /tmp).";
+        const char what[] = "F_PREALLOCATE";
 #else
-            msg << ". The destination filesystem may not support posix_fallocate;"
-                   " try writing the capture file to a different location (e.g. /tmp).";
+        const char what[] = "posix_fallocate";
 #endif
+        if (d_fileSize == 0) {
+            msg << ". The destination filesystem may not support " << what
+                << "; try writing the capture file to a different location (e.g. /tmp)"
+                   " or run memray with the --buffered-file-io argument if you can't.";
         }
         LOG(ERROR) << msg.str();
         errno = rc;
@@ -418,6 +420,75 @@ SocketSink::open()
     }
 
     d_socket_open = true;
+}
+
+BufferedFileSink::BufferedFileSink(const std::string& file_name, bool overwrite, bool compress)
+: BufferedSink(FILE_BUFFER_SIZE)
+, d_filename(file_name)
+, d_fileNameStem(removeSuffix(file_name, "." + std::to_string(::getpid())))
+, d_compress(compress)
+{
+    int flags = O_CREAT | O_RDWR | O_TRUNC | O_CLOEXEC;
+    if (!overwrite) {
+        flags |= O_EXCL;
+    }
+    do {
+        d_fd = ::open(file_name.c_str(), flags, 0644);
+    } while (d_fd < 0 && errno == EINTR);
+    if (d_fd < 0) {
+        throw IoError{"Could not create output file " + file_name + ": " + std::string(strerror(errno))};
+    }
+}
+
+bool
+BufferedFileSink::writeBufferedData(const char* data, size_t length)
+{
+    while (length) {
+        ssize_t ret = ::write(d_fd, data, length);
+        if (ret < 0 && errno != EINTR) {
+            return false;
+        } else if (ret >= 0) {
+            data += ret;
+            length -= ret;
+        }
+    }
+    return true;
+}
+
+bool
+BufferedFileSink::seek(off_t offset, int whence)
+{
+    if (whence != SEEK_SET && whence != SEEK_END) {
+        errno = EINVAL;
+        return false;
+    }
+
+    // Any buffered data belongs at the current file offset; drain it before we
+    // move the offset out from under it.
+    if (!flush()) {
+        return false;
+    }
+
+    return ::lseek(d_fd, offset, whence) >= 0;
+}
+
+std::unique_ptr<Sink>
+BufferedFileSink::cloneInChildProcess()
+{
+    std::string file_name = d_fileNameStem + "." + std::to_string(::getpid());
+    return std::make_unique<BufferedFileSink>(file_name, true, d_compress);
+}
+
+BufferedFileSink::~BufferedFileSink()
+{
+    if (d_fd != -1) {
+        flush();
+        ::close(d_fd);
+    }
+
+    if (d_compress) {
+        compressFile(d_filename);
+    }
 }
 
 NullSink::~NullSink()

--- a/src/memray/_memray/sink.h
+++ b/src/memray/_memray/sink.h
@@ -76,6 +76,31 @@ class FileSink : public memray::io::Sink
     char* d_bufferNeedle{nullptr};
 };
 
+class BufferedFileSink : public BufferedSink
+{
+  public:
+    BufferedFileSink(const std::string& file_name, bool overwrite, bool compress);
+    ~BufferedFileSink() override;
+    BufferedFileSink(BufferedFileSink&) = delete;
+    BufferedFileSink(BufferedFileSink&&) = delete;
+    void operator=(const BufferedFileSink&) = delete;
+    void operator=(const BufferedFileSink&&) = delete;
+
+    bool seek(off_t offset, int whence) override;
+    std::unique_ptr<Sink> cloneInChildProcess() override;
+
+  protected:
+    bool writeBufferedData(const char* data, size_t length) override;
+
+  private:
+    static const size_t FILE_BUFFER_SIZE{1 * 1024 * 1024};  // 1 MiB
+
+    std::string d_filename;
+    std::string d_fileNameStem;
+    bool d_compress{1};
+    int d_fd{-1};
+};
+
 class SocketSink : public BufferedSink
 {
   public:

--- a/src/memray/_memray/sink.h
+++ b/src/memray/_memray/sink.h
@@ -22,6 +22,28 @@ class Sink
     }
 };
 
+// Reusable in-memory write buffering for sinks. Data handed to writeAll() is
+// copied into a fixed-size buffer drained when the buffer fills or flush() is
+// called. Flushing dispatches to derived class's writeBufferedData().
+class BufferedSink : public Sink
+{
+  public:
+    explicit BufferedSink(size_t bufferSize);
+    bool writeAll(const char* data, size_t length) override final;
+    bool flush() override final;
+
+  protected:
+    // Pure virtual function to be implemented by derived classes.
+    virtual bool writeBufferedData(const char* data, size_t length) = 0;
+
+  private:
+    size_t freeSpaceInBuffer();
+
+    const size_t BUFFER_SIZE;
+    std::unique_ptr<char[]> d_buffer{nullptr};
+    char* d_bufferNeedle{nullptr};
+};
+
 class FileSink : public memray::io::Sink
 {
   public:
@@ -54,7 +76,7 @@ class FileSink : public memray::io::Sink
     char* d_bufferNeedle{nullptr};
 };
 
-class SocketSink : public Sink
+class SocketSink : public BufferedSink
 {
   public:
     explicit SocketSink(std::string host, uint16_t port);
@@ -65,24 +87,19 @@ class SocketSink : public Sink
     void operator=(const SocketSink&) = delete;
     void operator=(const SocketSink&&) = delete;
 
-    bool writeAll(const char* data, size_t length) override;
     bool seek(off_t offset, int whence) override;
     std::unique_ptr<Sink> cloneInChildProcess() override;
-    bool flush() override;
+
+  protected:
+    bool writeBufferedData(const char* data, size_t length) override;
 
   private:
-    size_t freeSpaceInBuffer();
     void open();
-    bool _flush();
 
     const std::string d_host;
     uint16_t d_port;
     int d_socket_fd{-1};
     bool d_socket_open{false};
-
-    const size_t BUFFER_SIZE{PIPE_BUF};
-    std::unique_ptr<char[]> d_buffer{nullptr};
-    char* d_bufferNeedle{nullptr};
 };
 
 class NullSink : public Sink

--- a/src/memray/_memray/sink.pxd
+++ b/src/memray/_memray/sink.pxd
@@ -10,6 +10,9 @@ cdef extern from "sink.h" namespace "memray::io":
     cdef cppclass FileSink(Sink):
         FileSink(const string& file_name, bool overwrite, bool compress) except +IOError
 
+    cdef cppclass BufferedFileSink(Sink):
+        BufferedFileSink(const string& file_name, bool overwrite, bool compress) except +IOError
+
     cdef cppclass SocketSink(Sink):
         SocketSink(string host, unsigned int port) except +IOError
 

--- a/src/memray/commands/run.py
+++ b/src/memray/commands/run.py
@@ -188,7 +188,10 @@ def _run_with_file_output(args: argparse.Namespace) -> None:
     ).strip()
 
     destination = FileDestination(
-        path=filename, overwrite=args.force, compress_on_exit=args.compress_on_exit
+        path=filename,
+        overwrite=args.force,
+        compress_on_exit=args.compress_on_exit,
+        buffered=args.buffered_file_io,
     )
     try:
         _run_tracker(
@@ -271,6 +274,13 @@ class RunCommand:
             action="store_true",
             default=False,
         )
+        parser.add_argument(
+            "--buffered-file-io",
+            help="Buffer captured records in memory instead of using memory mapped IO",
+            action="store_true",
+            dest="buffered_file_io",
+            default=False,
+        )
         compression = parser.add_mutually_exclusive_group()
         compression.add_argument(
             "--compress-on-exit",
@@ -333,6 +343,8 @@ class RunCommand:
             parser.error("--follow-fork cannot be used with the live TUI")
         if args.aggregate and (args.live_mode or args.live_remote_mode):
             parser.error("--aggregate cannot be used with the live TUI")
+        if args.buffered_file_io and (args.live_mode or args.live_remote_mode):
+            parser.error("--buffered-file-io cannot be used with --live/--live-remote")
         with contextlib.suppress(OSError):
             if args.run_as_cmd and pathlib.Path(args.script).exists():
                 parser.error("remove the option -c to run a file")

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -226,6 +226,43 @@ class TestRunSubcommand:
         assert 0 < out_file.stat().st_size < 4 * 1024 * 1024
         assert out_file.read_bytes()[:4] != b"oops"
 
+    @pytest.mark.parametrize("compress", [True, False])
+    def test_run_buffered_file_io(self, tmp_path, simple_test_file, compress):
+        # GIVEN
+        from memray import FileReader
+
+        out_file = tmp_path / "result.bin"
+        args = [
+            sys.executable,
+            "-m",
+            "memray",
+            "run",
+            "--buffered-file-io",
+            "--output",
+            str(out_file),
+        ]
+        if not compress:
+            args.append("--no-compress")
+        args.append(str(simple_test_file))
+
+        # WHEN
+        proc = subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        # THEN
+        assert "Allocating some memory!" in proc.stdout
+        assert proc.returncode == 0
+        assert out_file.exists()
+
+        # The capture file written through the buffered sink (including the
+        # header rewritten via seek at shutdown) must be readable.
+        records = list(FileReader(str(out_file)).get_allocation_records())
+        assert any(record.size == 1024 for record in records)
+
     def test_run_file_with_args(self, tmp_path):
         """Execute a Python script and make sure the arguments in the script
         are correctly forwarded."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -104,6 +104,36 @@ class TestRunSubCommand:
             native_traces=False,
         )
 
+    def test_run_buffered_file_io(
+        self, getpid_mock, runpy_mock, tracker_mock, validate_mock
+    ):
+        assert 0 == main(
+            ["run", "-o", "my_output", "--buffered-file-io", "-m", "foobar"]
+        )
+        runpy_mock.run_module.assert_called_with(
+            "foobar", run_name="__main__", alter_sys=True
+        )
+        tracker_mock.assert_called_with(
+            destination=FileDestination("my_output", overwrite=False, buffered=True),
+            native_traces=False,
+        )
+
+    def test_run_buffered_file_io_rejected_with_live(
+        self, getpid_mock, runpy_mock, tracker_mock, validate_mock, capsys
+    ):
+        with pytest.raises(SystemExit):
+            main(["run", "--buffered-file-io", "--live", "-m", "foobar"])
+        captured = capsys.readouterr()
+        assert "--buffered-file-io cannot be used with --live" in captured.err
+
+    def test_run_buffered_file_io_rejected_with_live_remote(
+        self, getpid_mock, runpy_mock, tracker_mock, validate_mock, capsys
+    ):
+        with pytest.raises(SystemExit):
+            main(["run", "--buffered-file-io", "--live-remote", "-m", "foobar"])
+        captured = capsys.readouterr()
+        assert "--buffered-file-io cannot be used with --live" in captured.err
+
     def test_run_module(self, getpid_mock, runpy_mock, tracker_mock, validate_mock):
         assert 0 == main(["run", "-m", "foobar"])
         runpy_mock.run_module.assert_called_with(


### PR DESCRIPTION
Add a `--buffered-file-io` option to `memray run` (and a `buffered=True` argument to `memray.FileDestination`) that writes the capture file using buffered `write` calls instead of the default memory-mapped IO. This is useful on filesystems that don't support shared writable `mmap`, though it's slower and less robust to crashes.

Closes #748 