### PR TITLE
Limit maximum reserved memory for parsing segments

### DIFF
--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -390,7 +390,7 @@ bool
 RecordReader::processSegmentHeader(const std::string& filename, size_t num_segments, uintptr_t addr)
 {
     std::vector<Segment> segments;
-    segments.reserve(num_segments);
+    segments.reserve(std::min(num_segments, static_cast<size_t>(1024)));
     for (size_t i = 0; i < num_segments; i++) {
         RecordType record_type;
         if (!d_input->read(reinterpret_cast<char*>(&record_type), sizeof(record_type))


### PR DESCRIPTION
If a capture file is corrupted it may have contain a SEGMENT_HEADER record that claims it will be followed by an absurdly large number of SEGMENT records. Since we currently try to preallocate space for every SEGMENT record we expect, that currently results in Memray dying with a MemoryError. Limit the amount of space we're willing to reserve in advance so that we instead fail when we reach a point where we're unable to parse another SEGMENT record out from the file, failing like other parse errors instead of failing with a memory allocation error.
