### PR TITLE
Handle invalid capture files more gracefully

### DIFF
--- a/src/memray/_memray/compat.cpp
+++ b/src/memray/_memray/compat.cpp
@@ -1,5 +1,8 @@
 #include "compat.h"
 
+#include <exception>
+#include <limits>
+
 namespace memray::compat {
 
 void
@@ -41,17 +44,33 @@ inline bool
 parseLinetable311(uintptr_t addrq, const std::string& linetable, int firstlineno, LocationInfo* info)
 {
     addrq /= 2;  // Convert from instruction offset to byte offset
-    const uint8_t* ptr = reinterpret_cast<const uint8_t*>(linetable.c_str());
+    const uint8_t* ptr = reinterpret_cast<const uint8_t*>(linetable.data());
+    const uint8_t* const end = ptr + linetable.size();
     uint64_t addr = 0;
     info->lineno = firstlineno;
 
+    struct InvalidLinetable : std::exception
+    {
+    };
+
+    auto read_byte = [&]() -> uint8_t {
+        if (ptr == end) {
+            throw InvalidLinetable{};
+        }
+        return *ptr++;
+    };
+
     auto scan_varint = [&]() {
-        unsigned int read = *ptr++;
+        unsigned int read = read_byte();
         unsigned int val = read & 63;
         unsigned int shift = 0;
         while (read & 64) {
-            read = *ptr++;
+            read = read_byte();
             shift += 6;
+            if (shift >= std::numeric_limits<unsigned int>::digits) {
+                // Shifting this much would be UB, so the table is malformed.
+                throw InvalidLinetable{};
+            }
             val |= (read & 63) << shift;
         }
         return val;
@@ -64,51 +83,57 @@ parseLinetable311(uintptr_t addrq, const std::string& linetable, int firstlineno
         return sign * sval;
     };
 
-    while (*ptr != '\0') {
-        uint8_t first_byte = *(ptr++);
-        uint8_t code = (first_byte >> 3) & 15;
-        size_t length = (first_byte & 7) + 1;
-        uintptr_t end_addr = addr + length;
-        switch (code) {
-            case PY_CODE_LOCATION_INFO_NONE: {
-                break;
+    try {
+        while (ptr < end) {
+            uint8_t first_byte = read_byte();
+            uint8_t code = (first_byte >> 3) & 15;
+            size_t length = (first_byte & 7) + 1;
+            uintptr_t end_addr = addr + length;
+            switch (code) {
+                case PY_CODE_LOCATION_INFO_NONE: {
+                    break;
+                }
+                case PY_CODE_LOCATION_INFO_LONG: {
+                    int line_delta = scan_signed_varint();
+                    info->lineno += line_delta;
+                    info->end_lineno = info->lineno + scan_varint();
+                    info->column = scan_varint() - 1;
+                    info->end_column = scan_varint() - 1;
+                    break;
+                }
+                case PY_CODE_LOCATION_INFO_NO_COLUMNS: {
+                    int line_delta = scan_signed_varint();
+                    info->lineno += line_delta;
+                    info->column = info->end_column = -1;
+                    break;
+                }
+                case PY_CODE_LOCATION_INFO_ONE_LINE0:
+                case PY_CODE_LOCATION_INFO_ONE_LINE1:
+                case PY_CODE_LOCATION_INFO_ONE_LINE2: {
+                    int line_delta = code - 10;
+                    info->lineno += line_delta;
+                    info->end_lineno = info->lineno;
+                    info->column = read_byte();
+                    info->end_column = read_byte();
+                    break;
+                }
+                default: {
+                    uint8_t second_byte = read_byte();
+                    if ((second_byte & 128) != 0) {
+                        throw InvalidLinetable{};
+                    }
+                    info->column = code << 3 | (second_byte >> 4);
+                    info->end_column = info->column + (second_byte & 15);
+                    break;
+                }
             }
-            case PY_CODE_LOCATION_INFO_LONG: {
-                int line_delta = scan_signed_varint();
-                info->lineno += line_delta;
-                info->end_lineno = info->lineno + scan_varint();
-                info->column = scan_varint() - 1;
-                info->end_column = scan_varint() - 1;
-                break;
+            if (addr <= addrq && end_addr > addrq) {
+                return true;
             }
-            case PY_CODE_LOCATION_INFO_NO_COLUMNS: {
-                int line_delta = scan_signed_varint();
-                info->lineno += line_delta;
-                info->column = info->end_column = -1;
-                break;
-            }
-            case PY_CODE_LOCATION_INFO_ONE_LINE0:
-            case PY_CODE_LOCATION_INFO_ONE_LINE1:
-            case PY_CODE_LOCATION_INFO_ONE_LINE2: {
-                int line_delta = code - 10;
-                info->lineno += line_delta;
-                info->end_lineno = info->lineno;
-                info->column = *(ptr++);
-                info->end_column = *(ptr++);
-                break;
-            }
-            default: {
-                uint8_t second_byte = *(ptr++);
-                assert((second_byte & 128) == 0);
-                info->column = code << 3 | (second_byte >> 4);
-                info->end_column = info->column + (second_byte & 15);
-                break;
-            }
+            addr = end_addr;
         }
-        if (addr <= addrq && end_addr > addrq) {
-            return true;
-        }
-        addr = end_addr;
+    } catch (const InvalidLinetable&) {
+        return false;
     }
     return false;
 }
@@ -126,7 +151,7 @@ parseLinetable310(
     // Word-code is two bytes, so the actual limit in the table is 2 * the instruction index
     std::string::size_type last_executed_instruction = instruction_offset << 1;
 
-    for (std::string::size_type i = 0, current_instruction = 0; i < linetable.size();) {
+    for (std::string::size_type i = 0, current_instruction = 0; i + 1 < linetable.size();) {
         unsigned char start_delta = linetable[i++];
         signed char line_delta = linetable[i++];
         current_instruction += start_delta;
@@ -153,7 +178,7 @@ parseLinetable39(
 {
     int code_lineno = firstlineno;
 
-    for (std::string::size_type i = 0, bc = 0; i < linetable.size();
+    for (std::string::size_type i = 0, bc = 0; i + 1 < linetable.size();
          code_lineno += static_cast<int8_t>(linetable[i++]))
     {
         bc += linetable[i++];

--- a/src/memray/_memray/compat.cpp
+++ b/src/memray/_memray/compat.cpp
@@ -146,6 +146,10 @@ parseLinetable310(
         int firstlineno,
         LocationInfo* info)
 {
+    if (linetable.size() % 2 != 0) {
+        return false;  // A valid linetable has 2 bytes per entry
+    }
+
     int code_lineno = firstlineno;
 
     // Word-code is two bytes, so the actual limit in the table is 2 * the instruction index
@@ -176,6 +180,10 @@ parseLinetable39(
         int firstlineno,
         LocationInfo* info)
 {
+    if (linetable.size() % 2 != 0) {
+        return false;  // A valid linetable has 2 bytes per entry
+    }
+
     int code_lineno = firstlineno;
 
     for (std::string::size_type i = 0, bc = 0; i + 1 < linetable.size();

--- a/src/memray/_memray/compat.cpp
+++ b/src/memray/_memray/compat.cpp
@@ -67,18 +67,52 @@ parseLinetable311(uintptr_t addrq, const std::string& linetable, int firstlineno
         while (read & 64) {
             read = read_byte();
             shift += 6;
+            unsigned int chunk = read & 63;
             if (shift >= std::numeric_limits<unsigned int>::digits) {
                 // Shifting this much would be UB, so the table is malformed.
                 throw InvalidLinetable{};
             }
-            val |= (read & 63) << shift;
+            if (chunk > (std::numeric_limits<unsigned int>::max() >> shift)) {
+                // This chunk would provide bits beyond the accumulator's width
+                throw InvalidLinetable{};
+            }
+            val |= chunk << shift;
         }
         return val;
     };
 
+    auto checked_add = [](int lhs, int rhs) {
+        long long result = static_cast<long long>(lhs) + static_cast<long long>(rhs);
+        if (result < std::numeric_limits<int>::min() || result > std::numeric_limits<int>::max()) {
+            throw InvalidLinetable{};
+        }
+        return static_cast<int>(result);
+    };
+
+    auto checked_add_unsigned = [&](int lhs, unsigned int rhs) {
+        if (rhs > static_cast<unsigned int>(std::numeric_limits<int>::max())) {
+            throw InvalidLinetable{};
+        }
+        return checked_add(lhs, static_cast<int>(rhs));
+    };
+
+    auto checked_decrement_unsigned = [](unsigned int value) {
+        if (value == 0) {
+            return -1;
+        }
+        if (value - 1 > static_cast<unsigned int>(std::numeric_limits<int>::max())) {
+            throw InvalidLinetable{};
+        }
+        return static_cast<int>(value - 1);
+    };
+
     auto scan_signed_varint = [&]() {
         unsigned int uval = scan_varint();
-        int sval = uval >> 1;
+        unsigned int magnitude = uval >> 1;
+        if (magnitude > static_cast<unsigned int>(std::numeric_limits<int>::max())) {
+            throw InvalidLinetable{};
+        }
+        int sval = static_cast<int>(magnitude);
         int sign = (uval & 1) ? -1 : 1;
         return sign * sval;
     };
@@ -95,15 +129,15 @@ parseLinetable311(uintptr_t addrq, const std::string& linetable, int firstlineno
                 }
                 case PY_CODE_LOCATION_INFO_LONG: {
                     int line_delta = scan_signed_varint();
-                    info->lineno += line_delta;
-                    info->end_lineno = info->lineno + scan_varint();
-                    info->column = scan_varint() - 1;
-                    info->end_column = scan_varint() - 1;
+                    info->lineno = checked_add(info->lineno, line_delta);
+                    info->end_lineno = checked_add_unsigned(info->lineno, scan_varint());
+                    info->column = checked_decrement_unsigned(scan_varint());
+                    info->end_column = checked_decrement_unsigned(scan_varint());
                     break;
                 }
                 case PY_CODE_LOCATION_INFO_NO_COLUMNS: {
                     int line_delta = scan_signed_varint();
-                    info->lineno += line_delta;
+                    info->lineno = checked_add(info->lineno, line_delta);
                     info->column = info->end_column = -1;
                     break;
                 }
@@ -111,7 +145,7 @@ parseLinetable311(uintptr_t addrq, const std::string& linetable, int firstlineno
                 case PY_CODE_LOCATION_INFO_ONE_LINE1:
                 case PY_CODE_LOCATION_INFO_ONE_LINE2: {
                     int line_delta = code - 10;
-                    info->lineno += line_delta;
+                    info->lineno = checked_add(info->lineno, line_delta);
                     info->end_lineno = info->lineno;
                     info->column = read_byte();
                     info->end_column = read_byte();

--- a/src/memray/_memray/record_reader.cpp
+++ b/src/memray/_memray/record_reader.cpp
@@ -231,13 +231,13 @@ RecordReader::processFramePop(const FramePop& record)
     if (!d_track_stacks) {
         return true;
     }
-    if (!d_curr_thread_stack) {
-        throw std::runtime_error("invalid capture file: FRAME_POP with no previous CONTEXT_SWITCH");
+
+    auto count = record.count;
+    if (!d_curr_thread_stack || count > d_curr_thread_stack->size()) {
+        throw std::runtime_error("invalid capture file: FRAME_POP count exceeds FRAME_PUSH count");
     }
 
     auto& stack = *d_curr_thread_stack;
-    assert(!stack.empty());
-    auto count = record.count;
     while (count) {
         --count;
         stack.pop_back();


### PR DESCRIPTION
Avoid doing an `assert` on data that originated from outside the process, and avoid UB while handling invalid data.