### PR TITLE
Record a high resolution timestamp for each allocation

### DIFF
--- a/src/memray/_memray.pyi
+++ b/src/memray/_memray.pyi
@@ -48,6 +48,8 @@ class AllocationRecord:
     @property
     def native_segment_generation(self) -> int: ...
     @property
+    def timestamp_us(self) -> int: ...
+    @property
     def thread_name(self) -> str: ...
     def hybrid_stack_trace(
         self,
@@ -246,6 +248,7 @@ class Tracker:
         memory_interval_ms: int = ...,
         follow_fork: bool = ...,
         trace_python_allocators: bool = ...,
+        allocation_timestamps: bool = ...,
         file_format: FileFormat = ...,
         reference_tracking: bool = ...,
         track_object_lifetimes: bool = ...,
@@ -259,6 +262,7 @@ class Tracker:
         memory_interval_ms: int = ...,
         follow_fork: bool = ...,
         trace_python_allocators: bool = ...,
+        allocation_timestamps: bool = ...,
         file_format: FileFormat = ...,
         reference_tracking: bool = ...,
     ) -> None: ...
@@ -336,6 +340,7 @@ class RecordWriterTestHarness:
         file_path: str,
         native_traces: bool = False,
         trace_python_allocators: bool = False,
+        allocation_timestamps: bool = False,
         file_format: FileFormat = FileFormat.ALL_ALLOCATIONS,
         main_tid: int = 1,
         skipped_frames: int = 0,
@@ -359,6 +364,7 @@ class RecordWriterTestHarness:
         size: int,
         allocator: int,
         native_frame_id: int = 0,
+        timestamp_us: int = 0,
     ) -> bool: ...
     def write_frame_push(
         self,

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -339,6 +339,10 @@ cdef class AllocationRecord:
         return self._tuple[7]
 
     @property
+    def timestamp_us(self):
+        return self._tuple[8]
+
+    @property
     def thread_name(self):
         if self.tid == -1:
             return "merged thread"
@@ -386,7 +390,7 @@ cdef class AllocationRecord:
     def __repr__(self):
         return (f"AllocationRecord<tid={hex(self.tid)}, address={hex(self.address)}, "
                 f"size={'N/A' if not self.size else size_fmt(self.size)}, allocator={self.allocator!r}, "
-                f"allocations={self.n_allocations}>")
+                f"allocations={self.n_allocations}, timestamp_us={self.timestamp_us}>")
 
 
 @cython.freelist(1024)
@@ -733,6 +737,8 @@ cdef class Tracker:
             created during the tracking session and still alive at the end (or
             in other words, what objects are leaked by the code being tracked).
             Defaults to False.
+        allocation_timestamps (bool): Whether or not to record a timestamp for
+            every allocation and deallocation event. Defaults to False.
         follow_fork (bool): Whether or not to continue tracking in a subprocess
             that is forked from the tracked process (see :ref:`Tracking across
             Forks`). Defaults to False.
@@ -753,6 +759,7 @@ cdef class Tracker:
     cdef unsigned int _memory_interval_ms
     cdef bool _follow_fork
     cdef bool _trace_python_allocators
+    cdef bool _allocation_timestamps
     cdef object _previous_profile_func
     cdef object _previous_thread_profile_func
     cdef object _patched_thread_class
@@ -782,6 +789,7 @@ cdef class Tracker:
     def __cinit__(self, object file_name=None, *, object destination=None,
                   bool native_traces=False, unsigned int memory_interval_ms = 10,
                   bool follow_fork=False, bool trace_python_allocators=False,
+                  bool allocation_timestamps=False,
                   bool track_object_lifetimes=False,
                   FileFormat file_format=FileFormat.ALL_ALLOCATIONS):
         if (file_name, destination).count(None) != 1:
@@ -800,6 +808,7 @@ cdef class Tracker:
         self._memory_interval_ms = memory_interval_ms
         self._follow_fork = follow_fork
         self._trace_python_allocators = trace_python_allocators
+        self._allocation_timestamps = allocation_timestamps
 
         if file_name is not None:
             destination = FileDestination(path=file_name)
@@ -811,6 +820,11 @@ cdef class Tracker:
             if file_format != FileFormat.ALL_ALLOCATIONS:
                 raise RuntimeError("AGGREGATED_ALLOCATIONS requires an output file")
 
+        if allocation_timestamps and file_format != FileFormat.ALL_ALLOCATIONS:
+            raise RuntimeError(
+                "allocation_timestamps requires FileFormat.ALL_ALLOCATIONS"
+            )
+
         self._writer = move(
             createRecordWriter(
                 move(self._make_writer(destination)),
@@ -819,6 +833,7 @@ cdef class Tracker:
                 file_format,
                 trace_python_allocators,
                 track_object_lifetimes,
+                allocation_timestamps,
             )
         )
 
@@ -864,6 +879,7 @@ cdef class Tracker:
                 self._follow_fork,
                 self._trace_python_allocators,
                 self._track_object_lifetimes,
+                self._allocation_timestamps,
             )
             return self
 
@@ -963,6 +979,7 @@ cdef _create_metadata(header, peak_memory):
         has_native_traces=header["native_traces"],
         trace_python_allocators=header["trace_python_allocators"],
         file_format=FileFormat(header["file_format"]),
+        has_allocation_timestamps=header["has_allocation_timestamps"],
     )
 
 
@@ -1822,6 +1839,7 @@ cdef class RecordWriterTestHarness:
         str file_path,
         bool native_traces=False,
         bool trace_python_allocators=False,
+        bool allocation_timestamps=False,
         track_object_lifetimes=False,
         records.FileFormat file_format=records.FileFormat.ALL_ALLOCATIONS,
         records.thread_id_t main_tid=1,
@@ -1844,6 +1862,7 @@ cdef class RecordWriterTestHarness:
             file_format,
             trace_python_allocators,
             track_object_lifetimes,
+            allocation_timestamps,
         )
         self._writer.get().setMainTidAndSkippedFrames(main_tid, skipped_frames)
         self.write_header(False)
@@ -1908,13 +1927,15 @@ cdef class RecordWriterTestHarness:
 
     def write_allocation_record(self, records.thread_id_t tid, uintptr_t address,
                                      size_t size, unsigned char allocator,
-                                     size_t native_frame_id=0) -> bool:
+                                     size_t native_frame_id=0,
+                                     uint64_t timestamp_us=0) -> bool:
         """Write a native allocation record to the file."""
         cdef records.AllocationRecord record
         record.address = address
         record.size = size
         record.allocator = <records.Allocator>allocator
         record.native_frame_id = native_frame_id
+        record.timestamp_us = timestamp_us
         return self._writer.get().writeThreadSpecificRecord(tid, record)
 
     def write_frame_push(

--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -98,7 +98,10 @@ RecordReader::readHeader(HeaderRecord& header)
                 sizeof(header.trace_python_allocators))
         || !d_input->read(
                 reinterpret_cast<char*>(&header.track_object_lifetimes),
-                sizeof(header.track_object_lifetimes)))
+                sizeof(header.track_object_lifetimes))
+        || !d_input->read(
+                reinterpret_cast<char*>(&header.has_allocation_timestamps),
+                sizeof(header.has_allocation_timestamps)))
     {
         throw std::ios_base::failure("Failed to read input file header.");
     }
@@ -318,6 +321,17 @@ RecordReader::parseAllocationRecord(AllocationRecord* record, unsigned int flags
         return false;
     }
 
+    if (d_header.has_allocation_timestamps) {
+        uint64_t delta_us = 0;
+        if (!readVarint(&delta_us)) {
+            return false;
+        }
+        d_last.allocation_timestamp_us += delta_us;
+        record->timestamp_us = d_last.allocation_timestamp_us;
+    } else {
+        record->timestamp_us = 0;
+    }
+
     return true;
 }
 
@@ -342,6 +356,7 @@ RecordReader::processAllocationRecord(const AllocationRecord& record)
         d_latest_allocation.native_segment_generation = 0;
     }
     d_latest_allocation.n_allocations = 1;
+    d_latest_allocation.timestamp_us = record.timestamp_us;
     return true;
 }
 
@@ -1151,7 +1166,7 @@ RecordReader::dumpAllRecords()
            " n_allocations=%zd n_frames=%zd start_time=%lld end_time=%lld"
            " pid=%d main_tid=%lu skipped_frames_on_main_tid=%zd"
            " command_line=%s python_allocator=%s trace_python_allocators=%s"
-           " track_object_lifetimes=%s\n",
+           " track_object_lifetimes=%s has_allocation_timestamps=%s\n",
            (int)sizeof(d_header.magic),
            d_header.magic,
            d_header.version,
@@ -1168,7 +1183,8 @@ RecordReader::dumpAllRecords()
            d_header.command_line.c_str(),
            python_allocator.c_str(),
            d_header.trace_python_allocators ? "true" : "false",
-           d_header.track_object_lifetimes ? "true" : "false");
+           d_header.track_object_lifetimes ? "true" : "false",
+           d_header.has_allocation_timestamps ? "true" : "false");
 
     switch (d_header.file_format) {
         case FileFormat::ALL_ALLOCATIONS:
@@ -1222,11 +1238,21 @@ RecordReader::dumpAllRecordsFromAllAllocationsFile()
                             "<unknown allocator " + std::to_string((int)record.allocator) + ">";
                     allocator = unknownAllocator.c_str();
                 }
-                printf("address=%p size=%zd allocator=%s native_frame_id=%zd\n",
-                       (void*)record.address,
-                       record.size,
-                       allocator,
-                       record.native_frame_id);
+                if (d_header.has_allocation_timestamps) {
+                    printf("address=%p size=%zd allocator=%s native_frame_id=%zd timestamp_us=%" PRIu64
+                           "\n",
+                           (void*)record.address,
+                           record.size,
+                           allocator,
+                           record.native_frame_id,
+                           record.timestamp_us);
+                } else {
+                    printf("address=%p size=%zd allocator=%s native_frame_id=%zd\n",
+                           (void*)record.address,
+                           record.size,
+                           allocator,
+                           record.native_frame_id);
+                }
             } break;
             case RecordType::FRAME_PUSH: {
                 printf("FRAME_PUSH ");

--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -321,16 +321,11 @@ RecordReader::parseAllocationRecord(AllocationRecord* record, unsigned int flags
         return false;
     }
 
-    if (d_header.has_allocation_timestamps) {
-        uint64_t delta_us = 0;
-        if (!readVarint(&delta_us)) {
-            return false;
-        }
-        d_last.allocation_timestamp_us += delta_us;
-        record->timestamp_us = d_last.allocation_timestamp_us;
-    } else {
-        record->timestamp_us = 0;
-    }
+    // The timestamp is not stored on the allocation record itself; it is carried
+    // by the CLOCK_ADVANCED records that precede it. Stamp this allocation with
+    // the current value of the running clock (0 when timestamps are disabled,
+    // since no CLOCK_ADVANCED records are ever emitted in that case).
+    record->timestamp_us = d_last.allocation_timestamp_us;
 
     return true;
 }
@@ -683,6 +678,9 @@ RecordReader::extractRecordTypeAndFlags(
     if (record_type_and_flags & static_cast<unsigned char>(RecordType::ALLOCATION)) {
         *record_type = RecordType::ALLOCATION;
         flags_mask = static_cast<unsigned char>(RecordType::ALLOCATION) - 1;
+    } else if (record_type_and_flags & static_cast<unsigned char>(RecordType::CLOCK_ADVANCED)) {
+        *record_type = RecordType::CLOCK_ADVANCED;
+        flags_mask = static_cast<unsigned char>(RecordType::CLOCK_ADVANCED) - 1;
     } else if (record_type_and_flags & static_cast<unsigned char>(RecordType::OBJECT_RECORD)) {
         *record_type = RecordType::OBJECT_RECORD;
         flags_mask = static_cast<unsigned char>(RecordType::OBJECT_RECORD) - 1;
@@ -726,6 +724,14 @@ RecordReader::nextRecordFromAllAllocationsFile()
                     return RecordResult::ERROR;
                 }
                 return RecordResult::ALLOCATION_RECORD;
+            } break;
+            case RecordType::CLOCK_ADVANCED: {
+                uint64_t delta_us = flags;
+                if (delta_us == 0 && !readVarint(&delta_us)) {
+                    if (d_input->is_open()) LOG(ERROR) << "Failed to process clock advance record";
+                    return RecordResult::ERROR;
+                }
+                d_last.allocation_timestamp_us += delta_us;
             } break;
             case RecordType::MEMORY_RECORD: {
                 MemoryRecord record;
@@ -1253,6 +1259,14 @@ RecordReader::dumpAllRecordsFromAllAllocationsFile()
                            allocator,
                            record.native_frame_id);
                 }
+            } break;
+            case RecordType::CLOCK_ADVANCED: {
+                uint64_t delta_us = flags;
+                if (delta_us == 0 && !readVarint(&delta_us)) {
+                    Py_RETURN_NONE;
+                }
+                d_last.allocation_timestamp_us += delta_us;
+                printf("CLOCK_ADVANCED us=%" PRIu64 "\n", delta_us);
             } break;
             case RecordType::FRAME_PUSH: {
                 printf("FRAME_PUSH ");

--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -683,15 +683,15 @@ RecordReader::extractRecordTypeAndFlags(
     if (record_type_and_flags & static_cast<unsigned char>(RecordType::ALLOCATION)) {
         *record_type = RecordType::ALLOCATION;
         flags_mask = static_cast<unsigned char>(RecordType::ALLOCATION) - 1;
-    } else if (record_type_and_flags & static_cast<unsigned char>(RecordType::FRAME_PUSH)) {
-        *record_type = RecordType::FRAME_PUSH;
-        flags_mask = static_cast<unsigned char>(RecordType::FRAME_PUSH) - 1;
     } else if (record_type_and_flags & static_cast<unsigned char>(RecordType::OBJECT_RECORD)) {
         *record_type = RecordType::OBJECT_RECORD;
         flags_mask = static_cast<unsigned char>(RecordType::OBJECT_RECORD) - 1;
     } else if (record_type_and_flags & static_cast<unsigned char>(RecordType::FRAME_POP)) {
         *record_type = RecordType::FRAME_POP;
         flags_mask = static_cast<unsigned char>(RecordType::FRAME_POP) - 1;
+    } else if ((record_type_and_flags & ~1u) == static_cast<unsigned char>(RecordType::FRAME_PUSH)) {
+        *record_type = RecordType::FRAME_PUSH;
+        flags_mask = 1;
     } else {
         *record_type = static_cast<RecordType>(record_type_and_flags);
         flags_mask = 0;

--- a/src/memray/_memray/record_writer.cpp
+++ b/src/memray/_memray/record_writer.cpp
@@ -65,7 +65,8 @@ class StreamingRecordWriter : public RecordWriter
             const std::string& command_line,
             bool native_traces,
             bool trace_python_allocators,
-            bool track_object_lifetimes);
+            bool track_object_lifetimes,
+            bool has_allocation_timestamps);
 
     StreamingRecordWriter(StreamingRecordWriter& other) = delete;
     StreamingRecordWriter(StreamingRecordWriter&& other) = delete;
@@ -128,7 +129,8 @@ class AggregatingRecordWriter : public RecordWriter
             const std::string& command_line,
             bool native_traces,
             bool trace_python_allocators,
-            bool track_object_lifetimes);
+            bool track_object_lifetimes,
+            bool has_allocation_timestamps);
 
     AggregatingRecordWriter(StreamingRecordWriter& other) = delete;
     AggregatingRecordWriter(StreamingRecordWriter&& other) = delete;
@@ -181,8 +183,10 @@ createRecordWriter(
         bool native_traces,
         FileFormat file_format,
         bool trace_python_allocators,
-        bool track_object_lifetimes)
+        bool track_object_lifetimes,
+        bool has_allocation_timestamps)
 {
+    has_allocation_timestamps = file_format == FileFormat::ALL_ALLOCATIONS && has_allocation_timestamps;
     switch (file_format) {
         case FileFormat::ALL_ALLOCATIONS:
             return std::make_unique<StreamingRecordWriter>(
@@ -190,14 +194,16 @@ createRecordWriter(
                     command_line,
                     native_traces,
                     trace_python_allocators,
-                    track_object_lifetimes);
+                    track_object_lifetimes,
+                    has_allocation_timestamps);
         case FileFormat::AGGREGATED_ALLOCATIONS:
             return std::make_unique<AggregatingRecordWriter>(
                     std::move(sink),
                     command_line,
                     native_traces,
                     trace_python_allocators,
-                    track_object_lifetimes);
+                    track_object_lifetimes,
+                    has_allocation_timestamps);
         default:
             throw std::runtime_error("Invalid file format enumerator");
     }
@@ -208,7 +214,8 @@ StreamingRecordWriter::StreamingRecordWriter(
         const std::string& command_line,
         bool native_traces,
         bool trace_python_allocators,
-        bool track_object_lifetimes)
+        bool track_object_lifetimes,
+        bool has_allocation_timestamps)
 : RecordWriter(std::move(sink))
 , d_stats({0, 0, duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count()})
 {
@@ -225,7 +232,8 @@ StreamingRecordWriter::StreamingRecordWriter(
             0,
             getPythonAllocator(),
             trace_python_allocators,
-            track_object_lifetimes};
+            track_object_lifetimes,
+            has_allocation_timestamps};
     strncpy(d_header.magic, MAGIC, sizeof(d_header.magic));
 }
 
@@ -398,6 +406,8 @@ StreamingRecordWriter::writeThreadSpecificRecord(thread_id_t tid, const Allocati
     // [native_id]   - Delta-encoded native_frame_id (only if native traces enabled
     //                 AND not a simple deallocator)
     // [size]        - Varint-encoded size (only if not a simple deallocator)
+    // [timestamp]   - Delta-encoded timestamp in microseconds since tracker start
+    //                 (only if allocation timestamps are enabled)
     //
     // Example sequences:
     // - Cached malloc(256):        [0b10011110] [size:256]
@@ -415,15 +425,24 @@ StreamingRecordWriter::writeThreadSpecificRecord(thread_id_t tid, const Allocati
     int pointer_cache_index = pointerCacheIndex(record.address);
     token |= (pointer_cache_index & 0x0f) << 3;
 
-    return writeSimpleType(token)
-           && (pointer_cache_index != -1
-               || writeIntegralDelta(&d_last.data_pointer, record.address >> 3))
-           && (allocator_id < 8 || writeSimpleType(record.allocator))
-           && (!d_header.native_traces
-               || hooks::allocatorKind(record.allocator) == hooks::AllocatorKind::SIMPLE_DEALLOCATOR
-               || writeIntegralDelta(&d_last.native_frame_id, record.native_frame_id))
-           && (hooks::allocatorKind(record.allocator) == hooks::AllocatorKind::SIMPLE_DEALLOCATOR
-               || writeVarint(record.size));
+    if (!writeSimpleType(token)
+        || (pointer_cache_index == -1 && !writeIntegralDelta(&d_last.data_pointer, record.address >> 3))
+        || (allocator_id >= 8 && !writeSimpleType(record.allocator))
+        || (d_header.native_traces
+            && hooks::allocatorKind(record.allocator) != hooks::AllocatorKind::SIMPLE_DEALLOCATOR
+            && !writeIntegralDelta(&d_last.native_frame_id, record.native_frame_id))
+        || (hooks::allocatorKind(record.allocator) != hooks::AllocatorKind::SIMPLE_DEALLOCATOR
+            && !writeVarint(record.size)))
+    {
+        return false;
+    }
+    if (d_header.has_allocation_timestamps) {
+        if (!writeVarint(record.timestamp_us - d_last.allocation_timestamp_us)) {
+            return false;
+        }
+        d_last.allocation_timestamp_us = record.timestamp_us;
+    }
+    return true;
 }
 
 bool
@@ -489,7 +508,8 @@ RecordWriter::writeHeaderCommon(const HeaderRecord& header)
         or !writeString(header.command_line.c_str()) or !writeSimpleType(header.pid)
         or !writeSimpleType(header.main_tid) or !writeSimpleType(header.skipped_frames_on_main_tid)
         or !writeSimpleType(header.python_allocator) or !writeSimpleType(header.trace_python_allocators)
-        or !writeSimpleType(header.track_object_lifetimes))
+        or !writeSimpleType(header.track_object_lifetimes)
+        or !writeSimpleType(header.has_allocation_timestamps))
     {
         return false;
     }
@@ -517,7 +537,8 @@ StreamingRecordWriter::cloneInChildProcess()
             d_header.command_line,
             d_header.native_traces,
             d_header.trace_python_allocators,
-            d_header.track_object_lifetimes);
+            d_header.track_object_lifetimes,
+            d_header.has_allocation_timestamps);
 }
 
 AggregatingRecordWriter::AggregatingRecordWriter(
@@ -525,7 +546,8 @@ AggregatingRecordWriter::AggregatingRecordWriter(
         const std::string& command_line,
         bool native_traces,
         bool trace_python_allocators,
-        bool track_object_lifetimes)
+        bool track_object_lifetimes,
+        bool has_allocation_timestamps)
 : RecordWriter(std::move(sink))
 {
     memcpy(d_header.magic, MAGIC, sizeof(d_header.magic));
@@ -538,6 +560,7 @@ AggregatingRecordWriter::AggregatingRecordWriter(
     d_header.python_allocator = getPythonAllocator();
     d_header.trace_python_allocators = trace_python_allocators;
     d_header.track_object_lifetimes = track_object_lifetimes;
+    d_header.has_allocation_timestamps = has_allocation_timestamps;
 
     d_stats.start_time = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 }
@@ -675,7 +698,8 @@ AggregatingRecordWriter::cloneInChildProcess()
             d_header.command_line,
             d_header.native_traces,
             d_header.trace_python_allocators,
-            d_header.track_object_lifetimes);
+            d_header.track_object_lifetimes,
+            d_header.has_allocation_timestamps);
 }
 
 bool
@@ -757,6 +781,7 @@ AggregatingRecordWriter::writeThreadSpecificRecord(thread_id_t tid, const Alloca
     }
     allocation.native_segment_generation = d_mappings_by_generation.size();
     allocation.n_allocations = 1;
+    allocation.timestamp_us = record.timestamp_us;
     d_high_water_mark_aggregator.addAllocation(allocation);
     return true;
 }

--- a/src/memray/_memray/record_writer.cpp
+++ b/src/memray/_memray/record_writer.cpp
@@ -365,9 +365,7 @@ StreamingRecordWriter::writeThreadSpecificRecord(thread_id_t tid, const FramePus
         return false;
     }
 
-    // FRAME_PUSH ENCODING: 0b01uuuuue, `u` are unused bits, `e` is is-entry-frame.
-    // In the future we can use `u` to pack more information into the token,
-    // like whether the code object id has been recently seen.
+    // FRAME_PUSH ENCODING: 0b0000001e, `e` is is-entry-frame.
     // This is followed by the varint encoded code object id and instruction offset.
     auto token = static_cast<unsigned char>(RecordType::FRAME_PUSH);
     token |= record.frame.is_entry_frame;

--- a/src/memray/_memray/record_writer.cpp
+++ b/src/memray/_memray/record_writer.cpp
@@ -129,8 +129,7 @@ class AggregatingRecordWriter : public RecordWriter
             const std::string& command_line,
             bool native_traces,
             bool trace_python_allocators,
-            bool track_object_lifetimes,
-            bool has_allocation_timestamps);
+            bool track_object_lifetimes);
 
     AggregatingRecordWriter(StreamingRecordWriter& other) = delete;
     AggregatingRecordWriter(StreamingRecordWriter&& other) = delete;
@@ -186,7 +185,6 @@ createRecordWriter(
         bool track_object_lifetimes,
         bool has_allocation_timestamps)
 {
-    has_allocation_timestamps = file_format == FileFormat::ALL_ALLOCATIONS && has_allocation_timestamps;
     switch (file_format) {
         case FileFormat::ALL_ALLOCATIONS:
             return std::make_unique<StreamingRecordWriter>(
@@ -202,8 +200,7 @@ createRecordWriter(
                     command_line,
                     native_traces,
                     trace_python_allocators,
-                    track_object_lifetimes,
-                    has_allocation_timestamps);
+                    track_object_lifetimes);
         default:
             throw std::runtime_error("Invalid file format enumerator");
     }
@@ -546,8 +543,7 @@ AggregatingRecordWriter::AggregatingRecordWriter(
         const std::string& command_line,
         bool native_traces,
         bool trace_python_allocators,
-        bool track_object_lifetimes,
-        bool has_allocation_timestamps)
+        bool track_object_lifetimes)
 : RecordWriter(std::move(sink))
 {
     memcpy(d_header.magic, MAGIC, sizeof(d_header.magic));
@@ -560,7 +556,7 @@ AggregatingRecordWriter::AggregatingRecordWriter(
     d_header.python_allocator = getPythonAllocator();
     d_header.trace_python_allocators = trace_python_allocators;
     d_header.track_object_lifetimes = track_object_lifetimes;
-    d_header.has_allocation_timestamps = has_allocation_timestamps;
+    d_header.has_allocation_timestamps = false;
 
     d_stats.start_time = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 }
@@ -698,8 +694,7 @@ AggregatingRecordWriter::cloneInChildProcess()
             d_header.command_line,
             d_header.native_traces,
             d_header.trace_python_allocators,
-            d_header.track_object_lifetimes,
-            d_header.has_allocation_timestamps);
+            d_header.track_object_lifetimes);
 }
 
 bool

--- a/src/memray/_memray/record_writer.cpp
+++ b/src/memray/_memray/record_writer.cpp
@@ -380,6 +380,35 @@ StreamingRecordWriter::writeThreadSpecificRecord(thread_id_t tid, const Allocati
         return false;
     }
 
+    // CLOCK_ADVANCED ENCODING: 0b01dddddd
+    //
+    // Rather than storing a timestamp on every allocation, we emit a separate
+    // CLOCK_ADVANCED record whenever this allocation's timestamp is higher than
+    // the last one we emitted. The reader accumulates these advances into a
+    // running clock and stamps each subsequent allocation with its current value.
+    //
+    // The 6 flag bits `dddddd` hold the advance in microseconds:
+    //   1-63: the advance itself, encoded directly in the flag bits (no extra bytes)
+    //      0: sentinel meaning the advance follows as an unsigned varint
+    if (d_header.has_allocation_timestamps && record.timestamp_us > d_last.allocation_timestamp_us) {
+        uint64_t delta_us = record.timestamp_us - d_last.allocation_timestamp_us;
+        d_last.allocation_timestamp_us = record.timestamp_us;
+
+        auto clock_token = static_cast<unsigned char>(RecordType::CLOCK_ADVANCED);
+        if (delta_us < 64) {
+            // Small advance (1-63): pack it into the flag bits.
+            clock_token |= static_cast<unsigned char>(delta_us);
+            if (!writeSimpleType(clock_token)) {
+                return false;
+            }
+        } else {
+            // Larger advance: flag bits are 0 and a full varint follows.
+            if (!writeSimpleType(clock_token) || !writeVarint(delta_us)) {
+                return false;
+            }
+        }
+    }
+
     // ALLOCATION ENCODING: 0b1ppppaaa
     //
     // Bit layout of the first byte:
@@ -401,8 +430,6 @@ StreamingRecordWriter::writeThreadSpecificRecord(thread_id_t tid, const Allocati
     // [native_id]   - Delta-encoded native_frame_id (only if native traces enabled
     //                 AND not a simple deallocator)
     // [size]        - Varint-encoded size (only if not a simple deallocator)
-    // [timestamp]   - Delta-encoded timestamp in microseconds since tracker start
-    //                 (only if allocation timestamps are enabled)
     //
     // Example sequences:
     // - Cached malloc(256):        [0b10011110] [size:256]
@@ -420,24 +447,15 @@ StreamingRecordWriter::writeThreadSpecificRecord(thread_id_t tid, const Allocati
     int pointer_cache_index = pointerCacheIndex(record.address);
     token |= (pointer_cache_index & 0x0f) << 3;
 
-    if (!writeSimpleType(token)
-        || (pointer_cache_index == -1 && !writeIntegralDelta(&d_last.data_pointer, record.address >> 3))
-        || (allocator_id >= 8 && !writeSimpleType(record.allocator))
-        || (d_header.native_traces
-            && hooks::allocatorKind(record.allocator) != hooks::AllocatorKind::SIMPLE_DEALLOCATOR
-            && !writeIntegralDelta(&d_last.native_frame_id, record.native_frame_id))
-        || (hooks::allocatorKind(record.allocator) != hooks::AllocatorKind::SIMPLE_DEALLOCATOR
-            && !writeVarint(record.size)))
-    {
-        return false;
-    }
-    if (d_header.has_allocation_timestamps) {
-        if (!writeVarint(record.timestamp_us - d_last.allocation_timestamp_us)) {
-            return false;
-        }
-        d_last.allocation_timestamp_us = record.timestamp_us;
-    }
-    return true;
+    return writeSimpleType(token)
+           && (pointer_cache_index != -1
+               || writeIntegralDelta(&d_last.data_pointer, record.address >> 3))
+           && (allocator_id < 8 || writeSimpleType(record.allocator))
+           && (!d_header.native_traces
+               || hooks::allocatorKind(record.allocator) == hooks::AllocatorKind::SIMPLE_DEALLOCATOR
+               || writeIntegralDelta(&d_last.native_frame_id, record.native_frame_id))
+           && (hooks::allocatorKind(record.allocator) == hooks::AllocatorKind::SIMPLE_DEALLOCATOR
+               || writeVarint(record.size));
 }
 
 bool

--- a/src/memray/_memray/record_writer.h
+++ b/src/memray/_memray/record_writer.h
@@ -64,7 +64,8 @@ createRecordWriter(
         bool native_traces,
         FileFormat file_format,
         bool trace_python_allocators,
-        bool track_object_lifetimes);
+        bool track_object_lifetimes,
+        bool has_allocation_timestamps);
 
 template<typename T>
 bool inline RecordWriter::writeSimpleType(const T& item)

--- a/src/memray/_memray/record_writer.pxd
+++ b/src/memray/_memray/record_writer.pxd
@@ -55,4 +55,5 @@ cdef extern from "record_writer.h" namespace "memray::tracking_api":
         FileFormat file_format,
         bool trace_python_allocators,
         bool track_object_lifetimes,
+        bool has_allocation_timestamps,
     ) except+

--- a/src/memray/_memray/records.cpp
+++ b/src/memray/_memray/records.cpp
@@ -15,7 +15,7 @@ Allocation::toPythonObject() const
     // operations speeds up the parsing moderately. Additionally, some of
     // the types we need to convert from are not supported by PyBuildValue
     // natively.
-    PyObject* tuple = PyTuple_New(8);
+    PyObject* tuple = PyTuple_New(9);
     if (tuple == nullptr) {
         return nullptr;
     }
@@ -51,6 +51,9 @@ Allocation::toPythonObject() const
     elem = PyLong_FromSize_t(native_segment_generation);
     __CHECK_ERROR(elem);
     PyTuple_SET_ITEM(tuple, 7, elem);
+    elem = PyLong_FromUnsignedLongLong(timestamp_us);
+    __CHECK_ERROR(elem);
+    PyTuple_SET_ITEM(tuple, 8, elem);
 #undef __CHECK_ERROR
     return tuple;
 }
@@ -67,6 +70,7 @@ AggregatedAllocation::contributionToHighWaterMark() const
             frame_index,
             native_segment_generation,
             n_allocations_in_high_water_mark,
+            0,
     };
 }
 
@@ -82,6 +86,7 @@ AggregatedAllocation::contributionToLeaks() const
             frame_index,
             native_segment_generation,
             n_allocations_leaked,
+            0,
     };
 }
 

--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -18,7 +18,7 @@
 namespace memray::tracking_api {
 
 extern const char MAGIC[7];  // Value assigned in records.cpp
-const int CURRENT_HEADER_VERSION = 12;
+const int CURRENT_HEADER_VERSION = 13;
 
 using frame_id_t = size_t;
 using thread_id_t = unsigned long;
@@ -113,6 +113,7 @@ struct HeaderRecord
     PythonAllocatorType python_allocator{};
     bool trace_python_allocators{};
     bool track_object_lifetimes{false};
+    bool has_allocation_timestamps{false};
 };
 
 struct MemoryRecord
@@ -134,6 +135,7 @@ struct AllocationRecord
     size_t size;
     hooks::Allocator allocator;
     frame_id_t native_frame_id{0};
+    uint64_t timestamp_us{0};
 };
 
 struct Allocation
@@ -146,6 +148,7 @@ struct Allocation
     size_t frame_index{0};
     size_t native_segment_generation{0};
     size_t n_allocations{1};
+    uint64_t timestamp_us{0};
 
     PyObject* toPythonObject() const;
 };
@@ -308,6 +311,7 @@ struct DeltaEncodedFields
     uintptr_t data_pointer{};
     frame_id_t native_frame_id{};
     int code_firstlineno{};
+    uint64_t allocation_timestamp_us{};
 };
 
 template<typename RecordType>

--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -40,7 +40,7 @@ using code_object_id_t = size_t;
 enum class RecordType : unsigned char {
     FILLER = 0,
     TRAILER = 1,
-    MEMORY_RECORD = 2,
+    MEMORY_RECORD = 4,
     NATIVE_TRACE_INDEX = 5,
     MEMORY_MAP_START = 6,
     SEGMENT_HEADER = 7,

--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -29,6 +29,9 @@ using code_object_id_t = size_t;
 // it's an ALLOCATION record with 7 bits available for flags (see
 // "ALLOCATION ENCODING" in record_writer.cpp for details).
 //
+// Otherwise, if the 64 bit is set, it's a CLOCK_ADVANCED record with 6 bits
+// available for flags (see "CLOCK_ADVANCED ENCODING" in record_writer.cpp).
+//
 // Otherwise, if the 16 bit is set, it's a FRAME_POP record with 4 bits
 // available for flags (see "FRAME_POP ENCODING" in record_writer.cpp).
 //
@@ -52,6 +55,7 @@ enum class RecordType : unsigned char {
     FRAME_PUSH = 2,  // 2 through 3
     FRAME_POP = 16,  // 16 through 31
     OBJECT_RECORD = 32,  // 32 through 63
+    CLOCK_ADVANCED = 64,  // 64 through 127
     ALLOCATION = 128,  // 128 through 255
 };
 

--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -29,11 +29,11 @@ using code_object_id_t = size_t;
 // it's an ALLOCATION record with 7 bits available for flags (see
 // "ALLOCATION ENCODING" in record_writer.cpp for details).
 //
-// Otherwise, if the 64 bit is set, it's a FRAME_PUSH record with 6 bits
-// available for flags (see "FRAME_PUSH ENCODING" in record_writer.cpp).
-//
 // Otherwise, if the 16 bit is set, it's a FRAME_POP record with 4 bits
 // available for flags (see "FRAME_POP ENCODING" in record_writer.cpp).
+//
+// Otherwise, if the value is 2 or 3, it's a FRAME_PUSH record with 1 bit
+// available for flags (see "FRAME_PUSH ENCODING" in record_writer.cpp).
 //
 // Otherwise, it's a record type that has no flags, and all remaining
 // bits identify the record type
@@ -49,9 +49,9 @@ enum class RecordType : unsigned char {
     CONTEXT_SWITCH = 12,
     CODE_OBJECT = 14,
 
+    FRAME_PUSH = 2,  // 2 through 3
     FRAME_POP = 16,  // 16 through 31
     OBJECT_RECORD = 32,  // 32 through 63
-    FRAME_PUSH = 64,  // 64 through 127
     ALLOCATION = 128,  // 128 through 255
 };
 

--- a/src/memray/_memray/records.pxd
+++ b/src/memray/_memray/records.pxd
@@ -39,6 +39,7 @@ cdef extern from "records.h" namespace "memray::tracking_api":
        size_t size
        Allocator allocator
        frame_id_t native_frame_id
+       uint64_t timestamp_us
 
    struct Frame:
        code_object_id_t code_object_id
@@ -89,6 +90,7 @@ cdef extern from "records.h" namespace "memray::tracking_api":
        int python_allocator
        bool trace_python_allocators
        bool track_object_lifetimes
+       bool has_allocation_timestamps
 
    cdef cppclass Allocation:
        thread_id_t tid
@@ -99,6 +101,7 @@ cdef extern from "records.h" namespace "memray::tracking_api":
        size_t frame_index
        size_t native_segment_generation
        size_t n_allocations
+       uint64_t timestamp_us
 
        object toPythonObject()
 

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -815,13 +815,15 @@ Tracker::Tracker(
         unsigned int memory_interval,
         bool follow_fork,
         bool trace_python_allocators,
-        bool reference_tracking)
+        bool reference_tracking,
+        bool allocation_timestamps)
 : d_writer(std::move(record_writer))
 , d_unwind_native_frames(native_traces)
 , d_memory_interval(memory_interval)
 , d_follow_fork(follow_fork)
 , d_trace_python_allocators(trace_python_allocators)
 , d_reference_tracking(reference_tracking)
+, d_allocation_timestamps(allocation_timestamps)
 {
     static std::once_flag once;
     call_once(once, [] {
@@ -1108,7 +1110,8 @@ Tracker::childFork()
             old_tracker->d_memory_interval,
             old_tracker->d_follow_fork,
             old_tracker->d_trace_python_allocators,
-            old_tracker->d_reference_tracking));
+            old_tracker->d_reference_tracking,
+            old_tracker->d_allocation_timestamps));
 
     StopTheWorldGuard stop_the_world;
     std::unique_lock<std::mutex> lock(*s_mutex);
@@ -1163,13 +1166,23 @@ Tracker::trackAllocationImpl(
                         return d_writer->writeRecord(UnresolvedNativeFrame{ip, index});
                     });
         }
-        AllocationRecord record{reinterpret_cast<uintptr_t>(ptr), size, func, native_index};
+        AllocationRecord record{
+                reinterpret_cast<uintptr_t>(ptr),
+                size,
+                func,
+                native_index,
+                d_allocation_timestamps ? currentTimestampUs() : 0};
         if (!d_writer->writeThreadSpecificRecord(thread_id(), record)) {
             std::cerr << "Failed to write output, deactivating tracking" << std::endl;
             deactivate();
         }
     } else {
-        AllocationRecord record{reinterpret_cast<uintptr_t>(ptr), size, func};
+        AllocationRecord record{
+                reinterpret_cast<uintptr_t>(ptr),
+                size,
+                func,
+                0,
+                d_allocation_timestamps ? currentTimestampUs() : 0};
         if (!d_writer->writeThreadSpecificRecord(thread_id(), record)) {
             std::cerr << "Failed to write output, deactivating tracking" << std::endl;
             deactivate();
@@ -1181,7 +1194,12 @@ void
 Tracker::trackDeallocationImpl(void* ptr, size_t size, hooks::Allocator func)
 {
     registerCachedThreadName();
-    AllocationRecord record{reinterpret_cast<uintptr_t>(ptr), size, func};
+    AllocationRecord record{
+            reinterpret_cast<uintptr_t>(ptr),
+            size,
+            func,
+            0,
+            d_allocation_timestamps ? currentTimestampUs() : 0};
     if (!d_writer->writeThreadSpecificRecord(thread_id(), record)) {
         std::cerr << "Failed to write output, deactivating tracking" << std::endl;
         deactivate();
@@ -1482,7 +1500,8 @@ Tracker::createTracker(
         unsigned int memory_interval,
         bool follow_fork,
         bool trace_python_allocators,
-        bool reference_tracking)
+        bool reference_tracking,
+        bool allocation_timestamps)
 {
     s_instance_owner.reset(new Tracker(
             std::move(record_writer),
@@ -1490,7 +1509,8 @@ Tracker::createTracker(
             memory_interval,
             follow_fork,
             trace_python_allocators,
-            reference_tracking));
+            reference_tracking,
+            allocation_timestamps));
 
     StopTheWorldGuard stop_the_world;
     std::unique_lock<std::mutex> lock(*s_mutex);
@@ -1511,6 +1531,14 @@ Tracker*
 Tracker::getTracker()
 {
     return s_instance;
+}
+
+uint64_t
+Tracker::currentTimestampUs() const
+{
+    return std::chrono::duration_cast<std::chrono::microseconds>(
+                   std::chrono::steady_clock::now() - d_monotonic_start)
+            .count();
 }
 
 static struct

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -4,6 +4,7 @@
 #include <Python.h>
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstddef>
 #include <fstream>
@@ -243,7 +244,8 @@ class Tracker
             unsigned int memory_interval,
             bool follow_fork,
             bool trace_python_allocators,
-            bool reference_tracking);
+            bool reference_tracking,
+            bool allocation_timestamps);
     static PyObject* destroyTracker();
     static Tracker* getTracker();
 
@@ -446,8 +448,10 @@ class Tracker
     const bool d_follow_fork;
     const bool d_trace_python_allocators;
     const bool d_reference_tracking;
+    const bool d_allocation_timestamps;
     linker::SymbolPatcher d_patcher;
     std::unique_ptr<BackgroundThread> d_background_thread;
+    const std::chrono::steady_clock::time_point d_monotonic_start{std::chrono::steady_clock::now()};
 
     std::unordered_map<PyCodeObject*, code_object_id_t> d_code_object_cache;
     code_object_id_t d_next_code_object_id{1};
@@ -480,9 +484,11 @@ class Tracker
             unsigned int memory_interval,
             bool follow_fork,
             bool trace_python_allocators,
-            bool reference_tracking);
+            bool reference_tracking,
+            bool allocation_timestamps);
 
     static bool areNativeTracesEnabled();
+    uint64_t currentTimestampUs() const;
 };
 
 }  // namespace memray::tracking_api

--- a/src/memray/_memray/tracking_api.pxd
+++ b/src/memray/_memray/tracking_api.pxd
@@ -26,6 +26,7 @@ cdef extern from "tracking_api.h" namespace "memray::tracking_api":
             bool follow_fork,
             bool trace_pymalloc,
             bool reference_tracking,
+            bool allocation_timestamps,
         ) except+
 
         @staticmethod

--- a/src/memray/_metadata.py
+++ b/src/memray/_metadata.py
@@ -22,3 +22,4 @@ class Metadata:
     has_native_traces: bool
     trace_python_allocators: bool
     file_format: FileFormat
+    has_allocation_timestamps: bool = False

--- a/src/memray/commands/run.py
+++ b/src/memray/commands/run.py
@@ -48,6 +48,8 @@ def _run_tracker(
             kwargs["follow_fork"] = True
         if args.trace_python_allocators:
             kwargs["trace_python_allocators"] = True
+        if args.allocation_timestamps:
+            kwargs["allocation_timestamps"] = True
         if args.aggregate:
             kwargs["file_format"] = FileFormat.AGGREGATED_ALLOCATIONS
         tracker = Tracker(destination=destination, native_traces=args.native, **kwargs)
@@ -90,6 +92,7 @@ def _child_process(
     port: int,
     native: bool,
     trace_python_allocators: bool,
+    allocation_timestamps: bool,
     run_as_module: bool,
     run_as_cmd: bool,
     quiet: bool,
@@ -99,6 +102,7 @@ def _child_process(
     args = argparse.Namespace(
         native=native,
         trace_python_allocators=trace_python_allocators,
+        allocation_timestamps=allocation_timestamps,
         follow_fork=False,
         aggregate=False,
         run_as_module=run_as_module,
@@ -118,7 +122,7 @@ def _run_child_process_and_attach(args: argparse.Namespace) -> None:
         raise MemrayCommandError(f"Invalid port: {port}", exit_code=1)
 
     arguments = (
-        f"{port},{args.native},{args.trace_python_allocators},"
+        f"{port},{args.native},{args.trace_python_allocators},{args.allocation_timestamps},"
         f"{args.run_as_module},{args.run_as_cmd},{args.quiet},"
         f"{args.script!r},{args.script_args}"
     )
@@ -259,6 +263,12 @@ class RunCommand:
             default=False,
         )
         parser.add_argument(
+            "--allocation-timestamps",
+            action="store_true",
+            help="Record a timestamp for every allocation and deallocation event",
+            default=False,
+        )
+        parser.add_argument(
             "-q",
             "--quiet",
             help="Don't show any tracking-specific output while running",
@@ -333,6 +343,8 @@ class RunCommand:
             parser.error("--follow-fork cannot be used with the live TUI")
         if args.aggregate and (args.live_mode or args.live_remote_mode):
             parser.error("--aggregate cannot be used with the live TUI")
+        if args.aggregate and args.allocation_timestamps:
+            parser.error("--allocation-timestamps requires non-aggregated output")
         with contextlib.suppress(OSError):
             if args.run_as_cmd and pathlib.Path(args.script).exists():
                 parser.error("remove the option -c to run a file")

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -105,3 +105,33 @@ def test_aggregated_capture_with_socket_destination():
             file_format=FileFormat.AGGREGATED_ALLOCATIONS,
         ):  # pragma: no cover
             pass
+
+
+def test_allocation_timestamps_are_exposed_in_records(tmp_path):
+    allocator = MemoryAllocator()
+    result_file = tmp_path / "test.bin"
+
+    with Tracker(result_file, allocation_timestamps=True):
+        allocator.valloc(1234)
+        allocator.free()
+
+    with FileReader(result_file) as reader:
+        records = list(filter_relevant_allocations(reader.get_allocation_records()))
+        assert reader.metadata.has_allocation_timestamps is True
+
+    assert len(records) == 2
+    assert records[0].timestamp_us > 0
+    assert records[1].timestamp_us >= records[0].timestamp_us
+
+
+def test_allocation_timestamps_require_all_allocations(tmp_path):
+    result_file = tmp_path / "test.bin"
+
+    with pytest.raises(
+        RuntimeError, match="allocation_timestamps requires FileFormat.ALL_ALLOCATIONS"
+    ):
+        Tracker(
+            result_file,
+            allocation_timestamps=True,
+            file_format=FileFormat.AGGREGATED_ALLOCATIONS,
+        )

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,5 +1,7 @@
 """Tests for exercising the public API."""
 
+import time
+
 import pytest
 
 from memray import FileDestination
@@ -112,7 +114,9 @@ def test_allocation_timestamps_are_exposed_in_records(tmp_path):
     result_file = tmp_path / "test.bin"
 
     with Tracker(result_file, allocation_timestamps=True):
+        time.sleep(0.001)
         allocator.valloc(1234)
+        time.sleep(0.001)
         allocator.free()
 
     with FileReader(result_file) as reader:
@@ -121,7 +125,7 @@ def test_allocation_timestamps_are_exposed_in_records(tmp_path):
 
     assert len(records) == 2
     assert records[0].timestamp_us > 0
-    assert records[1].timestamp_us >= records[0].timestamp_us
+    assert records[1].timestamp_us > records[0].timestamp_us
 
 
 def test_allocation_timestamps_require_all_allocations(tmp_path):

--- a/tests/integration/test_record_writer.py
+++ b/tests/integration/test_record_writer.py
@@ -142,7 +142,7 @@ def test_write_basic_records(tmp_path):
 
     assert header_fields == [
         ("magic", "memray"),
-        ("version", "12"),
+        ("version", "13"),
         ("python_version", f"{sys.hexversion:08x}"),
         ("native_traces", "true"),
         ("file_format", "ALL_ALLOCATIONS"),
@@ -157,6 +157,7 @@ def test_write_basic_records(tmp_path):
         ("python_allocator", allocator),
         ("trace_python_allocators", "true"),
         ("track_object_lifetimes", "false"),
+        ("has_allocation_timestamps", "false"),
     ]
 
     expected_parse_output = """
@@ -193,6 +194,40 @@ def test_write_basic_records(tmp_path):
 
     expected_records = textwrap.dedent(expected_parse_output).strip().splitlines()
     assert records == expected_records
+
+
+def test_write_basic_records_with_allocation_timestamps(tmp_path):
+    output_file = tmp_path / "timestamps.memray"
+
+    writer = RecordWriterTestHarness(
+        str(output_file),
+        file_format=FileFormat.ALL_ALLOCATIONS,
+        allocation_timestamps=True,
+    )
+
+    assert writer.write_allocation_record(
+        1, 0x1000, 1024, AllocatorType.MALLOC, timestamp_us=11
+    )
+    assert writer.write_allocation_record(
+        1, 0x1000, 0, AllocatorType.FREE, timestamp_us=29
+    )
+    assert writer.write_trailer()
+
+    header_fields, records = parse_capture_file(output_file)
+
+    assert dict(header_fields)["has_allocation_timestamps"] == "true"
+    assert records == [
+        "CONTEXT_SWITCH tid=1",
+        (
+            "ALLOCATION address=0x1000 size=1024 allocator=malloc "
+            "native_frame_id=0 timestamp_us=11"
+        ),
+        (
+            "ALLOCATION address=0x1000 size=0 allocator=free "
+            "native_frame_id=0 timestamp_us=29"
+        ),
+        "TRAILER",
+    ]
 
 
 def test_write_aggregated_records(tmp_path):
@@ -233,7 +268,7 @@ def test_write_aggregated_records(tmp_path):
 
     assert header_fields == [
         ("magic", "memray"),
-        ("version", "12"),
+        ("version", "13"),
         ("python_version", f"{sys.hexversion:08x}"),
         ("native_traces", "false"),
         ("file_format", "AGGREGATED_ALLOCATIONS"),
@@ -248,6 +283,7 @@ def test_write_aggregated_records(tmp_path):
         ("python_allocator", allocator),
         ("trace_python_allocators", "false"),
         ("track_object_lifetimes", "false"),
+        ("has_allocation_timestamps", "false"),
     ]
 
     records = sort_runs_of_same_record_type(records)

--- a/tests/integration/test_record_writer.py
+++ b/tests/integration/test_record_writer.py
@@ -205,11 +205,14 @@ def test_write_basic_records_with_allocation_timestamps(tmp_path):
         allocation_timestamps=True,
     )
 
+    # The two clock advances are 63 (packed into the flag bits) and 64 (the
+    # first value that must use the sentinel + trailing varint), exercising both
+    # CLOCK_ADVANCED encodings.
     assert writer.write_allocation_record(
-        1, 0x1000, 1024, AllocatorType.MALLOC, timestamp_us=11
+        1, 0x1000, 1024, AllocatorType.MALLOC, timestamp_us=63
     )
     assert writer.write_allocation_record(
-        1, 0x1000, 0, AllocatorType.FREE, timestamp_us=29
+        1, 0x1000, 0, AllocatorType.FREE, timestamp_us=127
     )
     assert writer.write_trailer()
 
@@ -218,13 +221,15 @@ def test_write_basic_records_with_allocation_timestamps(tmp_path):
     assert dict(header_fields)["has_allocation_timestamps"] == "true"
     assert records == [
         "CONTEXT_SWITCH tid=1",
+        "CLOCK_ADVANCED us=63",
         (
             "ALLOCATION address=0x1000 size=1024 allocator=malloc "
-            "native_frame_id=0 timestamp_us=11"
+            "native_frame_id=0 timestamp_us=63"
         ),
+        "CLOCK_ADVANCED us=64",
         (
             "ALLOCATION address=0x1000 size=0 allocator=free "
-            "native_frame_id=0 timestamp_us=29"
+            "native_frame_id=0 timestamp_us=127"
         ),
         "TRAILER",
     ]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -80,6 +80,20 @@ class TestRunSubCommand:
             trace_python_allocators=True,
         )
 
+    def test_run_with_allocation_timestamps(
+        self, getpid_mock, runpy_mock, tracker_mock, validate_mock
+    ):
+        getpid_mock.return_value = 0
+        assert 0 == main(["run", "--allocation-timestamps", "-m", "foobar"])
+        runpy_mock.run_module.assert_called_with(
+            "foobar", run_name="__main__", alter_sys=True
+        )
+        tracker_mock.assert_called_with(
+            destination=FileDestination("memray-foobar.0.bin", overwrite=False),
+            native_traces=False,
+            allocation_timestamps=True,
+        )
+
     def test_run_override_output(
         self, getpid_mock, runpy_mock, tracker_mock, validate_mock
     ):
@@ -168,7 +182,7 @@ class TestRunSubCommand:
                 sys.executable,
                 "-c",
                 "from memray.commands.run import _child_process;"
-                "_child_process(1234,False,False,False,False,False,"
+                "_child_process(1234,False,False,False,False,False,False,"
                 "'./directory/foobar.py',['arg1', 'arg2'])",
             ],
             stderr=-1,
@@ -209,7 +223,7 @@ class TestRunSubCommand:
                 sys.executable,
                 "-c",
                 "from memray.commands.run import _child_process;"
-                "_child_process(1234,False,True,False,False,False,"
+                "_child_process(1234,False,True,False,False,False,False,"
                 "'./directory/foobar.py',['arg1', 'arg2'])",
             ],
             stderr=-1,
@@ -330,6 +344,15 @@ class TestRunSubCommand:
             native_traces=False,
             trace_python_allocators=True,
         )
+
+    def test_run_with_aggregate_and_allocation_timestamps(
+        self, getpid_mock, runpy_mock, tracker_mock, validate_mock, capsys
+    ):
+        with pytest.raises(SystemExit):
+            main(["run", "--aggregate", "--allocation-timestamps", "-m", "foobar"])
+
+        captured = capsys.readouterr()
+        assert "--allocation-timestamps requires non-aggregated output" in captured.err
 
 
 class TestFlamegraphSubCommand:

--- a/tests/unit/test_stats_reporter.py
+++ b/tests/unit/test_stats_reporter.py
@@ -438,11 +438,12 @@ def test_stats_output_json(fake_stats, tmp_path):
             "peak_memory": 1500000,
             "command_line": "fake stats",
             "pid": 123456,
+            "main_thread_id": 0x1,
             "python_allocator": "pymalloc",
             "has_native_traces": False,
             "trace_python_allocators": True,
             "file_format": 0,
-            "main_thread_id": 0x1,
+            "has_allocation_timestamps": False,
         },
     }
     actual = json.loads(output_file.read_text())


### PR DESCRIPTION
This was originally included in #899, but was dropped when we realized these timestamps weren't actually necessary for the report we wanted to generate. Since we had already put in all the work to get the timestamp recording into a production-worthy state, I'm putting up this PR so that we can resurrect the timestamps if we ever do need them.