### PR TITLE
Use PyEval_SetProfileAllThreads on Python 3.12

### DIFF
--- a/news/1000.bugfix.rst
+++ b/news/1000.bugfix.rst
@@ -1,0 +1,1 @@
+Use the public ``PyEval_SetProfileAllThreads`` API on Python 3.12, rather than walking the interpreter's thread list ourselves and calling a private CPython function for each thread state.

--- a/src/memray/_memray/compat.cpp
+++ b/src/memray/_memray/compat.cpp
@@ -6,7 +6,7 @@ void
 setprofileAllThreads(Py_tracefunc func, PyObject* arg)
 {
     assert(PyGILState_Check());
-#if PY_VERSION_HEX >= 0x030D0000
+#if PY_VERSION_HEX >= 0x030C00F0
     PyEval_SetProfileAllThreads(func, arg);
 #else
     PyThreadState* this_tstate = PyThreadState_Get();


### PR DESCRIPTION
resolves: #999

**Describe your changes**
Updated to now use `SetProfileAllThreads` for `python>=3.12`. As this is when the method became available in CPython.

- https://docs.python.org/3/whatsnew/3.12.html
- https://github.com/python/cpython/issues/93503
