### PR TITLE
Handle multiarch tuples in the injecter filename

### DIFF
--- a/news/1014.bugfix.rst
+++ b/news/1014.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``memray attach`` when Memray is built from source for the latest release candidates of Python 3.15.

--- a/src/memray/commands/attach.py
+++ b/src/memray/commands/attach.py
@@ -143,8 +143,25 @@ def debugger_inject(debugger: str, pid: int, port: int, verbose: bool) -> str | 
         abi = "abi3t"
     else:
         abi = "abi3"
-    injecter = pathlib.Path(memray._memray.__file__).parent / f"_inject.{abi}.so"
-    assert injecter.exists()
+
+    parent_dir = pathlib.Path(memray._memray.__file__).parent
+    possible_injecters = []
+
+    soabi_platform = sysconfig.get_config_var("SOABI_PLATFORM")
+    if soabi_platform is not None:
+        # abi3 extension filenames may contain multiarch tuples in 3.15+
+        possible_injecters.append(parent_dir / f"_inject.{abi}-{soabi_platform}.so")
+
+    possible_injecters.append(parent_dir / f"_inject.{abi}.so")
+
+    for injecter in possible_injecters:
+        if injecter.exists():
+            break
+    else:
+        raise RuntimeError(
+            "Can't find the _inject extension for this Python version. "
+            f" Tried: {[str(x) for x in possible_injecters]}"
+        )
 
     gdb_cmd = [
         "gdb",


### PR DESCRIPTION
As of Python 3.15, it's possible (though not required) for an abi3 extension module to also encode a platform tuple in its filename.

Handle this case by checking for both possible filenames, to support both builds that include the new platform info and ones that don't.

See https://github.com/python/cpython/issues/122931