### PR TITLE
Scan capture file padding in blocks

### DIFF
--- a/news/faster-padding-scan.feature.rst
+++ b/news/faster-padding-scan.feature.rst
@@ -1,0 +1,1 @@
+Speed up reading uncompressed capture files with large zero-padded tails.

--- a/src/memray/_memray/source.cpp
+++ b/src/memray/_memray/source.cpp
@@ -1,6 +1,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+#include <array>
 #include <cerrno>
 #include <cstring>
 #include <iostream>
@@ -87,16 +88,35 @@ FileSource::findReadableSize()
     // in order to recover from the file truncation. To ignore these, we count
     // the zeroed bytes at the end of the file, and make calls to read() and
     // getline() fail if they read into those bytes.
-    d_raw_stream->seekg(-1, d_raw_stream->end);
-    while (*d_raw_stream) {
-        char c = d_raw_stream->peek();
-        if (c != 0x00) {
-            d_readable_size = d_raw_stream->tellg() + std::streamoff(1);
+    constexpr size_t buffer_size = 64 * 1024;
+    std::array<char, buffer_size> buffer;
+
+    d_raw_stream->clear();
+    d_raw_stream->seekg(0, d_raw_stream->end);
+    std::streamoff scan_end = d_raw_stream->tellg();
+    while (scan_end > 0) {
+        size_t bytes_to_scan =
+                static_cast<size_t>(std::min(scan_end, static_cast<std::streamoff>(buffer.size())));
+        std::streamoff scan_start = scan_end - static_cast<std::streamoff>(bytes_to_scan);
+        d_raw_stream->seekg(scan_start, d_raw_stream->beg);
+        d_raw_stream->read(buffer.data(), bytes_to_scan);
+        if (d_raw_stream->gcount() != static_cast<std::streamsize>(bytes_to_scan)) {
             break;
         }
-        // If we're at BOF, this sets failbit and makes the loop break.
-        d_raw_stream->seekg(-1, d_raw_stream->cur);
+
+        for (size_t i = bytes_to_scan; i > 0; --i) {
+            if (buffer[i - 1] != 0x00) {
+                d_readable_size = scan_start + static_cast<std::streamoff>(i);
+                break;
+            }
+        }
+        if (d_readable_size) {
+            break;
+        }
+        scan_end = scan_start;
     }
+
+    d_raw_stream->clear();
     d_raw_stream->seekg(0, d_raw_stream->beg);
 }
 

--- a/src/memray/_memray/source.cpp
+++ b/src/memray/_memray/source.cpp
@@ -94,9 +94,12 @@ FileSource::findReadableSize()
     d_raw_stream->clear();
     d_raw_stream->seekg(0, d_raw_stream->end);
     std::streamoff scan_end = d_raw_stream->tellg();
+
+    // Normally the file wasn't truncated and its last byte is a TRAILER.
+    std::streamoff max_bytes_to_scan = 1;
+
     while (scan_end > 0) {
-        size_t bytes_to_scan =
-                static_cast<size_t>(std::min(scan_end, static_cast<std::streamoff>(buffer.size())));
+        size_t bytes_to_scan = static_cast<size_t>(std::min(scan_end, max_bytes_to_scan));
         std::streamoff scan_start = scan_end - static_cast<std::streamoff>(bytes_to_scan);
         d_raw_stream->seekg(scan_start, d_raw_stream->beg);
         d_raw_stream->read(buffer.data(), bytes_to_scan);
@@ -114,6 +117,7 @@ FileSource::findReadableSize()
             break;
         }
         scan_end = scan_start;
+        max_bytes_to_scan = buffer.size();  // Fill the buffer on subsequent iterations
     }
 
     d_raw_stream->clear();

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -69,6 +69,22 @@ def test_filereader_fails_to_open_file(tmp_path):
         FileReader(test_file)
 
 
+@pytest.mark.parametrize("padding", [1, 64 * 1024, 64 * 1024 + 1])
+def test_ignores_trailing_zero_padding(tmp_path, padding):
+    output = tmp_path / "test.bin"
+    allocator = MemoryAllocator()
+
+    destination = FileDestination(output, overwrite=False, compress_on_exit=False)
+    with Tracker(destination=destination):
+        allocator.valloc(1024)
+
+    with output.open("ab") as f:
+        f.write(b"\0" * padding)
+
+    records = list(FileReader(output).get_allocation_records())
+    assert any(record.size == 1024 for record in records)
+
+
 def test_read_pid(tmp_path):
     # GIVEN
     output = tmp_path / "test.bin"


### PR DESCRIPTION
Uncompressed captures written through the mmap-backed file sink are grown ahead of the write position with posix_fallocate. That leaves a zero-filled tail after the trailer. FileSource supports interrupted captures by finding the last non-zero byte, but currently does that with one peek and seek per byte of padding.

I reproduced this from a by recording ten million 64-byte malloc/free pairs at the same call site, without compression:

    python -m memray run --no-compress -q -o /tmp/memray-padding.bin -c 'from collections import deque; from memray._test_utils import MemoryAllocator; a = MemoryAllocator(); deque(((a.malloc(64), a.free()) for _ in range(10_000_000)), maxlen=0)'

That produced a 76,042,240-byte capture containing about 20 million allocation records. The valid prefix ended at byte 70,008,450, leaving 6,033,790 zero bytes. I timed reader initialization, which is where the padding scan happens, with:

    /usr/bin/time -f '%e seconds' python -c "from memray import FileReader; FileReader('/tmp/memray-padding.bin')"

On the base branch that took 4.04 and 4.33 seconds. With this change it took 2.24 and 2.26 seconds. Removing the padding from the benchmark file makes both cases take about 2.2 seconds, so the difference is specifically the tail scan rather than parsing.

