### PR TITLE
Aggregate temporary allocations while reading

### DIFF
--- a/news/faster-temporary-aggregation.feature.rst
+++ b/news/faster-temporary-aggregation.feature.rst
@@ -1,0 +1,1 @@
+Reduce the time and memory needed to generate temporary-allocation reports from large capture files.

--- a/src/memray/_memray/snapshot.cpp
+++ b/src/memray/_memray/snapshot.cpp
@@ -224,7 +224,17 @@ TemporaryAllocationsAggregator::addAllocation(const Allocation& allocation)
                     });
 
             if (alloc_it != it->second.end()) {
-                d_temporary_allocations.push_back(*alloc_it);
+                const Allocation& record = alloc_it->allocation;
+                auto loc_key = LocationKey{record.frame_index, record.native_frame_id, record.tid};
+                auto [temporary_it, inserted] = d_temporary_allocations.emplace(loc_key, *alloc_it);
+                if (inserted) {
+                    d_temporary_allocation_order.push_back(loc_key);
+                } else {
+                    temporary_it->second.allocation.size += record.size;
+                    temporary_it->second.allocation.n_allocations += record.n_allocations;
+                    temporary_it->second.sequence_number =
+                            std::min(temporary_it->second.sequence_number, alloc_it->sequence_number);
+                }
             }
             break;
         }
@@ -235,18 +245,25 @@ TemporaryAllocationsAggregator::addAllocation(const Allocation& allocation)
 reduced_snapshot_map_t
 TemporaryAllocationsAggregator::getSnapshotAllocations(bool merge_threads)
 {
+    if (!merge_threads) {
+        return d_temporary_allocations;
+    }
+
     reduced_snapshot_map_t stack_to_allocation{};
 
-    for (const auto& snapshot_allocation : d_temporary_allocations) {
+    // Once merging drops the TID from the key, the first per-thread entry supplies the
+    // representative Allocation (including its address, allocator, and TID), while later entries
+    // update only its aggregate fields. Preserve capture order to match the old implementation.
+    for (const auto& key : d_temporary_allocation_order) {
+        const auto& snapshot_allocation = d_temporary_allocations.at(key);
         const Allocation& record = snapshot_allocation.allocation;
-        const thread_id_t thread_id = merge_threads ? NO_THREAD_INFO : record.tid;
-        auto loc_key = LocationKey{record.frame_index, record.native_frame_id, thread_id};
+        auto loc_key = LocationKey{record.frame_index, record.native_frame_id, NO_THREAD_INFO};
         auto alloc_it = stack_to_allocation.find(loc_key);
         if (alloc_it == stack_to_allocation.end()) {
             stack_to_allocation.insert(alloc_it, std::pair(loc_key, snapshot_allocation));
         } else {
             alloc_it->second.allocation.size += record.size;
-            alloc_it->second.allocation.n_allocations += 1;
+            alloc_it->second.allocation.n_allocations += record.n_allocations;
             alloc_it->second.sequence_number =
                     std::min(alloc_it->second.sequence_number, snapshot_allocation.sequence_number);
         }

--- a/src/memray/_memray/snapshot.h
+++ b/src/memray/_memray/snapshot.h
@@ -206,7 +206,8 @@ class TemporaryAllocationsAggregator : public AbstractAggregator
     size_t d_max_items;
     size_t d_index{0};
     std::unordered_map<thread_id_t, std::deque<SnapshotAllocation>> d_current_allocations{};
-    std::vector<SnapshotAllocation> d_temporary_allocations{};
+    reduced_snapshot_map_t d_temporary_allocations{};
+    std::vector<LocationKey> d_temporary_allocation_order{};
 
   public:
     TemporaryAllocationsAggregator(size_t max_items);

--- a/tests/integration/test_tracking.py
+++ b/tests/integration/test_tracking.py
@@ -1502,6 +1502,9 @@ class TestTemporaryAllocations:
             if record.allocator == AllocatorType.POSIX_MEMALIGN
         ]
         assert len(all_allocations) == 4
+        first_allocation_by_stack = {}
+        for allocation in all_allocations:
+            first_allocation_by_stack.setdefault(allocation.stack_id, allocation)
 
         temporary_allocation_records = (
             record
@@ -1516,6 +1519,19 @@ class TestTemporaryAllocations:
         # Each thread should have 4096 bytes total allocations
         for allocations in records.values():
             assert sum(allocation.size for allocation in allocations) == 4096
+
+        merged_allocations = [
+            record
+            for record in reader.get_temporary_allocation_records()
+            if record.allocator == AllocatorType.POSIX_MEMALIGN
+        ]
+        assert len(merged_allocations) == 2
+        assert sum(allocation.size for allocation in merged_allocations) == 8192
+        assert all(allocation.n_allocations == 2 for allocation in merged_allocations)
+        for allocation in merged_allocations:
+            first_allocation = first_allocation_by_stack[allocation.stack_id]
+            assert allocation.tid == first_allocation.tid
+            assert allocation.address == first_allocation.address
 
     def test_intertwined_temporary_allocations_in_threads(self, tmpdir):
         """This test checks that temporary allocations are correctly detected


### PR DESCRIPTION
Temporary-allocation reports currently keep every matching allocation until the whole capture has been read, then aggregate them by call site. That makes memory usage grow with the number of events even when the final report contains one row.

I reproduced this with ten million 64-byte `malloc`/`free` pairs from the same Python call site (twenty million records). The capture is uncompressed and uses buffered file IO so mmap padding is not part of this measurement:

```console
python -m memray run --buffered-file-io --no-compress -q -o /tmp/temporary.bin -c 'from memray._test_utils import MemoryAllocator; from collections import deque; allocator = MemoryAllocator(); deque(((allocator.malloc(64), allocator.free()) for _ in range(10_000_000)), maxlen=0)'
/usr/bin/time -f 'elapsed=%e maxrss=%M' python -m memray table --temporary-allocations -o /tmp/temporary.html /tmp/temporary.bin
```

The 67 MiB capture takes 12.27s and 1.18 GiB peak RSS on `main`, versus 11.39s and 55 MiB here.

This aggregates matches as they are found and retains only one record and ordering entry per unique call site, while preserving split/merged thread behavior and capture order.
