### PR TITLE
Pass IFrame path to IPython as a str

### DIFF
--- a/news/981.bugfix.rst
+++ b/news/981.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the ``%%memray_flamegraph`` :ref:`Jupyter magic <Jupyter integration>` to correctly embed a flame graph when used with IPython 9.16.0 (a regression in that version broke our integration; it was fixed in IPython 9.16.1).

--- a/src/memray/_ipython/flamegraph.py
+++ b/src/memray/_ipython/flamegraph.py
@@ -242,7 +242,7 @@ class FlamegraphMagics(Magics):
             )
         dump_file.unlink()
         pprint(f"Results saved to [bold cyan]{flamegraph_path}")
-        _display_iframe(IFrame(flamegraph_path, width="100%", height="600"))
+        _display_iframe(IFrame(str(flamegraph_path), width="100%", height="600"))
 
 
 assert FlamegraphMagics.memray_flamegraph.__doc__ is not None


### PR DESCRIPTION
Previously it was being passed as a `pathlib.Path` instead, but as of IPython 9.16.0 that no longer works.

This works around an issue that was reported to the IPython folks as https://github.com/ipython/ipython/issues/15345