### PR TITLE
Fix deadlocks in the GDB attach script

### DIFF
--- a/news/966.bugfix.rst
+++ b/news/966.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a potential deadlock in the gdb backend for ``memray attach``.

--- a/src/memray/commands/_attach.gdb
+++ b/src/memray/commands/_attach.gdb
@@ -15,7 +15,6 @@ p PyMem_Realloc
 p PyMem_Free
 
 p "MEMRAY: Process is Python 3.7+."
-set scheduler-locking on
 call (int)Py_AddPendingCall(&PyCallable_Check, (void*)0)
 
 p "Checking if we can access the library"
@@ -47,5 +46,4 @@ commands 1-10
     eval "sharedlibrary %s", $libpath
     p (int)memray_spawn_client($port) ? "FAILURE" : "SUCCESS"
 end
-set scheduler-locking off
 continue


### PR DESCRIPTION
We're getting deadlocks in the test suite on Alpine that are caused by the GDB attach script hanging while trying to make function calls in the context of the inferior process.

It's not safe to make these calls with scheduler-locking enabled, since that prevents other threads that may be holding mutexes from running and releasing those mutexes, which can mean that when we make these calls, the thread we're running in isn't able to acquire a lock it needs in order to advance, and the GDB scheduler locking is preventing the resource our thread needs from ever being released by another thread.

This locking seems to result in an worse problem than what we were trying to fix when we added it.
