### PR TITLE
Ensure user code never sees our 3rd party imports

### DIFF
--- a/src/memray/_ipython/flamegraph.py
+++ b/src/memray/_ipython/flamegraph.py
@@ -14,7 +14,6 @@ from IPython.core.magic import cell_magic
 from IPython.core.magic import magics_class
 from IPython.display import IFrame
 from IPython.display import display
-from rich import print as pprint
 
 from memray import FileReader
 from memray.commands.common import warn_if_not_enough_symbols
@@ -141,6 +140,8 @@ class FlamegraphMagics(Magics):
     @_typed_cell_magic
     def memray_flamegraph(self, line: str, cell: str) -> None:
         """Memory profile the code in the cell and display a flame graph."""
+        from rich import print as pprint
+
         if self.shell is None:
             raise UsageError("Cannot profile code when not in a shell")
 

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -10,10 +10,6 @@ cimport cython
 import threading
 from datetime import datetime
 
-from rich import print as pprint
-from rich.progress import Progress
-from rich.progress import SpinnerColumn
-
 from posix.time cimport CLOCK_MONOTONIC
 from posix.time cimport clock_gettime
 from posix.time cimport timespec
@@ -944,6 +940,8 @@ def greenlet_trace_function(event, args):
 
 
 def print_greenlet_warning():
+    from rich import print as pprint
+
     pprint(
         ":warning: [bold red]Memray support for Greenlet is experimental[/] :warning:\n"
         "[yellow]Please report any issues at https://github.com/bloomberg/memray/issues[/]\n"
@@ -1013,6 +1011,9 @@ cdef class ProgressIndicator:
         self._task = None
         self._context_manager = None
         if report_progress:
+            from rich.progress import Progress
+            from rich.progress import SpinnerColumn
+
             self._indicator = Progress(
                 SpinnerColumn(),
                 *Progress.get_default_columns(),

--- a/src/memray/commands/__init__.py
+++ b/src/memray/commands/__init__.py
@@ -1,4 +1,5 @@
 import argparse
+import importlib
 import logging
 import sys
 import textwrap
@@ -15,17 +16,6 @@ except ImportError:
 from memray._errors import MemrayCommandError
 from memray._errors import MemrayError
 from memray._memray import set_log_level
-
-from . import attach
-from . import flamegraph
-from . import live
-from . import parse
-from . import run
-from . import stats
-from . import summary
-from . import table
-from . import transform
-from . import tree
 
 _EPILOG = textwrap.dedent(
     """\
@@ -57,22 +47,53 @@ class Command(Protocol):
         ...
 
 
-_COMMANDS: List[Command] = [
-    run.RunCommand(),
-    flamegraph.FlamegraphCommand(),
-    table.TableCommand(),
-    live.LiveCommand(),
-    tree.TreeCommand(),
-    parse.ParseCommand(),
-    summary.SummaryCommand(),
-    stats.StatsCommand(),
-    transform.TransformCommand(),
-    attach.AttachCommand(),
-    attach.DetachCommand(),
-]
+# Map each subcommand name to the class that implements it. Kept as plain
+# strings so that building the parser (or importing this package, e.g. in the
+# `memray run --live` child) never imports a command module -- and therefore
+# never imports rich/textual/jinja2 -- until the selected command actually runs.
+_COMMANDS = {
+    "run": "memray.commands.run.RunCommand",
+    "flamegraph": "memray.commands.flamegraph.FlamegraphCommand",
+    "table": "memray.commands.table.TableCommand",
+    "live": "memray.commands.live.LiveCommand",
+    "tree": "memray.commands.tree.TreeCommand",
+    "parse": "memray.commands.parse.ParseCommand",
+    "summary": "memray.commands.summary.SummaryCommand",
+    "stats": "memray.commands.stats.StatsCommand",
+    "transform": "memray.commands.transform.TransformCommand",
+    "attach": "memray.commands.attach.AttachCommand",
+    "detach": "memray.commands.attach.DetachCommand",
+}
 
 
-def get_argument_parser() -> argparse.ArgumentParser:
+def _find_command(args: List[str]) -> Optional[str]:
+    """Return the subcommand named in ``args`` without invoking argparse.
+
+    This lets ``main`` configure (and import) only the selected subcommand.
+    Returns None when no command is found, so that the full parser can render
+    top-level help, the version, or an error. Only the global options that take
+    no value (``-v/--verbose``, ``-V/--version``, ``-h/--help``) are understood
+    here; a new value-taking global option would need to be handled too.
+    """
+    for token in args:
+        if token in _COMMANDS:
+            return token
+        if token in ("-h", "--help", "-V", "--version"):
+            return None
+        if token.startswith("-"):
+            continue
+        return None
+    return None
+
+
+def get_argument_parser(command: Optional[str] = None) -> argparse.ArgumentParser:
+    """Build the CLI parser.
+
+    When *command* is None (the default, and how docs/manpage generation calls
+    this) every subcommand is fully configured. When *command* names a specific
+    subcommand, only that one is imported and configured; the others are added
+    as bare subparsers so they remain valid choices in usage/error messages.
+    """
     parser = argparse.ArgumentParser(
         description=_DESCRIPTION,
         prog="memray",
@@ -100,17 +121,21 @@ def get_argument_parser() -> argparse.ArgumentParser:
         required=True,
     )
 
-    for command in _COMMANDS:
-        # Extract the CLI command name from the classes' names
-        assert command.__class__.__name__.endswith("Command")
-        name = command.__class__.__name__[: -len("Command")].lower()
-
-        # Add the subcommand
-        command_parser = subparsers.add_parser(
-            name, help=command.__doc__, description=command.__doc__, epilog=_EPILOG
-        )
-        command_parser.set_defaults(entrypoint=command.run)
-        command.prepare_parser(command_parser)
+    load_all_commands = command is None
+    for name in _COMMANDS:
+        if load_all_commands or name == command:
+            module_name, _, class_name = _COMMANDS[name].rpartition(".")
+            module = importlib.import_module(module_name)
+            cmd = getattr(module, class_name)()
+            command_parser = subparsers.add_parser(
+                name, help=cmd.__doc__, description=cmd.__doc__, epilog=_EPILOG
+            )
+            command_parser.set_defaults(entrypoint=cmd.run)
+            cmd.prepare_parser(command_parser)
+        else:
+            # Register the name without importing it, so it stays a valid
+            # choice and appears in the top-level usage listing.
+            subparsers.add_parser(name, epilog=_EPILOG)
 
     return parser
 
@@ -130,7 +155,7 @@ def main(args: Optional[List[str]] = None) -> int:
     if args is None:
         args = sys.argv[1:]
 
-    parser = get_argument_parser()
+    parser = get_argument_parser(_find_command(args))
     arg_values = parser.parse_args(args=args)
     set_log_level(determine_logging_level_from_verbosity(arg_values.verbose))
 

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -19,7 +19,6 @@ import threading
 import memray
 from memray._errors import MemrayCommandError
 
-from .live import LiveCommand
 from .run import _get_free_port
 
 try:
@@ -581,6 +580,12 @@ class AttachCommand(_DebuggerCommand):
         # already exited. If so we must ignore the extra KeyboardInterrupt.
         error_reader = ErrorReaderThread(client)
         error_reader.start()
+
+        # Imported lazily so that `memray attach -o <file>` (which never shows
+        # the live TUI) doesn't import the TUI, and therefore doesn't import
+        # textual/rich.
+        from .live import LiveCommand
+
         live = LiveCommand()
 
         with contextlib.suppress(KeyboardInterrupt):

--- a/src/memray/commands/common.py
+++ b/src/memray/commands/common.py
@@ -15,8 +15,6 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Protocol
 
-from rich import print as pprint
-
 from memray import AllocationRecord
 from memray import FileReader
 from memray import MemorySnapshot
@@ -57,6 +55,8 @@ class TemporalReporterFactory(Protocol):
 
 
 def warn_if_not_enough_symbols() -> None:
+    from rich import print as pprint
+
     support = get_symbolic_support()
     if support == SymbolicSupport.NONE:
         pprint(
@@ -85,6 +85,8 @@ def warn_if_not_enough_symbols() -> None:
 def warn_if_file_is_not_aggregated_and_is_too_big(
     reader: FileReader, result_path: Path
 ) -> None:
+    from rich import print as pprint
+
     FILE_SIZE_LIMIT = 10 * 1000 * 1000
     if (
         reader.metadata.file_format == FileFormat.ALL_ALLOCATIONS

--- a/src/memray/commands/run.py
+++ b/src/memray/commands/run.py
@@ -21,7 +21,6 @@ from memray import FileFormat
 from memray import SocketDestination
 from memray import Tracker
 from memray._errors import MemrayCommandError
-from memray.commands.live import LiveCommand
 
 
 def _get_free_port() -> int:
@@ -111,6 +110,11 @@ def _child_process(
 
 
 def _run_child_process_and_attach(args: argparse.Namespace) -> None:
+    # Imported lazily so that the common `memray run` paths (and the tracked
+    # child process, which imports this module) never pull in the live TUI,
+    # and therefore never import textual/rich.
+    from memray.commands.live import LiveCommand
+
     port = args.live_port
     if port is None:
         port = _get_free_port()

--- a/src/memray/commands/transform.py
+++ b/src/memray/commands/transform.py
@@ -3,8 +3,6 @@ import importlib.util
 import shutil
 import sys
 
-from rich import print as pprint
-
 from memray._errors import MemrayCommandError
 
 from ..reporters.transform import TransformReporter
@@ -47,6 +45,8 @@ class TransformCommand(HighWatermarkCommand):
             post_run_callable()
 
     def post_run_gprof2dot(self) -> None:
+        from rich import print as pprint
+
         assert self.output_file is not None
         command = ""
         if shutil.which("gprof2dot") is not None:

--- a/src/memray/reporters/common.py
+++ b/src/memray/reporters/common.py
@@ -1,3 +1,10 @@
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import DefaultDict
+from typing import Dict
+from typing import Iterable
+from typing import Optional
+from typing import Set
 from typing import Union
 
 from memray._memray import AllocationRecord
@@ -12,3 +19,67 @@ def format_thread_name(
     name = record.thread_name
     thread_id = hex(record.tid)
     return f"{thread_id} ({name})" if name else f"{thread_id}"
+
+
+@dataclass(frozen=True)
+class Location:
+    function: str
+    file: str
+
+
+@dataclass
+class AllocationEntry:
+    own_memory: int
+    total_memory: int
+    n_allocations: int
+    thread_ids: Set[int]
+
+
+def aggregate_allocations(
+    allocations: Iterable[AllocationRecord],
+    memory_threshold: float = float("inf"),
+    native_traces: Optional[bool] = False,
+) -> Dict[Location, AllocationEntry]:
+    """Take allocation records and for each frame contained, record "own"
+    allocations which happened on the frame, and sum up allocations on
+    all of the child frames to calculate "total" allocations."""
+
+    processed_allocations: DefaultDict[Location, AllocationEntry] = defaultdict(
+        lambda: AllocationEntry(
+            own_memory=0, total_memory=0, n_allocations=0, thread_ids=set()
+        )
+    )
+
+    current_total = 0
+    for allocation in allocations:
+        if current_total >= memory_threshold:
+            break
+        current_total += allocation.size
+
+        stack_trace = list(
+            allocation.hybrid_stack_trace()
+            if native_traces
+            else allocation.stack_trace()
+        )
+        if not stack_trace:
+            frame = processed_allocations[Location(function="???", file="???")]
+            frame.total_memory += allocation.size
+            frame.own_memory += allocation.size
+            frame.n_allocations += allocation.n_allocations
+            frame.thread_ids.add(allocation.tid)
+            continue
+
+        # Walk upwards and sum totals
+        visited = set()
+        for i, (function, file_name, _) in enumerate(stack_trace):
+            location = Location(function=function, file=file_name)
+            frame = processed_allocations[location]
+            if location in visited:
+                continue
+            visited.add(location)
+            if i == 0:
+                frame.own_memory += allocation.size
+            frame.total_memory += allocation.size
+            frame.n_allocations += allocation.n_allocations
+            frame.thread_ids.add(allocation.tid)
+    return processed_allocations

--- a/src/memray/reporters/stats.py
+++ b/src/memray/reporters/stats.py
@@ -11,8 +11,6 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-import rich
-
 from memray._memray import size_fmt
 from memray._stats import Stats
 
@@ -121,6 +119,8 @@ class StatsReporter:
             self._render_to_terminal(histogram_params)
 
     def _render_to_terminal(self, histogram_params: Dict[str, int]) -> None:
+        import rich
+
         rich.print("📏 [bold]Total allocations:[/]")
         print(f"\t{self._stats.total_num_allocations}")
 

--- a/src/memray/reporters/summary.py
+++ b/src/memray/reporters/summary.py
@@ -10,7 +10,7 @@ from rich.table import Table
 
 from memray import AllocationRecord
 from memray._memray import size_fmt
-from memray.reporters.tui import aggregate_allocations
+from memray.reporters.common import aggregate_allocations
 
 MAX_MEMORY_RATIO = 0.95
 DEFAULT_TERMINAL_LINES = 24

--- a/src/memray/reporters/tui.py
+++ b/src/memray/reporters/tui.py
@@ -3,19 +3,15 @@ import os
 import pathlib
 import sys
 import threading
-from collections import defaultdict
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
 from functools import total_ordering
 from math import ceil
 from typing import Any
-from typing import DefaultDict
 from typing import Dict
-from typing import Iterable
 from typing import List
 from typing import Optional
-from typing import Set
 from typing import Tuple
 from typing import cast
 
@@ -50,22 +46,11 @@ from memray._memray import size_fmt
 from memray.reporters._textual_hacks import Bindings
 from memray.reporters._textual_hacks import redraw_footer
 from memray.reporters._textual_hacks import update_key_description
+from memray.reporters.common import AllocationEntry
+from memray.reporters.common import Location
+from memray.reporters.common import aggregate_allocations
 
 MAX_MEMORY_RATIO = 0.95
-
-
-@dataclass(frozen=True)
-class Location:
-    function: str
-    file: str
-
-
-@dataclass
-class AllocationEntry:
-    own_memory: int
-    total_memory: int
-    n_allocations: int
-    thread_ids: Set[int]
 
 
 @dataclass(frozen=True, eq=False)
@@ -192,56 +177,6 @@ class SortableText(Text):
         if type(other) != SortableText:
             return NotImplemented
         return cast(bool, self.value == other.value)
-
-
-def aggregate_allocations(
-    allocations: Iterable[AllocationRecord],
-    memory_threshold: float = float("inf"),
-    native_traces: Optional[bool] = False,
-) -> Dict[Location, AllocationEntry]:
-    """Take allocation records and for each frame contained, record "own"
-    allocations which happened on the frame, and sum up allocations on
-    all of the child frames to calculate "total" allocations."""
-
-    processed_allocations: DefaultDict[Location, AllocationEntry] = defaultdict(
-        lambda: AllocationEntry(
-            own_memory=0, total_memory=0, n_allocations=0, thread_ids=set()
-        )
-    )
-
-    current_total = 0
-    for allocation in allocations:
-        if current_total >= memory_threshold:
-            break
-        current_total += allocation.size
-
-        stack_trace = list(
-            allocation.hybrid_stack_trace()
-            if native_traces
-            else allocation.stack_trace()
-        )
-        if not stack_trace:
-            frame = processed_allocations[Location(function="???", file="???")]
-            frame.total_memory += allocation.size
-            frame.own_memory += allocation.size
-            frame.n_allocations += allocation.n_allocations
-            frame.thread_ids.add(allocation.tid)
-            continue
-
-        # Walk upwards and sum totals
-        visited = set()
-        for i, (function, file_name, _) in enumerate(stack_trace):
-            location = Location(function=function, file=file_name)
-            frame = processed_allocations[location]
-            if location in visited:
-                continue
-            visited.add(location)
-            if i == 0:
-                frame.own_memory += allocation.size
-            frame.total_memory += allocation.size
-            frame.n_allocations += allocation.n_allocations
-            frame.thread_ids.add(allocation.tid)
-    return processed_allocations
 
 
 class TimeDisplay(Static):

--- a/tests/integration/test_attach.py
+++ b/tests/integration/test_attach.py
@@ -64,6 +64,9 @@ alloc_thread.join()
 io_thread.join()
 
 foo()
+assert "jinja2" not in sys.modules
+assert "textual" not in sys.modules
+assert "rich" not in sys.modules
 """
 
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -171,6 +171,43 @@ class TestRunSubcommand:
         out_file = re.search("Writing profile results into (.*)", proc.stdout).group(1)
         assert (tmp_path / out_file).exists()
 
+    def test_run_does_not_import_reporting_libraries(self, tmp_path):
+        # The tracked process must not import the reporters' heavy third party
+        # dependencies (rich/textual/jinja2), both to keep startup fast and to
+        # avoid interfering with the copies the tracked application depends on.
+        # GIVEN
+        code_file = tmp_path / "code.py"
+        code_file.write_text(
+            textwrap.dedent(
+                """
+                import sys
+
+                assert "jinja2" not in sys.modules
+                assert "rich" not in sys.modules
+                assert "textual" not in sys.modules
+                """
+            )
+        )
+
+        # WHEN
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "memray",
+                "run",
+                "--output",
+                str(tmp_path / "result.bin"),
+                str(code_file),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        # THEN
+        assert proc.returncode == 0
+
     def test_run_override_output(self, tmp_path, simple_test_file):
         # GIVEN
         out_file = tmp_path / "result.bin"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -179,7 +179,7 @@ class TestRunSubCommand:
         )
 
     @patch("memray.commands.run.subprocess.Popen")
-    @patch("memray.commands.run.LiveCommand")
+    @patch("memray.commands.live.LiveCommand")
     def test_run_with_live(
         self,
         live_command_mock,
@@ -211,7 +211,7 @@ class TestRunSubCommand:
         )
 
     @patch("memray.commands.run.subprocess.Popen")
-    @patch("memray.commands.run.LiveCommand")
+    @patch("memray.commands.live.LiveCommand")
     def test_run_with_live_and_trace_python_allocators(
         self,
         live_command_mock,


### PR DESCRIPTION
Import `jinja2`, `rich`, and `textual` lazily so that they aren't loaded into `sys.modules` before running user code in `memray run` or `memray attach`.