### PR TITLE
Avoid duplicating an error message

### DIFF
--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -998,8 +998,10 @@ Tracker::BackgroundThread::captureMemorySnapshot()
 
     std::lock_guard<std::mutex> lock(*s_mutex);
     if (!d_writer->writeRecord(MemoryRecord{now, rss})) {
-        std::cerr << "Failed to write output, deactivating tracking" << std::endl;
-        Tracker::deactivate();
+        if (Tracker::isActive()) {
+            std::cerr << "Failed to write output, deactivating tracking" << std::endl;
+            Tracker::deactivate();
+        }
         return false;
     }
 


### PR DESCRIPTION
When you run `memray --live-remote` with a script that runs indefinitely and then connect to the server from another terminal, the tracker currently writes two different error messages about the broken socket if you quit the GUI. First, it complains when it fails to write some allocation record, and then it complains again when its RSS-tracking background thread fails to write a periodic checkpoint a few milliseconds later.

Make the background thread recognize when we've already encountered a fatal error and stopped tracking, to avoid having it duplicate an error we already displayed.
