### PR TITLE
Reduce tracking overhead with sys.monitoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ add_custom_command(
 )
 python_add_library(_memray MODULE WITH_SOABI
     src/memray/_memray/compat.cpp
+    src/memray/_memray/compat_internal.c
     src/memray/_memray/hooks.cpp
     src/memray/_memray/tracking_api.cpp
     src/memray/_memray/${BINARY_FORMAT}_shenanigans.cpp

--- a/news/monitoring.feature.rst
+++ b/news/monitoring.feature.rst
@@ -1,0 +1,1 @@
+Use ``sys.monitoring`` on GIL-enabled Python 3.12 and newer to reduce the runtime overhead of tracking Python stacks.

--- a/src/memray/_memray.pyx
+++ b/src/memray/_memray.pyx
@@ -64,6 +64,8 @@ from _memray.tracking_api cimport RecursionGuard
 from _memray.tracking_api cimport Tracker as NativeTracker
 from _memray.tracking_api cimport getRSSFromProcStatus
 from _memray.tracking_api cimport install_trace_function
+from _memray.tracking_api cimport monitoring_trace_function
+from _memray.tracking_api cimport set_monitoring_tool
 from _memray.tracking_api cimport set_up_pthread_fork_handlers
 from cpython cimport Py_DECREF
 from cpython cimport PyErr_CheckSignals
@@ -98,6 +100,91 @@ from ._thread_name_interceptor import ThreadNameInterceptor
 #       a pthread fork handler to disable tracking before forking.
 set_up_pthread_fork_handlers()
 os.register_at_fork(after_in_child=NativeTracker.childFork)
+
+
+@cython.profile(False)
+def _monitoring_push(code, instruction_offset, arg=None):
+    monitoring_trace_function(<PyCodeObject*>code, True)
+
+
+@cython.profile(False)
+def _monitoring_pop(code, instruction_offset, arg):
+    monitoring_trace_function(<PyCodeObject*>code, False)
+
+
+class _MonitoringToolName(str):
+    # CPython retains this object, allowing identity checks if the slot is reused.
+    pass
+
+
+_MONITORING_TOOL_NAME = _MonitoringToolName("memray")
+_MONITORING_CALLBACKS = (
+    _monitoring_push,
+    _monitoring_push,
+    _monitoring_pop,
+    _monitoring_pop,
+    _monitoring_pop,
+    _monitoring_push,
+)
+
+
+def _monitoring_callbacks(monitoring):
+    events = (
+        monitoring.events.PY_START,
+        monitoring.events.PY_RESUME,
+        monitoring.events.PY_RETURN,
+        monitoring.events.PY_YIELD,
+        monitoring.events.PY_UNWIND,
+        monitoring.events.PY_THROW,
+    )
+    return zip(events, _MONITORING_CALLBACKS)
+
+
+def _monitoring_event_mask(monitoring):
+    return sum(event for event, _ in _monitoring_callbacks(monitoring))
+
+
+def _start_monitoring():
+    if sys.version_info < (3, 12) or not getattr(
+        sys, "_is_gil_enabled", lambda: True
+    )():
+        return False
+
+    monitoring = sys.monitoring
+    tool_id = monitoring.PROFILER_ID
+    try:
+        monitoring.use_tool_id(tool_id, _MONITORING_TOOL_NAME)
+    except ValueError:
+        return False
+
+    try:
+        for event, callback in _monitoring_callbacks(monitoring):
+            monitoring.register_callback(tool_id, event, callback)
+
+        monitoring.set_events(tool_id, _monitoring_event_mask(monitoring))
+    except BaseException:
+        _stop_monitoring()
+        raise
+
+    set_monitoring_tool(
+        tool_id,
+        <PyObject*>_MONITORING_TOOL_NAME,
+        <PyObject*>_MONITORING_CALLBACKS,
+    )
+    return True
+
+
+def _stop_monitoring():
+    set_monitoring_tool(-1, NULL, NULL)
+    monitoring = sys.monitoring
+    tool_id = monitoring.PROFILER_ID
+    if monitoring.get_tool(tool_id) is not _MONITORING_TOOL_NAME:
+        return
+
+    monitoring.set_events(tool_id, 0)
+    for event, _ in _monitoring_callbacks(monitoring):
+        monitoring.register_callback(tool_id, event, None)
+    monitoring.free_tool_id(tool_id)
 
 
 def set_log_level(int level):
@@ -756,6 +843,7 @@ cdef class Tracker:
     cdef bool _trace_python_allocators
     cdef object _previous_profile_func
     cdef object _previous_thread_profile_func
+    cdef bool _using_monitoring
     cdef object _patched_thread_class
     cdef unique_ptr[RecordWriter] _writer
     cdef object _surviving_objects
@@ -867,21 +955,34 @@ cdef class Tracker:
 
                 setattr(self._patched_thread_class, "_set_os_name", set_os_name_wrapper)
 
-            self._previous_profile_func = sys.getprofile()
-            self._previous_thread_profile_func = threading._profile_hook
-            threading.setprofile(start_thread_trace)
+            try:
+                self._previous_profile_func = sys.getprofile()
+                self._previous_thread_profile_func = threading._profile_hook
+                self._using_monitoring = _start_monitoring()
+                if self._using_monitoring:
+                    sys.setprofile(None)
+                    threading.setprofile(None)
+                else:
+                    threading.setprofile(start_thread_trace)
 
-            if "greenlet" in sys.modules:
-                NativeTracker.beginTrackingGreenlets()
+                if "greenlet" in sys.modules:
+                    NativeTracker.beginTrackingGreenlets()
 
-            NativeTracker.createTracker(
-                move(writer),
-                self._native_traces,
-                self._memory_interval_ms,
-                self._follow_fork,
-                self._trace_python_allocators,
-                self._track_object_lifetimes,
-            )
+                NativeTracker.createTracker(
+                    move(writer),
+                    self._native_traces,
+                    self._memory_interval_ms,
+                    self._follow_fork,
+                    self._trace_python_allocators,
+                    self._track_object_lifetimes,
+                )
+            except BaseException:
+                if self._using_monitoring:
+                    _stop_monitoring()
+                sys.setprofile(self._previous_profile_func)
+                threading.setprofile(self._previous_thread_profile_func)
+                self._restore_thread_class()
+                raise
             return self
 
     @cython.profile(False)
@@ -890,15 +991,19 @@ cdef class Tracker:
             self._populate_surviving_objects()
         with tracker_creation_lock:
             NativeTracker.destroyTracker()
+            if self._using_monitoring:
+                _stop_monitoring()
             sys.setprofile(self._previous_profile_func)
             threading.setprofile(self._previous_thread_profile_func)
+            self._restore_thread_class()
 
-            for attr in ("_name", "_ident"):
-                try:
-                    delattr(self._patched_thread_class, attr)
-                except AttributeError:
-                    pass
-            self._patched_thread_class = None
+    cdef void _restore_thread_class(self):
+        for attr in ("_name", "_ident"):
+            try:
+                delattr(self._patched_thread_class, attr)
+            except AttributeError:
+                pass
+        self._patched_thread_class = None
 
     cdef void _populate_surviving_objects(self):
         cdef NativeTracker *tracker = NativeTracker.getTracker()

--- a/src/memray/_memray/CMakeLists.txt
+++ b/src/memray/_memray/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   ${MEMRAY_LINKER_FILE}
   inject.cpp
   compat.cpp
+  compat_internal.c
   hooks.cpp
   logging.cpp
   native_resolver.cpp

--- a/src/memray/_memray/compat.cpp
+++ b/src/memray/_memray/compat.cpp
@@ -1,6 +1,25 @@
 #include "compat.h"
+#include "compat_internal.h"
 
 namespace memray::compat {
+
+bool
+isCurrentOrCallerFrame(PyFrameObject* frame)
+{
+    return memray_compat_is_current_or_caller_frame(frame);
+}
+
+bool
+isParentFrame(PyFrameObject* parent, PyFrameObject* frame)
+{
+    return memray_compat_is_parent_frame(parent, frame);
+}
+
+bool
+isMonitoringToolActive(int tool_id, PyObject* tool_name, PyObject* callbacks)
+{
+    return memray_compat_is_monitoring_tool_active(tool_id, tool_name, callbacks);
+}
 
 void
 setprofileAllThreads(Py_tracefunc func, PyObject* arg)

--- a/src/memray/_memray/compat.h
+++ b/src/memray/_memray/compat.h
@@ -9,6 +9,15 @@
 
 namespace memray::compat {
 
+bool
+isCurrentOrCallerFrame(PyFrameObject* frame);
+
+bool
+isParentFrame(PyFrameObject* parent, PyFrameObject* frame);
+
+bool
+isMonitoringToolActive(int tool_id, PyObject* tool_name, PyObject* callbacks);
+
 inline int
 isPythonFinalizing()
 {

--- a/src/memray/_memray/compat_internal.c
+++ b/src/memray/_memray/compat_internal.c
@@ -1,0 +1,108 @@
+#define PY_SSIZE_T_CLEAN
+#include <patchlevel.h>
+
+#if PY_VERSION_HEX >= 0x030C0000
+#    define Py_BUILD_CORE_MODULE
+#endif
+#include <Python.h>
+
+#if PY_VERSION_HEX >= 0x030C0000
+#    include "internal/pycore_frame.h"
+#    if PY_VERSION_HEX >= 0x030E0000
+#        include "internal/pycore_interp_structs.h"
+#        include "internal/pycore_interpframe.h"
+#    else
+#        include "internal/pycore_interp.h"
+#    endif
+#    undef Py_BUILD_CORE
+#    undef Py_BUILD_CORE_MODULE
+#endif
+
+#include "compat_internal.h"
+
+int
+memray_compat_is_current_or_caller_frame(PyFrameObject* frame)
+{
+#if PY_VERSION_HEX >= 0x030C0000
+    PyThreadState* tstate = PyGILState_GetThisThreadState();
+    if (!tstate) {
+        return 0;
+    }
+
+#    if PY_VERSION_HEX < 0x030D0000
+    _PyInterpreterFrame* current = tstate->cframe ? tstate->cframe->current_frame : NULL;
+#    else
+    _PyInterpreterFrame* current = tstate->current_frame;
+#    endif
+    current = _PyFrame_GetFirstComplete(current);
+    if (!current) {
+        return 0;
+    }
+    if (current->frame_obj == frame) {
+        return 1;
+    }
+    _PyInterpreterFrame* caller = _PyFrame_GetFirstComplete(current->previous);
+    return caller && caller->frame_obj == frame;
+#else
+    (void)frame;
+#endif
+    return 0;
+}
+
+int
+memray_compat_is_parent_frame(PyFrameObject* parent, PyFrameObject* frame)
+{
+#if PY_VERSION_HEX >= 0x030C0000
+    _PyInterpreterFrame* previous = frame->f_frame->previous;
+    previous = _PyFrame_GetFirstComplete(previous);
+    return previous && previous->frame_obj == parent;
+#else
+    (void)parent;
+    (void)frame;
+#endif
+    return 0;
+}
+
+int
+memray_compat_is_monitoring_tool_active(int tool_id, PyObject* tool_name, PyObject* callbacks)
+{
+#if PY_VERSION_HEX >= 0x030C0000
+    static const int events[] = {
+            PY_MONITORING_EVENT_PY_START,
+            PY_MONITORING_EVENT_PY_RESUME,
+            PY_MONITORING_EVENT_PY_RETURN,
+            PY_MONITORING_EVENT_PY_YIELD,
+            PY_MONITORING_EVENT_PY_UNWIND,
+            PY_MONITORING_EVENT_PY_THROW,
+    };
+    const Py_ssize_t event_count = sizeof(events) / sizeof(events[0]);
+    PyThreadState* tstate = PyGILState_GetThisThreadState();
+    if (!tstate || !tool_name || !callbacks || !PyTuple_CheckExact(callbacks)
+        || PyTuple_GET_SIZE(callbacks) != event_count || tool_id < 0
+        || tool_id >= PY_MONITORING_TOOL_IDS)
+    {
+        return 0;
+    }
+
+    PyInterpreterState* interp = PyThreadState_GetInterpreter(tstate);
+    if (interp->monitoring_tool_names[tool_id] != tool_name) {
+        return 0;
+    }
+
+    const uint8_t tool = 1U << tool_id;
+    const _Py_GlobalMonitors* monitors = &interp->monitors;
+    for (Py_ssize_t i = 0; i < event_count; ++i) {
+        if (interp->monitoring_callables[tool_id][events[i]] != PyTuple_GET_ITEM(callbacks, i)
+            || !(monitors->tools[events[i]] & tool))
+        {
+            return 0;
+        }
+    }
+    return 1;
+#else
+    (void)tool_id;
+    (void)tool_name;
+    (void)callbacks;
+    return 0;
+#endif
+}

--- a/src/memray/_memray/compat_internal.h
+++ b/src/memray/_memray/compat_internal.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Python.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int
+memray_compat_is_current_or_caller_frame(PyFrameObject* frame);
+
+int
+memray_compat_is_parent_frame(PyFrameObject* parent, PyFrameObject* frame);
+
+int
+memray_compat_is_monitoring_tool_active(int tool_id, PyObject* tool_name, PyObject* callbacks);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -200,6 +200,9 @@ class PythonStackTracker
         void ignoreProfileCall();
         bool consumeIgnoredProfileReturn(PyFrameObject* frame);
         bool isCurrentFrame(PyFrameObject* frame) const;
+        bool isCallerOf(PyFrameObject* frame) const;
+        bool isCurrentOrCaller() const;
+        bool isCurrentCode(PyCodeObject* code) const;
 
         // Update the instruction offset from the frame, if possible.
         // If the offset changes, mark the frame as not emitted.
@@ -221,8 +224,6 @@ class PythonStackTracker
 
       private:
         bool d_emitted{false};
-
-        // Cython can emit nested call/return pairs for the current Python frame.
         uint32_t d_ignored_profile_calls{};
 
         // Threads' initial stacks can have calls to sys.settrace tracing
@@ -237,6 +238,10 @@ class PythonStackTracker
         // has been assigned. For initial frames, we assign that ID while the
         // world is stopped, before the reference could become invalid.
         PyCodeObject* d_code{};
+
+        // Borrowed identity token used to match monitoring return events after
+        // d_code has been resolved. It is cleared with d_frame.
+        PyCodeObject* d_live_code{};
 
         // Information extracted from PyCodeObject while the GIL is held,
         // and later used while the GIL may not be held.
@@ -264,6 +269,8 @@ class PythonStackTracker
     void emitPendingPushesAndPops();
     void populateShadowStack();
     void handleProfileEvent(int what, PyFrameObject* frame);
+    void handlePush(PyFrameObject* frame);
+    void handlePop(PyCodeObject* expected_code = nullptr);
 
     void installGreenletTraceFunctionIfNeeded();
     void handleGreenletSwitch(PyObject* from, PyObject* to);
@@ -276,15 +283,13 @@ class PythonStackTracker
     pythonFrameToStack(PyFrameObject* current_frame, Tracker& tracker);
 
     void reloadStackIfTrackerChanged();
-    bool replaceFrozenStackIfNeeded();
-    void clear();
+    bool rebuildStackIfNeeded();
 
     void pushLazilyEmittedFrame(const LazilyEmittedFrame& frame);
 
     int pushPythonFrame(PyFrameObject* frame);
-    void handlePush(PyFrameObject* frame);
-    void handlePop();
     void popPythonFrame();
+    void clear();
 
     static std::mutex s_mutex;
     static std::unordered_map<PyThreadState*, std::vector<LazilyEmittedFrame>> s_initial_stack_by_thread;
@@ -294,10 +299,44 @@ class PythonStackTracker
     uint32_t d_tracker_generation{};
     std::vector<LazilyEmittedFrame>* d_stack{};
     bool d_greenlet_hooks_installed{};
+    bool d_monitoring_stack_invalidated{};
 };
 
 bool PythonStackTracker::s_greenlet_tracking_enabled{false};
 bool PythonStackTracker::s_native_tracking_enabled{false};
+
+class MonitoringState
+{
+  public:
+    bool enabled() const
+    {
+        return d_tool_name != nullptr;
+    }
+
+    bool active() const
+    {
+        return enabled() && compat::isMonitoringToolActive(d_tool_id, d_tool_name, d_callbacks);
+    }
+
+    void configure(int tool_id, PyObject* tool_name, PyObject* callbacks)
+    {
+        assert((tool_name == nullptr) == (callbacks == nullptr));
+        Py_XINCREF(tool_name);
+        Py_XINCREF(callbacks);
+        Py_XDECREF(d_tool_name);
+        Py_XDECREF(d_callbacks);
+        d_tool_id = tool_id;
+        d_tool_name = tool_name;
+        d_callbacks = callbacks;
+    }
+
+  private:
+    int d_tool_id{-1};
+    PyObject* d_tool_name{};
+    PyObject* d_callbacks{};
+};
+
+static MonitoringState s_monitoring;
 
 std::mutex PythonStackTracker::s_mutex;
 std::unordered_map<PyThreadState*, std::vector<PythonStackTracker::LazilyEmittedFrame>>
@@ -328,20 +367,34 @@ PythonStackTracker::emitPendingPushesAndPops()
         return;
     }
 
-    if (!d_stack->empty()) {
-        PyThreadState* ts = PyGILState_GetThisThreadState();
-        if (!ts || ts->c_profilefunc != PyTraceFunction) {
-            // Note: clear() will call back into emitPendingPushesAndPops() to
-            //       emit the pops, but we won't call back into clear() because
-            //       the stack has already been emptied.
-            clear();
-            return;
-        }
-    }
-
 #ifdef Py_GIL_DISABLED
     PyGILState_STATE gstate = PyGILState_Ensure();
 #endif
+
+    if (s_monitoring.enabled() && !d_stack->empty()
+        && ((!d_stack->back().isFrozen() && !d_stack->back().isCurrentOrCaller())
+            || !s_monitoring.active()))
+    {
+        // clear() re-enters this method with an empty stack.
+        d_monitoring_stack_invalidated = true;
+        clear();
+#ifdef Py_GIL_DISABLED
+        PyGILState_Release(gstate);
+#endif
+        return;
+    }
+
+    if (!s_monitoring.enabled() && !d_stack->empty()) {
+        PyThreadState* ts = PyGILState_GetThisThreadState();
+        if (!ts || ts->c_profilefunc != PyTraceFunction) {
+            // clear() re-enters this method with an empty stack.
+            clear();
+#ifdef Py_GIL_DISABLED
+            PyGILState_Release(gstate);
+#endif
+            return;
+        }
+    }
 
     // At any time, the stack contains (from beginning to end) any number of
     // emitted frames followed by any number of not yet emitted frames.
@@ -413,6 +466,7 @@ PythonStackTracker::reloadStackIfTrackerChanged()
         d_stack->clear();
     }
     d_num_pending_pops = 0;
+    d_monitoring_stack_invalidated = false;
 
     std::vector<LazilyEmittedFrame> correct_stack;
 
@@ -466,19 +520,20 @@ PythonStackTracker::handleProfileEvent(int what, PyFrameObject* frame)
         }
         handlePop();
     } else {
-        replaceFrozenStackIfNeeded();
+        rebuildStackIfNeeded();
     }
 }
 
 bool
-PythonStackTracker::replaceFrozenStackIfNeeded()
+PythonStackTracker::rebuildStackIfNeeded()
 {
     installGreenletTraceFunctionIfNeeded();
-    if (d_stack && !d_stack->empty() && d_stack->back().isFrozen()) {
-        // This stack was set by reloadStackIfTrackerChanged and may have calls
-        // to sys.settrace tracing functions on it. Drop it now, replacing it
-        // with a stack fetched from PyEval_GetFrame which we know can't have
-        // trace function frames on it, and which we can track properly.
+    const bool monitoring_stack_invalidated = d_monitoring_stack_invalidated;
+    d_monitoring_stack_invalidated = false;
+    if (monitoring_stack_invalidated || (d_stack && !d_stack->empty() && d_stack->back().isFrozen())) {
+        // Frozen initial stacks may contain trace-function frames, while an
+        // invalidated monitoring stack has been cleared. Rebuild either one
+        // from the interpreter's current stack.
         populateShadowStack();
         return true;
     }
@@ -488,7 +543,12 @@ PythonStackTracker::replaceFrozenStackIfNeeded()
 void
 PythonStackTracker::handlePush(PyFrameObject* frame)
 {
-    if (replaceFrozenStackIfNeeded()) {
+    if (s_monitoring.enabled() && d_stack && !d_stack->empty() && !d_stack->back().isFrozen()
+        && !d_stack->back().isCallerOf(frame))
+    {
+        d_monitoring_stack_invalidated = true;
+    }
+    if (rebuildStackIfNeeded()) {
         // The replacement stack includes the frame for this call.
         return;
     }
@@ -496,10 +556,14 @@ PythonStackTracker::handlePush(PyFrameObject* frame)
 }
 
 void
-PythonStackTracker::handlePop()
+PythonStackTracker::handlePop(PyCodeObject* expected_code)
 {
-    replaceFrozenStackIfNeeded();
-    popPythonFrame();
+    rebuildStackIfNeeded();
+
+    if (!expected_code || (d_stack && !d_stack->empty() && d_stack->back().isCurrentCode(expected_code)))
+    {
+        popPythonFrame();
+    }
 }
 
 int
@@ -618,6 +682,12 @@ PythonStackTracker::handleGreenletSwitch(PyObject* from, PyObject* to)
 {
     RecursionGuard guard;
 
+    if (s_monitoring.enabled() && !s_monitoring.active()) {
+        d_monitoring_stack_invalidated = true;
+        clear();
+        return;
+    }
+
     // Clear any old TLS stack, emitting pops for frames that had been pushed.
     this->clear();
 
@@ -654,6 +724,7 @@ PythonStackTracker::LazilyEmittedFrame::LazilyEmittedFrame(PyFrameObject* frame)
 
     d_frame = frame;
     d_code = compat::frameGetCode(frame);
+    d_live_code = d_code;
 #if PY_VERSION_HEX < 0x030C0000
     if (s_extra_index != -1) {
         void* extra;
@@ -714,6 +785,24 @@ PythonStackTracker::LazilyEmittedFrame::isCurrentFrame(PyFrameObject* frame) con
     return d_frame == frame;
 }
 
+bool
+PythonStackTracker::LazilyEmittedFrame::isCallerOf(PyFrameObject* frame) const
+{
+    return compat::isParentFrame(d_frame, frame);
+}
+
+bool
+PythonStackTracker::LazilyEmittedFrame::isCurrentOrCaller() const
+{
+    return compat::isCurrentOrCallerFrame(d_frame);
+}
+
+bool
+PythonStackTracker::LazilyEmittedFrame::isCurrentCode(PyCodeObject* code) const
+{
+    return d_live_code == code;
+}
+
 void
 PythonStackTracker::LazilyEmittedFrame::updateInstructionOffset()
 {
@@ -731,6 +820,7 @@ void
 PythonStackTracker::LazilyEmittedFrame::freezeInstructionOffset()
 {
     d_frame = nullptr;
+    d_live_code = nullptr;
 }
 
 bool
@@ -840,6 +930,11 @@ PythonStackTracker::recordAllStacks(Tracker& tracker)
 void
 PythonStackTracker::installProfileHooks()
 {
+    if (s_monitoring.enabled()) {
+        compat::setprofileAllThreads(nullptr, nullptr);
+        return;
+    }
+
     // Install our profile function in all existing threads. Note that the
     // profile function may begin executing before recordAllStacks is called.
     compat::setprofileAllThreads(PyTraceFunction, nullptr);
@@ -1654,11 +1749,11 @@ Tracker::beginTrackingGreenlets()
 void
 Tracker::handleGreenletSwitch(PyObject* from, PyObject* to)
 {
-    // We must stop tracking the stack once our trace function is uninstalled.
-    // Otherwise, we'd keep referencing frames after they're destroyed.
-    PyThreadState* ts = PyThreadState_Get();
-    if (ts->c_profilefunc != PyTraceFunction) {
-        return;
+    if (!s_monitoring.enabled()) {
+        PyThreadState* ts = PyThreadState_Get();
+        if (ts->c_profilefunc != PyTraceFunction) {
+            return;
+        }
     }
 
     // Grab the Tracker lock, as this may need to write pushes/pops.
@@ -1684,6 +1779,10 @@ void
 install_trace_function()
 {
     assert(PyGILState_Check());
+    if (s_monitoring.enabled()) {
+        return;
+    }
+
     RecursionGuard guard;
     // Don't clear the python stack if we have already registered the tracking
     // function with the current thread. This happens when PyGILState_Ensure is
@@ -1695,6 +1794,39 @@ install_trace_function()
 
     PyEval_SetProfile(PyTraceFunction, nullptr);
     PythonStackTracker::get().populateShadowStack();
+}
+
+void
+set_monitoring_tool(int tool_id, PyObject* tool_name, PyObject* callbacks)
+{
+    assert(!Tracker::isActive());
+    s_monitoring.configure(tool_id, tool_name, callbacks);
+}
+
+void
+monitoring_trace_function(PyCodeObject* code, bool is_push)
+{
+    RecursionGuard guard;
+    if (!Tracker::isActive()) {
+        return;
+    }
+
+    PyFrameObject* frame = nullptr;
+    if (is_push) {
+        frame = PyEval_GetFrame();
+        while (frame && compat::frameGetCode(frame) != code) {
+            frame = compat::frameGetBack(frame);
+        }
+        if (!frame) {
+            return;
+        }
+    }
+
+    if (is_push) {
+        PythonStackTracker::get().handlePush(frame);
+    } else {
+        PythonStackTracker::get().handlePop(code);
+    }
 }
 
 }  // namespace memray::tracking_api

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -543,7 +543,7 @@ PythonStackTracker::rebuildStackIfNeeded()
 void
 PythonStackTracker::handlePush(PyFrameObject* frame)
 {
-    if (s_monitoring.enabled() && d_stack && !d_stack->empty() && !d_stack->back().isFrozen()
+    if (d_stack && !d_stack->empty() && !d_stack->back().isFrozen()
         && !d_stack->back().isCallerOf(frame))
     {
         d_monitoring_stack_invalidated = true;

--- a/src/memray/_memray/tracking_api.cpp
+++ b/src/memray/_memray/tracking_api.cpp
@@ -197,6 +197,10 @@ class PythonStackTracker
         // Has this frame been emitted already?
         bool isEmitted() const;
 
+        void ignoreProfileCall();
+        bool consumeIgnoredProfileReturn(PyFrameObject* frame);
+        bool isCurrentFrame(PyFrameObject* frame) const;
+
         // Update the instruction offset from the frame, if possible.
         // If the offset changes, mark the frame as not emitted.
         void updateInstructionOffset();
@@ -217,6 +221,9 @@ class PythonStackTracker
 
       private:
         bool d_emitted{false};
+
+        // Cython can emit nested call/return pairs for the current Python frame.
+        uint32_t d_ignored_profile_calls{};
 
         // Threads' initial stacks can have calls to sys.settrace tracing
         // functions which our profile function won't see get popped. We can't
@@ -256,7 +263,7 @@ class PythonStackTracker
     static PythonStackTracker& get();
     void emitPendingPushesAndPops();
     void populateShadowStack();
-    void handleTraceEvent(int what, PyFrameObject* frame);
+    void handleProfileEvent(int what, PyFrameObject* frame);
 
     void installGreenletTraceFunctionIfNeeded();
     void handleGreenletSwitch(PyObject* from, PyObject* to);
@@ -269,11 +276,14 @@ class PythonStackTracker
     pythonFrameToStack(PyFrameObject* current_frame, Tracker& tracker);
 
     void reloadStackIfTrackerChanged();
+    bool replaceFrozenStackIfNeeded();
     void clear();
 
     void pushLazilyEmittedFrame(const LazilyEmittedFrame& frame);
 
     int pushPythonFrame(PyFrameObject* frame);
+    void handlePush(PyFrameObject* frame);
+    void handlePop();
     void popPythonFrame();
 
     static std::mutex s_mutex;
@@ -442,29 +452,54 @@ PythonStackTracker::populateShadowStack()
 }
 
 void
-PythonStackTracker::handleTraceEvent(int what, PyFrameObject* frame)
+PythonStackTracker::handleProfileEvent(int what, PyFrameObject* frame)
+{
+    if (what == PyTrace_CALL) {
+        if (d_stack && !d_stack->empty() && d_stack->back().isCurrentFrame(frame)) {
+            d_stack->back().ignoreProfileCall();
+            return;
+        }
+        handlePush(frame);
+    } else if (what == PyTrace_RETURN) {
+        if (d_stack && !d_stack->empty() && d_stack->back().consumeIgnoredProfileReturn(frame)) {
+            return;
+        }
+        handlePop();
+    } else {
+        replaceFrozenStackIfNeeded();
+    }
+}
+
+bool
+PythonStackTracker::replaceFrozenStackIfNeeded()
 {
     installGreenletTraceFunctionIfNeeded();
-
     if (d_stack && !d_stack->empty() && d_stack->back().isFrozen()) {
         // This stack was set by reloadStackIfTrackerChanged and may have calls
         // to sys.settrace tracing functions on it. Drop it now, replacing it
         // with a stack fetched from PyEval_GetFrame which we know can't have
         // trace function frames on it, and which we can track properly.
         populateShadowStack();
-
-        if (what == PyTrace_CALL) {
-            // The stack we just populated includes the frame for this call.
-            // Return early to avoid duplicating it.
-            return;
-        }
+        return true;
     }
+    return false;
+}
 
-    if (what == PyTrace_CALL) {
-        pushPythonFrame(frame);
-    } else if (what == PyTrace_RETURN) {
-        popPythonFrame();
+void
+PythonStackTracker::handlePush(PyFrameObject* frame)
+{
+    if (replaceFrozenStackIfNeeded()) {
+        // The replacement stack includes the frame for this call.
+        return;
     }
+    pushPythonFrame(frame);
+}
+
+void
+PythonStackTracker::handlePop()
+{
+    replaceFrozenStackIfNeeded();
+    popPythonFrame();
 }
 
 int
@@ -654,6 +689,29 @@ bool
 PythonStackTracker::LazilyEmittedFrame::isEmitted() const
 {
     return d_emitted;
+}
+
+bool
+PythonStackTracker::LazilyEmittedFrame::consumeIgnoredProfileReturn(PyFrameObject* frame)
+{
+    if (!isCurrentFrame(frame) || !d_ignored_profile_calls) {
+        return false;
+    }
+    --d_ignored_profile_calls;
+    return true;
+}
+
+void
+PythonStackTracker::LazilyEmittedFrame::ignoreProfileCall()
+{
+    ++d_ignored_profile_calls;
+    assert(d_ignored_profile_calls != 0);
+}
+
+bool
+PythonStackTracker::LazilyEmittedFrame::isCurrentFrame(PyFrameObject* frame) const
+{
+    return d_frame == frame;
 }
 
 void
@@ -1582,7 +1640,7 @@ PyTraceFunction(
         return 0;
     }
 
-    PythonStackTracker::get().handleTraceEvent(what, frame);
+    PythonStackTracker::get().handleProfileEvent(what, frame);
     return 0;
 }
 

--- a/src/memray/_memray/tracking_api.h
+++ b/src/memray/_memray/tracking_api.h
@@ -130,6 +130,12 @@ PyTraceFunction(PyObject* obj, PyFrameObject* frame, int what, PyObject* arg);
 void
 install_trace_function();
 
+void
+set_monitoring_tool(int tool_id, PyObject* tool_name, PyObject* callbacks);
+
+void
+monitoring_trace_function(PyCodeObject* code, bool is_push);
+
 /**
  * Install our pthread fork handlers.
  */

--- a/src/memray/_memray/tracking_api.pxd
+++ b/src/memray/_memray/tracking_api.pxd
@@ -1,3 +1,4 @@
+from _memray.record_writer cimport PyCodeObject
 from _memray.record_writer cimport RecordWriter
 from cpython cimport PyObject
 from libc.stddef cimport size_t
@@ -13,6 +14,10 @@ cdef extern from "tracking_api.h" namespace "memray::tracking_api":
 
     void set_up_pthread_fork_handlers() except+
     void install_trace_function() except*
+    void set_monitoring_tool(
+        int tool_id, PyObject* tool_name, PyObject* callbacks
+    ) except*
+    void monitoring_trace_function(PyCodeObject* code, bool is_push) except*
 
     cdef cppclass RecursionGuard:
         RecursionGuard()

--- a/src/memray/_memray_test_utils.pyx
+++ b/src/memray/_memray_test_utils.pyx
@@ -14,6 +14,7 @@ from posix.mman cimport munmap
 from posix.unistd cimport read
 from posix.unistd cimport write
 
+cimport cython
 from _memray.alloc cimport PyMem_Calloc
 from _memray.alloc cimport PyMem_Free
 from _memray.alloc cimport PyMem_Malloc
@@ -214,6 +215,7 @@ cdef class PymallocMemoryAllocator:
 cdef do_not_optimize_ptr(void* ptr):
     return ptr == <void*>(1)
 
+@cython.profile(True)
 def _cython_nested_allocation(allocator_fn, size):
     allocator_fn(size)
     cdef void* p = valloc(size);

--- a/tests/integration/test_greenlet.py
+++ b/tests/integration/test_greenlet.py
@@ -7,7 +7,9 @@ import pytest
 
 from memray import AllocatorType
 from memray import FileReader
+from tests.utils import MONITORING_BACKEND_SUPPORTED
 from tests.utils import filter_relevant_allocations
+from tests.utils import requires_monitoring_backend
 
 pytestmark = pytest.mark.skipif(
     sys.version_info >= (3, 14), reason="Greenlet does not yet support Python 3.14"
@@ -250,17 +252,63 @@ def test_uninstall_profile_in_greenlet(tmpdir):
     def stack(alloc):
         return [frame[0] for frame in alloc.stack_trace()]
 
-    # Verify allocations and their stack traces (which should be empty
-    # because we remove the tracking function)
     assert len(vallocs) == 2
 
-    assert stack(vallocs[0]) == []
-    assert vallocs[0].size == 70 * 1024
+    if MONITORING_BACKEND_SUPPORTED:
+        assert stack(vallocs[0]) == ["valloc", "test"]
+        assert stack(vallocs[1]) == ["valloc", "foo", "<module>"]
+    else:
+        assert stack(vallocs[0]) == []
+        assert stack(vallocs[1]) == []
 
-    assert stack(vallocs[1]) == []
+    assert vallocs[0].size == 70 * 1024
     assert vallocs[1].size == 10 * 1024
 
     # Verify thread IDs
     main_tid = vallocs[0].tid  # inner greenlet
     outer_tid = vallocs[1].tid  # outer greenlet
-    assert main_tid == outer_tid
+    if MONITORING_BACKEND_SUPPORTED:
+        assert main_tid != outer_tid
+    else:
+        assert main_tid == outer_tid
+
+
+@requires_monitoring_backend
+def test_disabling_monitoring_before_greenlet_switch_clears_stack(tmp_path):
+    # GIVEN
+    output = tmp_path / "test.bin"
+    subprocess_code = textwrap.dedent(
+        f"""
+        import greenlet
+        import sys
+
+        from memray import Tracker
+        from memray._test import MemoryAllocator
+
+
+        def target():
+            sys.monitoring.set_events(sys.monitoring.PROFILER_ID, 0)
+            main_greenlet.switch()
+            allocator.valloc(1234)
+            allocator.free()
+
+
+        allocator = MemoryAllocator()
+        with Tracker("{output}"):
+            main_greenlet = greenlet.getcurrent()
+            other = greenlet.greenlet(target)
+            other.switch()
+            other.switch()
+        """
+    )
+
+    # WHEN
+    subprocess.run([sys.executable, "-Xdev", "-c", subprocess_code], timeout=5)
+
+    # THEN
+    (valloc,) = (
+        record
+        for record in FileReader(output).get_allocation_records()
+        if record.allocator == AllocatorType.VALLOC
+    )
+    assert valloc.stack_trace() == []

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -163,6 +163,27 @@ def test_cython_traceback(tmpdir):
         free.stack_trace()
 
 
+def test_profiled_cython_frame_is_balanced(tmp_path):
+    allocator = MemoryAllocator()
+    output = tmp_path / "test.bin"
+
+    with Tracker(output):
+        _cython_nested_allocation(allocator.valloc, 1234)
+        allocator.free()
+        allocator.valloc(4321)
+    allocator.free()
+
+    (allocation,) = (
+        record
+        for record in FileReader(output).get_allocation_records()
+        if record.allocator == AllocatorType.VALLOC and record.size == 4321
+    )
+    assert [frame[0] for frame in allocation.stack_trace()] == [
+        "valloc",
+        "test_profiled_cython_frame_is_balanced",
+    ]
+
+
 def test_large_number_of_frame_pops_between_subsequent_allocations(tmpdir):
     # GIVEN
     output = Path(tmpdir) / "test.bin"

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -13,6 +13,7 @@ from memray._test import MemoryAllocator
 from memray._test import _cython_nested_allocation
 from memray._test import allocate_without_gil_held
 from memray._test import function_caller
+from tests import utils
 
 
 def alloc_func3(allocator):
@@ -56,10 +57,10 @@ def test_traceback(tmpdir):
     (alloc,) = allocs
     traceback = list(alloc.stack_trace())
     assert traceback[-4:] == [
-        ("alloc_func3", __file__, 20),
-        ("alloc_func2", __file__, 29),
-        ("alloc_func1", __file__, 36),
-        ("test_traceback", __file__, 49),
+        ("alloc_func3", __file__, 21),
+        ("alloc_func2", __file__, 30),
+        ("alloc_func1", __file__, 37),
+        ("test_traceback", __file__, 50),
     ]
     frees = [
         record
@@ -90,10 +91,10 @@ def test_traceback_for_high_watermark(tmpdir):
     (alloc,) = allocs
     traceback = list(alloc.stack_trace())
     assert traceback[-4:] == [
-        ("alloc_func3", __file__, 20),
-        ("alloc_func2", __file__, 29),
-        ("alloc_func1", __file__, 36),
-        ("test_traceback_for_high_watermark", __file__, 83),
+        ("alloc_func3", __file__, 21),
+        ("alloc_func2", __file__, 30),
+        ("alloc_func1", __file__, 37),
+        ("test_traceback_for_high_watermark", __file__, 84),
     ]
 
 
@@ -144,12 +145,12 @@ def test_cython_traceback(tmpdir):
     traceback = list(alloc1.stack_trace())
     assert traceback == [
         ("valloc", sys.modules["memray._test"].__file__, 50),
-        ("test_cython_traceback", __file__, 134),
+        ("test_cython_traceback", __file__, 135),
     ]
 
     traceback = list(alloc2.stack_trace())
     assert traceback == [
-        ("test_cython_traceback", __file__, 134),
+        ("test_cython_traceback", __file__, 135),
     ]
 
     frees = [
@@ -325,6 +326,306 @@ def test_profile_function_is_restored_after_tracking(tmpdir):
 
     # THEN
     assert sys.getprofile() == profilefunc
+
+
+@utils.requires_monitoring_backend
+def test_uses_sys_monitoring(tmp_path):
+    # GIVEN
+    output = tmp_path / "test.bin"
+
+    # WHEN
+    with Tracker(output):
+        active_tool = sys.monitoring.get_tool(sys.monitoring.PROFILER_ID)
+        active_profile = sys.getprofile()
+    released_tool = sys.monitoring.get_tool(sys.monitoring.PROFILER_ID)
+
+    # THEN
+    assert (active_tool, active_profile, released_tool) == ("memray", None, None)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="requires sys.monitoring")
+def test_falls_back_to_profile_function_when_monitoring_tool_is_in_use(tmp_path):
+    # GIVEN
+    output = tmp_path / "test.bin"
+    allocator = MemoryAllocator()
+    tool_id = sys.monitoring.PROFILER_ID
+    sys.monitoring.use_tool_id(tool_id, "test")
+
+    # WHEN
+    try:
+        with Tracker(output):
+            active_tool = sys.monitoring.get_tool(tool_id)
+            allocator.valloc(1234)
+            allocator.free()
+    finally:
+        sys.monitoring.free_tool_id(tool_id)
+
+    # THEN
+    (valloc,) = (
+        record
+        for record in FileReader(output).get_allocation_records()
+        if record.allocator == AllocatorType.VALLOC
+    )
+    assert active_tool == "test"
+    assert valloc.stack_trace()[0][0] == "valloc"
+
+
+@utils.requires_monitoring_backend
+def test_profile_fallback_updates_preexisting_thread_line_numbers(tmp_path):
+    # GIVEN
+    output = tmp_path / "test.bin"
+    ready_r, ready_w = os.pipe()
+    proceed_r, proceed_w = os.pipe()
+    allocation_line = None
+
+    def thread_body():
+        nonlocal allocation_line
+        os.write(ready_w, b"x")
+        os.read(proceed_r, 1)
+        allocation_line = sys._getframe().f_lineno + 1
+        mapping = mmap.mmap(-1, 1)
+        mapping.close()
+
+    tool_id = sys.monitoring.PROFILER_ID
+    sys.monitoring.use_tool_id(tool_id, "test")
+    thread = threading.Thread(target=thread_body)
+    thread.start()
+    os.read(ready_r, 1)
+
+    # WHEN
+    try:
+        with Tracker(output):
+            os.write(proceed_w, b"x")
+            thread.join()
+    finally:
+        sys.monitoring.free_tool_id(tool_id)
+
+    # THEN
+    (allocation,) = (
+        record
+        for record in FileReader(output).get_allocation_records()
+        if record.allocator == AllocatorType.MMAP and record.size == 1
+    )
+    assert allocation.stack_trace()[0][2] == allocation_line
+
+
+def disable_monitoring_events(monitoring):
+    monitoring.set_events(monitoring.PROFILER_ID, 0)
+
+
+def replace_monitoring_callback(monitoring):
+    monitoring.register_callback(
+        monitoring.PROFILER_ID,
+        monitoring.events.PY_START,
+        lambda *args: None,
+    )
+
+
+@utils.requires_monitoring_backend
+@pytest.mark.parametrize(
+    "invalidate",
+    [disable_monitoring_events, replace_monitoring_callback],
+    ids=["events-disabled", "callback-replaced"],
+)
+def test_clears_stack_when_monitoring_configuration_changes(tmp_path, invalidate):
+    output = tmp_path / "test.bin"
+    allocator = MemoryAllocator()
+
+    with Tracker(output):
+        invalidate(sys.monitoring)
+        allocator.valloc(1234)
+        allocator.free()
+
+    (valloc,) = (
+        record
+        for record in FileReader(output).get_allocation_records()
+        if record.allocator == AllocatorType.VALLOC
+    )
+    assert valloc.stack_trace() == []
+
+
+@utils.requires_monitoring_backend
+@pytest.mark.parametrize("allocate_while_disabled", [False, True])
+def test_rebuilds_stack_when_monitoring_configuration_is_restored(
+    tmp_path, allocate_while_disabled
+):
+    output = tmp_path / "test.bin"
+    allocator = MemoryAllocator()
+    monitoring = sys.monitoring
+    tool_id = monitoring.PROFILER_ID
+
+    def allocate_after_restore():
+        allocator.valloc(2345)
+        allocator.free()
+
+    def disable_monitoring():
+        events = monitoring.get_events(tool_id)
+        monitoring.set_events(tool_id, 0)
+        if allocate_while_disabled:
+            allocator.valloc(1234)
+            allocator.free()
+        return events
+
+    with Tracker(output):
+        events = disable_monitoring()
+        monitoring.set_events(tool_id, events)
+        allocate_after_restore()
+
+    (valloc,) = (
+        record
+        for record in FileReader(output).get_allocation_records()
+        if record.allocator == AllocatorType.VALLOC and record.size == 2345
+    )
+    functions = [frame[0] for frame in valloc.stack_trace()]
+    assert functions[:2] == ["valloc", "allocate_after_restore"]
+    assert "disable_monitoring" not in functions
+    assert "test_rebuilds_stack_when_monitoring_configuration_is_restored" in functions
+
+
+@utils.requires_monitoring_backend
+def test_clears_stack_for_no_gil_allocation_after_monitoring_is_disabled(tmp_path):
+    output = tmp_path / "test.bin"
+    ready_r, ready_w = os.pipe()
+    proceed_r, proceed_w = os.pipe()
+
+    def thread_body():
+        sys.monitoring.set_events(sys.monitoring.PROFILER_ID, 0)
+        allocate_without_gil_held(ready_w, proceed_r)
+
+    with Tracker(output):
+        thread = threading.Thread(target=thread_body)
+        thread.start()
+        os.read(ready_r, 1)
+        os.write(proceed_w, b"x")
+        thread.join()
+
+    stacks = {
+        record.size: record.stack_trace()
+        for record in FileReader(output).get_allocation_records()
+        if record.allocator == AllocatorType.VALLOC and record.size in {1234, 4321}
+    }
+    assert stacks == {1234: [], 4321: []}
+
+
+@utils.requires_monitoring_backend
+def test_clears_stack_when_monitoring_tool_is_replaced(tmp_path):
+    # GIVEN
+    output = tmp_path / "test.bin"
+    allocator = MemoryAllocator()
+    monitoring = sys.monitoring
+    tool_id = monitoring.PROFILER_ID
+    events = (
+        monitoring.events.PY_START,
+        monitoring.events.PY_RESUME,
+        monitoring.events.PY_RETURN,
+        monitoring.events.PY_YIELD,
+        monitoring.events.PY_UNWIND,
+        monitoring.events.PY_THROW,
+    )
+
+    # WHEN
+    try:
+        with Tracker(output):
+            callbacks = [
+                monitoring.register_callback(tool_id, event, None) for event in events
+            ]
+            monitoring.free_tool_id(tool_id)
+            monitoring.use_tool_id(tool_id, "memray")
+            for event, callback in zip(events, callbacks):
+                monitoring.register_callback(tool_id, event, callback)
+            monitoring.set_events(tool_id, sum(events))
+            allocator.valloc(1234)
+            allocator.free()
+        replacement_tool = monitoring.get_tool(tool_id)
+    finally:
+        if monitoring.get_tool(tool_id) is not None:
+            monitoring.set_events(tool_id, 0)
+            for event in events:
+                monitoring.register_callback(tool_id, event, None)
+            monitoring.free_tool_id(tool_id)
+
+    # THEN
+    (valloc,) = (
+        record
+        for record in FileReader(output).get_allocation_records()
+        if record.allocator == AllocatorType.VALLOC
+    )
+    assert replacement_tool == "memray"
+    assert valloc.stack_trace() == []
+
+
+@utils.requires_monitoring_backend
+def test_monitoring_tracks_generator_resumes(tmp_path):
+    # GIVEN
+    output = tmp_path / "test.bin"
+    allocator = MemoryAllocator()
+
+    def generator():
+        allocator.valloc(1234)
+        allocator.free()
+        yield
+        allocator.valloc(2345)
+        allocator.free()
+
+    # WHEN
+    with Tracker(output):
+        iterator = generator()
+        next(iterator)
+        with pytest.raises(StopIteration):
+            next(iterator)
+        allocator.valloc(3456)
+        allocator.free()
+
+    # THEN
+    stacks = {
+        record.size: [frame[0] for frame in record.stack_trace()]
+        for record in FileReader(output).get_allocation_records()
+        if record.allocator == AllocatorType.VALLOC
+    }
+    assert stacks == {
+        1234: ["valloc", "generator", "test_monitoring_tracks_generator_resumes"],
+        2345: ["valloc", "generator", "test_monitoring_tracks_generator_resumes"],
+        3456: ["valloc", "test_monitoring_tracks_generator_resumes"],
+    }
+
+
+@utils.requires_monitoring_backend
+def test_monitoring_tracks_exceptions_thrown_into_generators(tmp_path):
+    # GIVEN
+    output = tmp_path / "test.bin"
+    allocator = MemoryAllocator()
+
+    def generator():
+        try:
+            yield
+        except ValueError:
+            allocator.valloc(1234)
+            allocator.free()
+            raise
+
+    # WHEN
+    with Tracker(output):
+        iterator = generator()
+        next(iterator)
+        with pytest.raises(ValueError):
+            iterator.throw(ValueError)
+        allocator.valloc(2345)
+        allocator.free()
+
+    # THEN
+    stacks = {
+        record.size: [frame[0] for frame in record.stack_trace()]
+        for record in FileReader(output).get_allocation_records()
+        if record.allocator == AllocatorType.VALLOC
+    }
+    assert stacks == {
+        1234: [
+            "valloc",
+            "generator",
+            "test_monitoring_tracks_exceptions_thrown_into_generators",
+        ],
+        2345: ["valloc", "test_monitoring_tracks_exceptions_thrown_into_generators"],
+    }
 
 
 def test_initial_tracking_frames_are_correctly_populated(tmpdir):
@@ -918,10 +1219,6 @@ def test_cython_frame_in_pre_existing_thread_stack_when_restarting_tracking(tmp_
 
 
 def test_allocation_after_unsetting_profile_function(tmp_path):
-    """After tracking starts, unset the profile function then allocate.
-
-    Make sure that the stack for the allocation is unknown.
-    """
     # GIVEN
     allocator = MemoryAllocator()
     output = tmp_path / "test.bin"
@@ -956,14 +1253,13 @@ def test_allocation_after_unsetting_profile_function(tmp_path):
         "func",
         "test_allocation_after_unsetting_profile_function",
     ]
-    assert alloc2_funcs == []
+    if utils.MONITORING_BACKEND_SUPPORTED:
+        assert alloc2_funcs == alloc1_funcs
+    else:
+        assert alloc2_funcs == []
 
 
 def test_allocation_in_thread_after_unsetting_profile_function(tmp_path):
-    """In a thread, unset the profile function then allocate.
-
-    Make sure that the stack for the allocation is unknown.
-    """
     # GIVEN
     allocator = MemoryAllocator()
     output = tmp_path / "test.bin"
@@ -996,7 +1292,10 @@ def test_allocation_in_thread_after_unsetting_profile_function(tmp_path):
     alloc2_funcs = [frame[0] for frame in second.stack_trace()]
 
     assert alloc1_funcs[:2] == ["valloc", "func"]
-    assert alloc2_funcs == []
+    if utils.MONITORING_BACKEND_SUPPORTED:
+        assert alloc2_funcs == alloc1_funcs
+    else:
+        assert alloc2_funcs == []
 
 
 class TestMmap:

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -1378,3 +1378,48 @@ class TestMmap:
         assert munmap_record is not None
         with pytest.raises(NotImplementedError):
             munmap_record.stack_trace()
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="requires Python 3.14")
+def test_profile_fallback_repairs_stack_after_preexisting_cython_call(tmp_path):
+    output = tmp_path / "test.bin"
+    allocator = MemoryAllocator()
+    ready_read, ready_write = os.pipe()
+    proceed_read, proceed_write = os.pipe()
+
+    def blocker(size):
+        os.write(ready_write, b"x")
+        os.read(proceed_read, 1)
+
+    def thread_body():
+        _cython_nested_allocation(blocker, 1234)
+        allocator.valloc(4321)
+        allocator.free()
+
+    monitoring = sys.monitoring
+    tool_id = monitoring.PROFILER_ID
+    monitoring.use_tool_id(tool_id, "test")
+    previous_thread_profile = threading.getprofile()
+    threading.setprofile(lambda *args: None)
+
+    try:
+        thread = threading.Thread(target=thread_body)
+        thread.start()
+        os.read(ready_read, 1)
+
+        with Tracker(output):
+            os.write(proceed_write, b"x")
+            thread.join()
+    finally:
+        threading.setprofile(previous_thread_profile)
+        monitoring.free_tool_id(tool_id)
+
+    (allocation,) = (
+        record
+        for record in FileReader(output).get_allocation_records()
+        if record.allocator == AllocatorType.VALLOC and record.size == 4321
+    )
+    assert [frame[0] for frame in allocation.stack_trace()][:2] == [
+        "valloc",
+        "thread_body",
+    ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,6 +11,14 @@ import pytest
 
 from memray import AllocatorType
 
+MONITORING_BACKEND_SUPPORTED = (
+    sys.version_info >= (3, 12) and getattr(sys, "_is_gil_enabled", lambda: True)()
+)
+requires_monitoring_backend = pytest.mark.skipif(
+    not MONITORING_BACKEND_SUPPORTED,
+    reason="requires the sys.monitoring backend",
+)
+
 
 def filter_relevant_allocations(records, ranged=False):
     addresses = set()


### PR DESCRIPTION
On Python 3.12 and newer, use `sys.monitoring` instead of the legacy profile hook to maintain Memray's Python shadow stack. The profile hook makes CPython materialize a `PyFrameObject` and enter the general profiling callback for every Python call and return, and it also reports C-call events that Memray ignores. `sys.monitoring` passes the existing code object and lets Memray subscribe only to the six Python events that can change the stack. Removing that work from every function transition makes the benchmark workloads below 20% to 43% faster while tracking. If the monitoring slot is occupied, Memray keeps using the profile hook as a fallback.

Allocator hooks validate the shadow stack through CPython's interpreter bookkeeping, avoiding calls that can allocate or execute Python while an allocation is already being recorded. This keeps the hot path self-contained and lets Memray discard stale shadow stacks when monitoring is disabled or the tool slot changes ownership.

| Workload | Source | Mode | Faster |
|---|---|---|---:|
| Async CPU | benchmarks/ | Normal | 30.0% |
| Async CPU | benchmarks/ | Native | 29.9% |
| Async I/O | benchmarks/ | Native | 23.2% |
| Async memoization | benchmarks/ | Normal | 28.9% |
| Async memoization | benchmarks/ | Native | 27.0% |
| Async mixed | benchmarks/ | Native | 20.7% |
| Fannkuch | benchmarks/ | Normal | 24.7% |
| Fannkuch | benchmarks/ | Native | 24.0% |
| Pretty-print | benchmarks/ | Normal | 42.4% |
| Pretty-print | benchmarks/ | Native | 42.7% |
