### PR TITLE
ci: Use Alpine's packaged libdebuginfod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,18 +53,7 @@ jobs:
           persist-credentials: false
       - name: Set up dependencies
         run: |
-          apk add --update build-base libunwind-dev lz4-dev musl-dev python3-dev python3-dbg gdb lldb git bash perl perl-datetime build-base perl-app-cpanminus
-          cpanm Date::Parse
-          cpanm Capture::Tiny
-          # Build elfutils
-          cd /
-          apk add --update argp-standalone bison bsd-compat-headers bzip2-dev curl curl-dev flex-dev libtool linux-headers musl-fts-dev musl-libintl musl-obstack-dev xz-dev zlib-dev zstd-dev
-          VERS=0.191
-          curl -L https://mirrors.kernel.org/sourceware/elfutils/$VERS/elfutils-$VERS.tar.bz2 >./elfutils.tar.bz2
-          tar -xf elfutils.tar.bz2
-          cd elfutils-$VERS
-          CFLAGS='-Wno-error -DFNM_EXTMATCH=0 -g -O3' CXXFLAGS='-Wno-error -DFNM_EXTMATCH=0 -g -O3' ./configure --enable-libdebuginfod --disable-debuginfod --disable-nls --with-zstd
-          make install
+          apk add --update build-base libunwind-dev lz4-dev musl-dev python3-dev python3-dbg gdb lldb elfutils-dev libdebuginfod
       - name: Create virtual environment
         run: |
           python3 -m venv /venv


### PR DESCRIPTION
We've been building this from source because at the time when we added a hard dependency on libdebuginfod it wasn't packaged for Alpine yet, but now it is and we can simplify - and incidentally, upgrade to a more recent version than we've been building.
