### PR TITLE
Reduce overallocation in memory-mapped capture files

### DIFF
--- a/src/memray/_memray/sink.cpp
+++ b/src/memray/_memray/sink.cpp
@@ -120,6 +120,7 @@ FileSink::writeAll(const char* data, size_t length)
         d_bufferNeedle += toCopy;
         data += toCopy;
         length -= toCopy;
+        d_maxWrittenPos = std::max(d_maxWrittenPos, d_bufferOffset + (d_bufferNeedle - d_buffer));
     }
     return true;
 }
@@ -266,6 +267,16 @@ FileSink::~FileSink()
         if (0 != munmap(d_buffer, BUFFER_SIZE)) {
             LOG(ERROR) << "Failed to unmap output file: " << strerror(errno);
         }
+
+        int rc;
+        do {
+            rc = ::ftruncate(d_fd, d_maxWrittenPos);
+        } while (rc < 0 && errno == EINTR);
+        if (rc < 0) {
+            LOG(WARNING) << "Failed to truncate output file (reading it will be slower): "
+                         << strerror(errno);
+        }
+
         d_buffer = d_bufferNeedle = d_bufferEnd = nullptr;
     }
     if (d_fd != -1) {

--- a/src/memray/_memray/sink.cpp
+++ b/src/memray/_memray/sink.cpp
@@ -202,13 +202,24 @@ FileSink::seek(off_t offset, int whence)
 bool
 FileSink::grow(size_t needed)
 {
-    static size_t pagesize = sysconf(_SC_PAGESIZE);
-    // Grow to next multiple of the page size that is strictly > 110% of current size + needed
-    size_t new_size = (d_fileSize + needed) * 1.1;
-    new_size = (new_size / pagesize + 1) * pagesize;
-    assert(new_size > d_fileSize);  // check for overflow
+    // Grow to some multiple of maxSurplus, overallocating by up to maxSurplus.
+    // The maximum surplus is 4KiB until we reach 4MiB, then 4MiB afterwards.
+    const size_t fourKiB = 4 * 1024;
+    const size_t fourMiB = 4 * 1024 * 1024;
+    size_t newSize = d_fileSize + needed;
+    const size_t maxSurplus = (newSize < fourMiB) ? fourKiB : fourMiB;
+    newSize = (newSize / maxSurplus + 1) * maxSurplus;
 
-    off_t delta = new_size - d_fileSize;
+    // Ensure we're ending on a page boundary.
+    static size_t pageSize = sysconf(_SC_PAGESIZE);
+    newSize = (newSize + pageSize - 1) / pageSize * pageSize;
+
+    if (newSize < d_fileSize) {
+        LOG(ERROR) << "Integer overflow while growing output file.";
+        return false;
+    }
+
+    off_t delta = newSize - d_fileSize;
     int rc;
     do {
         // posix_fallocate returns an error number instead of setting errno
@@ -234,7 +245,7 @@ FileSink::grow(size_t needed)
         return false;
     }
 
-    d_fileSize = new_size;
+    d_fileSize = newSize;
     assert(static_cast<off_t>(d_fileSize) == lseek(d_fd, 0, SEEK_END));
 
     return true;

--- a/src/memray/_memray/sink.h
+++ b/src/memray/_memray/sink.h
@@ -71,6 +71,7 @@ class FileSink : public memray::io::Sink
     size_t d_fileSize{0};
     const size_t BUFFER_SIZE{16 * 1024 * 1024};  // 16 MiB
     size_t d_bufferOffset{0};
+    size_t d_maxWrittenPos{0};
     char* d_buffer{nullptr};
     char* d_bufferEnd{nullptr};  // exclusive
     char* d_bufferNeedle{nullptr};


### PR DESCRIPTION
When tracking ends normally, shrink a capture file down to the size that was written, dropping any overallocation.

Limit the maximum amount we overallocate by to no more than 4MiB + the page size.