### PR TITLE
Guide users towards overwriting files

### DIFF
--- a/src/memray/_memray/sink.cpp
+++ b/src/memray/_memray/sink.cpp
@@ -137,6 +137,12 @@ FileSink::FileSink(const std::string& file_name, bool overwrite, bool compress)
         d_fd = ::open(file_name.c_str(), flags, 0644);
     } while (d_fd < 0 && errno == EINTR);
     if (d_fd < 0) {
+        if (errno == EEXIST) {
+            throw IoError{
+                    "Output file " + file_name
+                    + " already exists. Memray can overwrite it with the"
+                      " --force CLI argument or the overwrite=True API argument."};
+        }
         throw IoError{"Could not create output file " + file_name + ": " + std::string(strerror(errno))};
     }
 }
@@ -436,6 +442,12 @@ BufferedFileSink::BufferedFileSink(const std::string& file_name, bool overwrite,
         d_fd = ::open(file_name.c_str(), flags, 0644);
     } while (d_fd < 0 && errno == EINTR);
     if (d_fd < 0) {
+        if (errno == EEXIST) {
+            throw IoError{
+                    "Output file " + file_name
+                    + " already exists. Memray can overwrite it with the"
+                      " --force CLI argument or the overwrite=True API argument."};
+        }
         throw IoError{"Could not create output file " + file_name + ": " + std::string(strerror(errno))};
     }
 }

--- a/src/memray/commands/common.py
+++ b/src/memray/commands/common.py
@@ -136,7 +136,8 @@ class HighWatermarkCommand:
         )
         if not overwrite and output_file.exists():
             raise MemrayCommandError(
-                f"File already exists, will not overwrite: {output_file}",
+                f"File already exists, will not overwrite without --force:"
+                f" {output_file}",
                 exit_code=1,
             )
         return result_path, output_file

--- a/src/memray/commands/stats.py
+++ b/src/memray/commands/stats.py
@@ -83,7 +83,8 @@ class StatsCommand:
 
             if not args.force and json_output_file.exists():
                 raise MemrayCommandError(
-                    f"File already exists, will not overwrite: {json_output_file}",
+                    f"File already exists, will not overwrite without --force:"
+                    f" {json_output_file}",
                     exit_code=1,
                 )
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -529,19 +529,21 @@ class TestRunSubcommand:
         )
 
     @patch("memray.commands.run.os.getpid")
-    def test_run_file_exists(self, getpid, tmp_path, monkeypatch, capsys):
+    @pytest.mark.parametrize("flag", [None, "--buffered-file-io"])
+    def test_run_file_exists(self, getpid, tmp_path, monkeypatch, capsys, flag):
         # GIVEN / WHEN
         getpid.return_value = 0
         (tmp_path / "memray-json.tool.0.bin").touch()
         monkeypatch.chdir(tmp_path)
 
         # THEN
-        assert main(["run", "-m", "json.tool", "-h"]) == 1
+        assert main(["run", *([flag] if flag else ()), "-m", "json.tool", "-h"]) == 1
         captured = capsys.readouterr()
-        assert (
-            captured.err.strip()
-            == "Could not create output file memray-json.tool.0.bin: File exists"
+        expected_error = (
+            "Output file memray-json.tool.0.bin already exists. Memray can overwrite it"
+            " with the --force CLI argument or the overwrite=True API argument."
         )
+        assert captured.err.strip() == expected_error
 
     def test_run_output_file_directory_does_not_exist(self, capsys):
         # GIVEN / WHEN / THEN


### PR DESCRIPTION
Users may not know that the `--force` option exists (or its equivalent `overwrite=True` API argument for `memray.Tracker`). Try to point them to it in our error messages to help them out.

Closes #828 