### PR TITLE
Record module search paths while tracking

### DIFF
--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -800,6 +800,15 @@ cdef class Tracker:
             )
 
         cdef cppstring command_line = " ".join(sys.argv)
+
+        # Record the traced process's search paths. Reporters will use them for
+        # classifying filenames to module names.
+        from memray.reporters.module_tools import get_python_path_info
+        path_info = get_python_path_info()
+        py_libdest = os.path.abspath(path_info["stdlib"]) if path_info["stdlib"] else ""
+        py_site_packages = [os.path.abspath(p) for p in path_info["site_packages"]]
+        py_sys_path = [os.path.abspath(p) for p in path_info["sys_path"]]
+
         self._native_traces = native_traces
         self._track_object_lifetimes = track_object_lifetimes
         self._memory_interval_ms = memory_interval_ms
@@ -824,6 +833,9 @@ cdef class Tracker:
                 file_format,
                 trace_python_allocators,
                 track_object_lifetimes,
+                py_libdest,
+                py_site_packages,
+                py_sys_path,
             )
         )
 
@@ -1576,7 +1588,13 @@ def compute_statistics(
 
     # Resolve each distinct call stack to a module name, adding its aggregated
     # counts into the per-module totals.
-    module_resolver = ModuleResolver()
+    module_resolver = ModuleResolver(
+        {
+            "stdlib": pathlib.Path(header["libdest"]) if header["libdest"] else None,
+            "site_packages": [pathlib.Path(p) for p in header["site_packages"]],
+            "sys_path": [pathlib.Path(p) for p in header["sys_path"]],
+        }
+    )
     module_stats = {}  # module -> [num_allocations, total_bytes]
     cdef pair[size_t, pair[size_t, size_t]] stack_stats
     for stack_stats in stats_by_stack:
@@ -1877,6 +1895,9 @@ cdef class RecordWriterTestHarness:
         records.thread_id_t main_tid=1,
         size_t skipped_frames=0,
         str command_line="memray test harness",
+        str libdest="",
+        list site_packages=[],
+        list sys_path=[],
     ):
         """Initialize a new RecordWriterTestHarness.
 
@@ -1894,6 +1915,9 @@ cdef class RecordWriterTestHarness:
             file_format,
             trace_python_allocators,
             track_object_lifetimes,
+            libdest,
+            site_packages,
+            sys_path,
         )
         self._writer.get().setMainTidAndSkippedFrames(main_tid, skipped_frames)
         self.write_header(False)

--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -102,6 +102,25 @@ RecordReader::readHeader(HeaderRecord& header)
     {
         throw std::ios_base::failure("Failed to read input file header.");
     }
+
+    // The traced process's module search paths. libdest is a single string;
+    // each vector is a run of null-terminated strings ended by an empty string.
+    // This works because vector entries are absolute paths and can't be empty.
+    if (!d_input->getline(header.libdest, '\0')) {
+        throw std::ios_base::failure("Failed to read input file header.");
+    }
+    for (std::vector<std::string>* paths : {&header.site_packages, &header.sys_path}) {
+        while (true) {
+            std::string entry;
+            if (!d_input->getline(entry, '\0')) {
+                throw std::ios_base::failure("Failed to read input file header.");
+            }
+            if (entry.empty()) {
+                break;
+            }
+            paths->push_back(std::move(entry));
+        }
+    }
 }
 
 bool
@@ -1147,11 +1166,32 @@ RecordReader::dumpAllRecords()
             file_format = "<unknown enum value " + std::to_string((int)d_header.file_format) + ">";
         } break;
     }
+
+    std::ostringstream site_packages;
+    site_packages << "[";
+    for (size_t i = 0; i < d_header.site_packages.size(); ++i) {
+        if (i >= 1) {
+            site_packages << ", ";
+        }
+        site_packages << d_header.site_packages[i];
+    }
+    site_packages << "]";
+
+    std::ostringstream sys_path;
+    sys_path << "[";
+    for (size_t i = 0; i < d_header.sys_path.size(); ++i) {
+        if (i >= 1) {
+            sys_path << ", ";
+        }
+        sys_path << d_header.sys_path[i];
+    }
+    sys_path << "]";
+
     printf("HEADER magic=%.*s version=%d python_version=%08x native_traces=%s file_format=%s"
            " n_allocations=%zd n_frames=%zd start_time=%lld end_time=%lld"
            " pid=%d main_tid=%lu skipped_frames_on_main_tid=%zd"
            " command_line=%s python_allocator=%s trace_python_allocators=%s"
-           " track_object_lifetimes=%s\n",
+           " track_object_lifetimes=%s libdest=%s site_packages=%s sys.path=%s\n",
            (int)sizeof(d_header.magic),
            d_header.magic,
            d_header.version,
@@ -1168,7 +1208,10 @@ RecordReader::dumpAllRecords()
            d_header.command_line.c_str(),
            python_allocator.c_str(),
            d_header.trace_python_allocators ? "true" : "false",
-           d_header.track_object_lifetimes ? "true" : "false");
+           d_header.track_object_lifetimes ? "true" : "false",
+           d_header.libdest.c_str(),
+           site_packages.str().c_str(),
+           sys_path.str().c_str());
 
     switch (d_header.file_format) {
         case FileFormat::ALL_ALLOCATIONS:

--- a/src/memray/_memray/record_writer.cpp
+++ b/src/memray/_memray/record_writer.cpp
@@ -65,7 +65,10 @@ class StreamingRecordWriter : public RecordWriter
             const std::string& command_line,
             bool native_traces,
             bool trace_python_allocators,
-            bool track_object_lifetimes);
+            bool track_object_lifetimes,
+            const std::string& libdest,
+            const std::vector<std::string>& site_packages,
+            const std::vector<std::string>& sys_path);
 
     StreamingRecordWriter(StreamingRecordWriter& other) = delete;
     StreamingRecordWriter(StreamingRecordWriter&& other) = delete;
@@ -128,7 +131,10 @@ class AggregatingRecordWriter : public RecordWriter
             const std::string& command_line,
             bool native_traces,
             bool trace_python_allocators,
-            bool track_object_lifetimes);
+            bool track_object_lifetimes,
+            const std::string& libdest,
+            const std::vector<std::string>& site_packages,
+            const std::vector<std::string>& sys_path);
 
     AggregatingRecordWriter(StreamingRecordWriter& other) = delete;
     AggregatingRecordWriter(StreamingRecordWriter&& other) = delete;
@@ -181,7 +187,10 @@ createRecordWriter(
         bool native_traces,
         FileFormat file_format,
         bool trace_python_allocators,
-        bool track_object_lifetimes)
+        bool track_object_lifetimes,
+        const std::string& libdest,
+        const std::vector<std::string>& site_packages,
+        const std::vector<std::string>& sys_path)
 {
     switch (file_format) {
         case FileFormat::ALL_ALLOCATIONS:
@@ -190,14 +199,20 @@ createRecordWriter(
                     command_line,
                     native_traces,
                     trace_python_allocators,
-                    track_object_lifetimes);
+                    track_object_lifetimes,
+                    libdest,
+                    site_packages,
+                    sys_path);
         case FileFormat::AGGREGATED_ALLOCATIONS:
             return std::make_unique<AggregatingRecordWriter>(
                     std::move(sink),
                     command_line,
                     native_traces,
                     trace_python_allocators,
-                    track_object_lifetimes);
+                    track_object_lifetimes,
+                    libdest,
+                    site_packages,
+                    sys_path);
         default:
             throw std::runtime_error("Invalid file format enumerator");
     }
@@ -208,7 +223,10 @@ StreamingRecordWriter::StreamingRecordWriter(
         const std::string& command_line,
         bool native_traces,
         bool trace_python_allocators,
-        bool track_object_lifetimes)
+        bool track_object_lifetimes,
+        const std::string& libdest,
+        const std::vector<std::string>& site_packages,
+        const std::vector<std::string>& sys_path)
 : RecordWriter(std::move(sink))
 , d_stats({0, 0, duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count()})
 {
@@ -225,7 +243,10 @@ StreamingRecordWriter::StreamingRecordWriter(
             0,
             getPythonAllocator(),
             trace_python_allocators,
-            track_object_lifetimes};
+            track_object_lifetimes,
+            libdest,
+            site_packages,
+            sys_path};
     strncpy(d_header.magic, MAGIC, sizeof(d_header.magic));
 }
 
@@ -493,6 +514,23 @@ RecordWriter::writeHeaderCommon(const HeaderRecord& header)
     {
         return false;
     }
+
+    // The traced process's module search paths. Each vector is written as a
+    // sequence of null-terminated strings followed by an empty-string sentinel;
+    // since these hold absolute paths, an empty string can only mean "end".
+    if (!writeString(header.libdest.c_str())) {
+        return false;
+    }
+    for (const auto& paths : {header.site_packages, header.sys_path}) {
+        for (const auto& path : paths) {
+            if (!writeString(path.c_str())) {
+                return false;
+            }
+        }
+        if (!writeString("")) {
+            return false;
+        }
+    }
     return true;
 }
 
@@ -517,7 +555,10 @@ StreamingRecordWriter::cloneInChildProcess()
             d_header.command_line,
             d_header.native_traces,
             d_header.trace_python_allocators,
-            d_header.track_object_lifetimes);
+            d_header.track_object_lifetimes,
+            d_header.libdest,
+            d_header.site_packages,
+            d_header.sys_path);
 }
 
 AggregatingRecordWriter::AggregatingRecordWriter(
@@ -525,7 +566,10 @@ AggregatingRecordWriter::AggregatingRecordWriter(
         const std::string& command_line,
         bool native_traces,
         bool trace_python_allocators,
-        bool track_object_lifetimes)
+        bool track_object_lifetimes,
+        const std::string& libdest,
+        const std::vector<std::string>& site_packages,
+        const std::vector<std::string>& sys_path)
 : RecordWriter(std::move(sink))
 {
     memcpy(d_header.magic, MAGIC, sizeof(d_header.magic));
@@ -538,6 +582,9 @@ AggregatingRecordWriter::AggregatingRecordWriter(
     d_header.python_allocator = getPythonAllocator();
     d_header.trace_python_allocators = trace_python_allocators;
     d_header.track_object_lifetimes = track_object_lifetimes;
+    d_header.libdest = libdest;
+    d_header.site_packages = site_packages;
+    d_header.sys_path = sys_path;
 
     d_stats.start_time = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 }
@@ -675,7 +722,10 @@ AggregatingRecordWriter::cloneInChildProcess()
             d_header.command_line,
             d_header.native_traces,
             d_header.trace_python_allocators,
-            d_header.track_object_lifetimes);
+            d_header.track_object_lifetimes,
+            d_header.libdest,
+            d_header.site_packages,
+            d_header.sys_path);
 }
 
 bool

--- a/src/memray/_memray/record_writer.h
+++ b/src/memray/_memray/record_writer.h
@@ -64,7 +64,10 @@ createRecordWriter(
         bool native_traces,
         FileFormat file_format,
         bool trace_python_allocators,
-        bool track_object_lifetimes);
+        bool track_object_lifetimes,
+        const std::string& libdest,
+        const std::vector<std::string>& site_packages,
+        const std::vector<std::string>& sys_path);
 
 template<typename T>
 bool inline RecordWriter::writeSimpleType(const T& item)

--- a/src/memray/_memray/record_writer.pxd
+++ b/src/memray/_memray/record_writer.pxd
@@ -55,4 +55,7 @@ cdef extern from "record_writer.h" namespace "memray::tracking_api":
         FileFormat file_format,
         bool trace_python_allocators,
         bool track_object_lifetimes,
+        string libdest,
+        vector[string] site_packages,
+        vector[string] sys_path,
     ) except+

--- a/src/memray/_memray/records.h
+++ b/src/memray/_memray/records.h
@@ -18,7 +18,7 @@
 namespace memray::tracking_api {
 
 extern const char MAGIC[7];  // Value assigned in records.cpp
-const int CURRENT_HEADER_VERSION = 12;
+const int CURRENT_HEADER_VERSION = 13;
 
 using frame_id_t = size_t;
 using thread_id_t = unsigned long;
@@ -113,6 +113,12 @@ struct HeaderRecord
     PythonAllocatorType python_allocator{};
     bool trace_python_allocators{};
     bool track_object_lifetimes{false};
+    // The traced process's module search paths, captured once when tracking
+    // starts and used by reporters to map filenames to modules. Like
+    // command_line, these must not be mutated while the tracker is running.
+    std::string libdest;
+    std::vector<std::string> site_packages;
+    std::vector<std::string> sys_path;
 };
 
 struct MemoryRecord

--- a/src/memray/_memray/records.pxd
+++ b/src/memray/_memray/records.pxd
@@ -89,6 +89,9 @@ cdef extern from "records.h" namespace "memray::tracking_api":
        int python_allocator
        bool trace_python_allocators
        bool track_object_lifetimes
+       string libdest
+       vector[string] site_packages
+       vector[string] sys_path
 
    cdef cppclass Allocation:
        thread_id_t tid

--- a/tests/integration/test_record_writer.py
+++ b/tests/integration/test_record_writer.py
@@ -89,6 +89,9 @@ def test_write_basic_records(tmp_path):
         file_format=FileFormat.ALL_ALLOCATIONS,
         main_tid=10,
         skipped_frames=15,
+        libdest='/some/path with spaces and a ":" too',
+        site_packages=["/some/path", '/"another"/path too'],
+        sys_path=["/some/path", '/"another"/path too'],
     )
 
     assert writer.write_memory_record(1757101101880, 1024)
@@ -142,7 +145,7 @@ def test_write_basic_records(tmp_path):
 
     assert header_fields == [
         ("magic", "memray"),
-        ("version", "12"),
+        ("version", "13"),
         ("python_version", f"{sys.hexversion:08x}"),
         ("native_traces", "true"),
         ("file_format", "ALL_ALLOCATIONS"),
@@ -157,6 +160,9 @@ def test_write_basic_records(tmp_path):
         ("python_allocator", allocator),
         ("trace_python_allocators", "true"),
         ("track_object_lifetimes", "false"),
+        ("libdest", '/some/path with spaces and a ":" too'),
+        ("site_packages", '[/some/path, /"another"/path too]'),
+        ("sys.path", '[/some/path, /"another"/path too]'),
     ]
 
     expected_parse_output = """
@@ -260,7 +266,7 @@ def test_write_aggregated_records(tmp_path):
 
     assert header_fields == [
         ("magic", "memray"),
-        ("version", "12"),
+        ("version", "13"),
         ("python_version", f"{sys.hexversion:08x}"),
         ("native_traces", "false"),
         ("file_format", "AGGREGATED_ALLOCATIONS"),
@@ -275,6 +281,9 @@ def test_write_aggregated_records(tmp_path):
         ("python_allocator", allocator),
         ("trace_python_allocators", "false"),
         ("track_object_lifetimes", "false"),
+        ("libdest", ""),
+        ("site_packages", "[]"),
+        ("sys.path", "[]"),
     ]
 
     records = sort_runs_of_same_record_type(records)


### PR DESCRIPTION
This allows the `stats` reporter to use the search paths that were active when the tracked process ran, rather than the search paths that are used by the reporter process, for determining a module name and type from its file path. This fixes an issue where we would categorize a module incorrectly if the reporter was run on a different machine or container or from a different virtual environment.
